### PR TITLE
name files artifacts on rendered templates

### DIFF
--- a/main.star
+++ b/main.star
@@ -42,7 +42,8 @@ def run(plan, args):
             "deploy_parameters.json": struct(
                 template=deploy_parameters_template, data=args
             )
-        }
+        },
+        name="deploy-parameters-artifact"
     )
     # Create rollup paramaters
     create_rollup_parameters_template = read_file(
@@ -53,7 +54,8 @@ def run(plan, args):
             "create_rollup_parameters.json": struct(
                 template=create_rollup_parameters_template, data=args
             )
-        }
+        },
+        name="create-rollup-parameters-artifact"
     )
     # Create contract deployment script
     contract_deployment_script_template = read_file(
@@ -64,7 +66,8 @@ def run(plan, args):
             "run-contract-setup.sh": struct(
                 template=contract_deployment_script_template, data=args
             )
-        }
+        },
+        name="contract-deployment-script-artifact"
     )
 
     # Create bridge configuration
@@ -72,19 +75,22 @@ def run(plan, args):
     bridge_config_artifact = plan.render_templates(
         config={
             "bridge-config.toml": struct(template=bridge_config_template, data=args)
-        }
+        },
+        name="bridge-config-artifact"
     )
     # Create AggLayer configuration
     agglayer_config_template = read_file(src="./templates/agglayer-config.toml")
     agglayer_config_artifact = plan.render_templates(
         config={
             "agglayer-config.toml": struct(template=agglayer_config_template, data=args)
-        }
+        },
+        name="agglayer-config-artifact"
     )
     # Create DAC configuration
     dac_config_template = read_file(src="./templates/dac-config.toml")
     dac_config_artifact = plan.render_templates(
-        config={"dac-config.toml": struct(template=dac_config_template, data=args)}
+        config={"dac-config.toml": struct(template=dac_config_template, data=args)},
+        name="dac-config-artifact"
     )
     # Create prover configuration
     prover_config_template = read_file(
@@ -93,7 +99,8 @@ def run(plan, args):
     prover_config_artifact = plan.render_templates(
         config={
             "prover-config.json": struct(template=prover_config_template, data=args)
-        }
+        },
+        name="prover-config-artifact"
     )
 
     # Create helper service to deploy contracts

--- a/main.star
+++ b/main.star
@@ -294,7 +294,8 @@ def start_node_components(
     # Create node configuration file.
     config_template = read_file(src="./templates/trusted-node/node-config.toml")
     config_artifact = plan.render_templates(
-        config={"node-config.toml": struct(template=config_template, data=args)}
+        config={"node-config.toml": struct(template=config_template, data=args)},
+        name="node-config-artifact",
     )
 
     # Deploy components.
@@ -303,6 +304,7 @@ def start_node_components(
     zkevm_node_package.start_sequence_sender(
         plan, args, config_artifact, genesis_artifact, sequencer_keystore_artifact
     )
+    
     zkevm_node_package.start_aggregator(
         plan,
         args,


### PR DESCRIPTION
Naming the files artifacts allows Kurtosis to detect if a files artifact has changed when doing an enclave edit - this makes it so that if none of the files artifacts related to contract deployment change, contract deployment step won't be rerun.

A further improvement could also be updating each `render_templates` to take in only the `args` needed for that template. Right now, if any param changes, `args` gets updated and even if the update doesn't affect that particular rendered template, the `render_template` instruction will be run again, thus contract deployment will be run again. 

These two adjustments will make it so that you can update the network started by `kurtosis-cdk` without running the long contract deployment step again. (unless you're updating config that requires contract deployment to be rerun)

kurtosis tip: `name all files artifacts` : ), gonna make this more explicit in our docs

https://www.loom.com/share/3b2122a21f6f4c3b814f0584c460bf3a