### PR TITLE
feat: deploy default permissionless node in cdk environment

### DIFF
--- a/cdk/main.star
+++ b/cdk/main.star
@@ -1,7 +1,9 @@
 ethereum_package = import_module(
     "github.com/kurtosis-tech/ethereum-package/main.star@2.0.0"
 )
-zkevm_permissionless_node_package = import_module("github.com/0xPolygon/kurtosis-cdk/permissionless-node/main.star")
+zkevm_permissionless_node_package = import_module(
+    "github.com/0xPolygon/kurtosis-cdk/permissionless-node/main.star"
+)
 
 CONTRACTS_IMAGE = "node:20-bookworm"
 CONTRACTS_BRANCH = "develop"

--- a/cdk/main.star
+++ b/cdk/main.star
@@ -1,7 +1,7 @@
 ethereum_package = import_module(
     "github.com/kurtosis-tech/ethereum-package/main.star@2.0.0"
 )
-zkevm_permissionless_node_package = import_module("../permissionless-node/main.star")
+zkevm_permissionless_node_package = import_module("github.com/0xPolygon/kurtosis-cdk/permissionless-node/main.star")
 
 CONTRACTS_IMAGE = "node:20-bookworm"
 CONTRACTS_BRANCH = "develop"

--- a/cdk/params.yml
+++ b/cdk/params.yml
@@ -60,10 +60,6 @@ zkevm_db_prover_hostname: "prover-db"
 zkevm_db_prover_user: "prover_user"
 zkevm_db_prover_password: "SR5xq2KZPgvQkPDranCRhvkv6pnqfo77"
 
-zkevm_permissionless_db_prover_hostname: "permissionless-prover-db"
-zkevm_permissionless_db_prover_user: "permissionless_prover_user"
-zkevm_permissionless_db_prover_password: "fJc3BNTnURMNtie4w3HUhtQbe7omWn23"
-
 ## Pool db
 # Note: Do not change the name of the db
 # https://github.com/0xPolygonHermez/zkevm-node/blob/develop/db/db.go#L19
@@ -73,20 +69,12 @@ zkevm_db_pool_hostname: "pool-db"
 zkevm_db_pool_user: "pool_user"
 zkevm_db_pool_password: "Qso5wMcLAN3oF7EfaawzgWKUUKWM3Vov"
 
-zkevm_permissionless_db_pool_hostname: "permissionless-pool-db"
-zkevm_permissionless_db_pool_user: "permissionless_pool_user"
-zkevm_permissionless_db_pool_password: "hkqvUnE65RvFjxaurXxNTDf4j6ozkejn"
-
 ## Event db
 zkevm_db_event_name: "event_db"
 
 zkevm_db_event_hostname: "event-db"
 zkevm_db_event_user: "event_user"
 zkevm_db_event_password: "rJXJN6iUAczh4oz8HRKYbVM8yC7tPeZm"
-
-zkevm_permissionless_db_event_hostname: "permissionless-event-db"
-zkevm_permissionless_db_event_user: "permissionless_event_user"
-zkevm_permissionless_db_event_password: "d3GSJ8dkWxtMpNbP7w4Za7dF3Gh23XwM"
 
 ## State db
 # Note: Do not change the name of the db
@@ -96,10 +84,6 @@ zkevm_db_state_name: "state_db"
 zkevm_db_state_hostname: "state-db"
 zkevm_db_state_user: "state_user"
 zkevm_db_state_password: "rHTX7EpajF8zYDPatN32rH3B2pn89dmq"
-
-zkevm_permissionless_db_state_hostname: "permissionless-state-db"
-zkevm_permissionless_db_state_user: "permissionless_state_user"
-zkevm_permissionless_db_state_password: "BXeRf7Y4QgkB4Z6c7w6mtXzkdptvwixR"
 
 ## Bridge db
 zkevm_db_bridge_name: "bridge_db"

--- a/permissionless-node/main.star
+++ b/permissionless-node/main.star
@@ -8,10 +8,15 @@ def run(plan, args):
     start_databases(plan, args)
     start_executor(plan, args, cpu_arch)
 
-    genesis_file = read_file(src=args["genesis_file"])
-    genesis_artifact = plan.render_templates(
-        name="genesis", config={"genesis.json": struct(template=genesis_file, data={})}
-    )
+    genesis_artifact = ""
+    if "genesis_artifact" in args:
+        genesis_artifact = args["genesis_artifact"]
+    else:
+        genesis_file = read_file(src=args["genesis_file"])
+        genesis_artifact = plan.render_templates(
+            name="genesis",
+            config={"genesis.json": struct(template=genesis_file, data={})},
+        )
 
     node_config_template = read_file(src="./templates/node-config.toml")
     node_config_artifact = plan.render_templates(

--- a/permissionless-node/params.yml
+++ b/permissionless-node/params.yml
@@ -2,7 +2,7 @@
 # Deployment suffix that will be appended to all the resources deployed by the permissionless package.
 # WARNING: When deploying both the CDK and permissionless package, ensure the permissionless package's
 # deployment suffix differs from the CDK environment's suffix to prevent naming clashes.
-deployment_suffix: "-pless-001"
+deployment_suffix: "-pless-002"
 
 # Components to connect to
 l1_rpc_url: "http://el-1-geth-lighthouse:8545"


### PR DESCRIPTION
**This PR requires the https://github.com/0xPolygon/kurtosis-cdk repository to be public!**

## Description

- Deploy a default permissionless node in cdk environment. The permisionnless node databases will use the same credentials as databases of the trusted/central node.
- Clean up `cdk` parameters.
- Enable to specify a genesis artifact file to the `permissionless-node` package.

## Test

- [x] Provision a full environment (with a quick hack: move the `permissionless-node` folder under `cdk` and import the package using a relative locator + making sure db init scripts don't clash, e.g. `event-db-init.sql` and `event-db-init-pless-001.sql` - but this can be solved if Kurtosis implements something like `get_file_artifact`, similar to [`get_service`](vent-db-init-pless-001.sql)).
- [ ] Provision a full environment (without any hack)