### PR TITLE
refactor: break down the deployment process into various stages

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,6 +122,47 @@ node to the ~cdk-v1~ enclave:
 kurtosis run --enclave cdk-v1 --args-file params.yml --main-file zkevm_permissionless_node.star .
 #+end_src
 
+** For Developers
+
+Rather than executing the deployment process as a monolithic operation, you can break it down into stages and run each stage separately. The `stages` parameter indicates the specific stages you wish the deployment to proceed through. By default, it will execute all the stages.
+
+Currently, the deployment process includes the following stages:
+
+  1. Deploy L1
+  2. Configure L1 (which involves funding accounts, deploying CDK contracts, and creating configuration files)
+  3. Deploy Trusted / Central Environment
+  4. Deploy Bridge, AggLayer, and DAC
+  5. Deploy Permissionless Node
+
+Here's an example of how you can specify the stages to run through.
+
+#+begin_src bash
+# Execute the first stage (deploy L1).
+yq e '.stages = [1]' --inplace params.yml
+kurtosis run --enclave cdk-v1 --args-file params.yml .
+# Perform additional tasks...
+
+# Execute the second stage (configure L1).
+yq e '.stages = [2]' --inplace params.yml
+kurtosis run --enclave cdk-v1 --args-file params.yml .
+# Perform additional tasks...
+
+# Execute the thirs stage (deploy trusted/central environment).
+yq e '.stages = [3]' --inplace params.yml
+kurtosis run --enclave cdk-v1 --args-file params.yml .
+# Perform additional tasks...
+
+# Execute the fourth stage (deploy bridge/agglayer/dac).
+yq e '.stages = [4]' --inplace params.yml
+kurtosis run --enclave cdk-v1 --args-file params.yml .
+# Perform additional tasks...
+
+# Execute the fifth stage (deploy permissionless node).
+yq e '.stages = [5]' --inplace params.yml
+kurtosis run --enclave cdk-v1 --args-file params.yml .
+# Perform additional tasks...
+#+end_src
+
 ** License
 
 Copyright (c) 2024 PT Services DMCC

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,13 +1,3 @@
-# Read and retrieve the content of a file, within a service.
-# Note: It automatically removes newline characters.
-def read_file_from_service(plan, service_name, filename):
-    exec_recipe = ExecRecipe(
-        command=["/bin/sh", "-c", "cat {} | tr -d '\n'".format(filename)]
-    )
-    result = plan.exec(service_name=service_name, recipe=exec_recipe)
-    return result["output"]
-
-
 # Extract a specific key from a JSON file, within a service, using jq.
 def extract_json_key_from_service(plan, service_name, filename, key):
     plan.print("Extracting contract addresses and ports...")

--- a/lib/service.star
+++ b/lib/service.star
@@ -5,8 +5,9 @@ def extract_json_key_from_service(plan, service_name, filename, key):
         command=[
             "/bin/sh",
             "-c",
-            "cat {} | grep -w '{}' | xargs -n1 | tail -1".format(filename, key),
-        ]
+            "cat {}".format(filename, key),
+        ],
+        extract={"extracted_value": "fromjson | .{}".format(key)},
     )
     result = plan.exec(service_name=service_name, recipe=exec_recipe)
-    return result["output"]
+    return result["extract.extracted_value"]

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,3 +1,14 @@
+# Read and retrieve the content of a file, within a service.
+# Note: It automatically removes newline characters.
+def read_file_from_service(plan, service_name, filename):
+    exec_recipe = ExecRecipe(
+        command=["/bin/sh", "-c", "cat {} | tr -d '\n'".format(filename)]
+    )
+    result = plan.exec(service_name=service_name, recipe=exec_recipe)
+    return result["output"]
+
+
+# Extract a specific key from a JSON file, within a service, using jq.
 def extract_json_key_from_service(plan, service_name, filename, key):
     plan.print("Extracting contract addresses and ports...")
     exec_recipe = ExecRecipe(

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,0 +1,11 @@
+def extract_json_key_from_service(plan, service_name, filename, key):
+    plan.print("Extracting contract addresses and ports...")
+    exec_recipe = ExecRecipe(
+        command=[
+            "/bin/sh",
+            "-c",
+            "cat {} | grep -w '{}' | xargs -n1 | tail -1".format(filename, key),
+        ]
+    )
+    result = plan.exec(service_name=service_name, recipe=exec_recipe)
+    return result["output"]

--- a/main.star
+++ b/main.star
@@ -182,46 +182,22 @@ def run(plan, args):
         )
         zkevm_prover_package.start_prover(plan, args, prover_config_artifact)
 
-        # Fetch genesis and keystores.
-        genesis_file = service_package.read_file_from_service(
-            plan,
-            service_name="contracts" + args["deployment_suffix"],
-            filename="/opt/zkevm/genesis.json",
-        )
-        genesis_artifact = plan.render_templates(
-            name="genesis",
-            config={"genesis.json": struct(template=genesis_file, data={})},
-        )
-
-        sequencer_keystore_file = service_package.read_file_from_service(
-            plan,
-            service_name="contracts" + args["deployment_suffix"],
-            filename="/opt/zkevm/sequencer.keystore",
-        )
-        sequencer_keystore_artifact = plan.render_templates(
-            name="sequencer-keystore",
-            config={
-                "sequencer.keystore": struct(
-                    template=sequencer_keystore_artifact, data={}
-                )
-            },
-        )
-
-        aggregator_keystore_file = service_package.read_file_from_service(
-            plan,
-            service_name="contracts" + args["deployment_suffix"],
-            filename="/opt/zkevm/aggregator.keystore",
-        )
-        aggregator_keystore_artifact = plan.render_templates(
-            name="aggregator-keystore",
-            config={
-                "aggregator.keystore": struct(
-                    template=aggregator_keystore_file, data={}
-                )
-            },
-        )
-
         # Start the zkevm node components
+        genesis_artifact = plan.store_service_files(
+            name="genesis",
+            service_name="contracts" + args["deployment_suffix"],
+            src="/opt/zkevm/genesis.json",
+        )
+        sequencer_keystore_artifact = plan.store_service_files(
+            name="sequencer-keystore",
+            service_name="contracts" + args["deployment_suffix"],
+            src="/opt/zkevm/sequencer.keystore",
+        )
+        aggregator_keystore_artifact = plan.store_service_files(
+            name="aggregator-keystore",
+            service_name="contracts" + args["deployment_suffix"],
+            src="/opt/zkevm/aggregator.keystore",
+        )
         start_node_components(
             plan,
             args,

--- a/main.star
+++ b/main.star
@@ -150,6 +150,13 @@ def run(plan, args):
     else:
         plan.print("Skipping stage " + str(DEPLOYMENT_STAGE.configure_l1))
 
+    # Get the genesis file.
+    genesis_artifact = plan.store_service_files(
+        name="genesis",
+        service_name="contracts" + args["deployment_suffix"],
+        src="/opt/zkevm/genesis.json",
+    )
+
     ## STAGE 3: Deploy trusted / central environment
     if DEPLOYMENT_STAGE.deploy_central_environment in args["stages"]:
         plan.print(
@@ -183,11 +190,6 @@ def run(plan, args):
         zkevm_prover_package.start_prover(plan, args, prover_config_artifact)
 
         # Start the zkevm node components
-        genesis_artifact = plan.store_service_files(
-            name="genesis",
-            service_name="contracts" + args["deployment_suffix"],
-            src="/opt/zkevm/genesis.json",
-        )
         sequencer_keystore_artifact = plan.store_service_files(
             name="sequencer-keystore",
             service_name="contracts" + args["deployment_suffix"],
@@ -222,12 +224,6 @@ def run(plan, args):
     if DEPLOYMENT_STAGE.deploy_permissionless_node in args["stages"]:
         plan.print(
             "Executing stage " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
-        )
-
-        genesis_artifact = plan.store_service_files(
-            name="genesis",
-            service_name="contracts" + args["deployment_suffix"],
-            src="/opt/zkevm/genesis.json",
         )
 
         # FIXME: This will create an alias of args and not a deep copy!

--- a/main.star
+++ b/main.star
@@ -206,9 +206,7 @@ def run(plan, args):
             aggregator_keystore_artifact,
         )
     else:
-        plan.print(
-            "Skipping stage " + str(DEPLOYMENT_STAGE.deploy_central_environment)
-        )
+        plan.print("Skipping stage " + str(DEPLOYMENT_STAGE.deploy_central_environment))
 
     ## STAGE 4: Deploy CDK/Bridge infra
     if DEPLOYMENT_STAGE.deploy_cdk_bridge_infra in args["stages"]:
@@ -233,9 +231,7 @@ def run(plan, args):
         permissionless_args["genesis_artifact"] = genesis_artifact
         zkevm_permissionless_node_package.run(plan, args)
     else:
-        plan.print(
-            "Skipping stage " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
-        )
+        plan.print("Skipping stage " + str(DEPLOYMENT_STAGE.deploy_permissionless_node))
 
 
 def start_node_components(

--- a/main.star
+++ b/main.star
@@ -224,6 +224,12 @@ def run(plan, args):
             "Executing stage " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
         )
 
+        genesis_artifact = plan.store_service_files(
+            name="genesis",
+            service_name="contracts" + args["deployment_suffix"],
+            src="/opt/zkevm/genesis.json",
+        )
+
         # FIXME: This will create an alias of args and not a deep copy!
         permissionless_args = args
         # Note that an additional suffix will be added to the permissionless services.

--- a/main.star
+++ b/main.star
@@ -36,7 +36,7 @@ def run(plan, args):
     ## STAGE 1: Deploy L1
     # For now we'll stick with most of the defaults
     if DEPLOYMENT_STAGE.deploy_l1 in args["stages"]:
-        plan.print("Executing stage: " + str(DEPLOYMENT_STAGE.deploy_l1))
+        plan.print("Executing stage " + str(DEPLOYMENT_STAGE.deploy_l1))
         ethereum_package.run(
             plan,
             {
@@ -51,12 +51,12 @@ def run(plan, args):
             },
         )
     else:
-        plan.print("Skipping stage: " + str(DEPLOYMENT_STAGE.deploy_l1))
+        plan.print("Skipping stage " + str(DEPLOYMENT_STAGE.deploy_l1))
 
     ## STAGE 2: Configure L1
     # Ffund accounts, deploy cdk contracts and create config files.
     if DEPLOYMENT_STAGE.configure_l1 in args["stages"]:
-        plan.print("Executing stage: " + str(DEPLOYMENT_STAGE.configure_l1))
+        plan.print("Executing stage " + str(DEPLOYMENT_STAGE.configure_l1))
 
         # Create deploy parameters
         deploy_parameters_template = read_file(src="./templates/deploy_parameters.json")
@@ -148,12 +148,12 @@ def run(plan, args):
             recipe=ExecRecipe(command=["/opt/contract-deploy/run-contract-setup.sh"]),
         )
     else:
-        plan.print("Skipping stage: " + str(DEPLOYMENT_STAGE.configure_l1))
+        plan.print("Skipping stage " + str(DEPLOYMENT_STAGE.configure_l1))
 
     ## STAGE 3: Deploy trusted / central environment
     if DEPLOYMENT_STAGE.deploy_central_environment in args["stages"]:
         plan.print(
-            "Executing stage: " + str(DEPLOYMENT_STAGE.deploy_central_environment)
+            "Executing stage " + str(DEPLOYMENT_STAGE.deploy_central_environment)
         )
 
         # Start databases
@@ -207,23 +207,23 @@ def run(plan, args):
         )
     else:
         plan.print(
-            "Skipping stage: " + str(DEPLOYMENT_STAGE.deploy_central_environment)
+            "Skipping stage " + str(DEPLOYMENT_STAGE.deploy_central_environment)
         )
 
     ## STAGE 4: Deploy CDK/Bridge infra
     if DEPLOYMENT_STAGE.deploy_cdk_bridge_infra in args["stages"]:
-        plan.print("Executing stage: " + str(DEPLOYMENT_STAGE.deploy_cdk_bridge_infra))
+        plan.print("Executing stage " + str(DEPLOYMENT_STAGE.deploy_cdk_bridge_infra))
         zkevm_bridge_service = start_bridge_service(plan, args)
         start_bridge_ui(plan, args, zkevm_bridge_service)
         start_agglayer(plan, args)
         start_dac(plan, args)
     else:
-        plan.print("Skipping stage: " + str(DEPLOYMENT_STAGE.deploy_cdk_bridge_infra))
+        plan.print("Skipping stage " + str(DEPLOYMENT_STAGE.deploy_cdk_bridge_infra))
 
     ## STAGE 5: Deploy permissionless node
     if DEPLOYMENT_STAGE.deploy_permissionless_node in args["stages"]:
         plan.print(
-            "Executing stage: " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
+            "Executing stage " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
         )
 
         # FIXME: This will create an alias of args and not a deep copy!
@@ -234,7 +234,7 @@ def run(plan, args):
         zkevm_permissionless_node_package.run(plan, args)
     else:
         plan.print(
-            "Skipping stage: " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
+            "Skipping stage " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
         )
 
 

--- a/main.star
+++ b/main.star
@@ -287,12 +287,67 @@ def start_node_components(
 
 
 def start_bridge_service(plan, args):
+    # Fetch addresses.
+    rollup_manager_block_number = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "deploymentRollupManagerBlockNumber",
+    )
+    zkevm_bridge_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "polygonZkEVMGlobalExitRootAddress",
+    )
+    zkevm_global_exit_root_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "polygonZkEVMBridgeAddress",
+    )
+    zkevm_rollup_manager_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "polygonRollupManagerAddress",
+    )
+    zkevm_rollup_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "rollupAddress",
+    )
+
     # Create bridge config.
     bridge_config_template = read_file(src="./templates/bridge-config.toml")
     bridge_config_artifact = plan.render_templates(
         name="bridge-config-artifact",
         config={
-            "bridge-config.toml": struct(template=bridge_config_template, data=args)
+            "bridge-config.toml": struct(
+                template=bridge_config_template,
+                data={
+                    "deployment_suffix": args["deployment_suffix"],
+                    "l1_rpc_url": args["l1_rpc_url"],
+                    "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
+                    # addresses
+                    "rollup_manager_block_number": rollup_manager_block_number,
+                    "zkevm_bridge_address": zkevm_bridge_address,
+                    "zkevm_global_exit_root_address": zkevm_global_exit_root_address,
+                    "zkevm_rollup_manager_address": zkevm_rollup_manager_address,
+                    "zkevm_rollup_address": zkevm_rollup_address,
+                    # bridge db
+                    "zkevm_db_bridge_hostname": args["zkevm_db_bridge_hostname"],
+                    "zkevm_db_bridge_name": args["zkevm_db_bridge_name"],
+                    "zkevm_db_bridge_user": args["zkevm_db_bridge_user"],
+                    "zkevm_db_bridge_password": args["zkevm_db_bridge_password"],
+                    # ports
+                    "zkevm_db_postgres_port": args["zkevm_db_postgres_port"],
+                    "zkevm_bridge_grpc_port": args["zkevm_bridge_grpc_port"],
+                    "zkevm_bridge_rpc_port": args["zkevm_bridge_rpc_port"],
+                    "zkevm_rpc_http_port": args["zkevm_rpc_http_port"],
+                },
+            )
         },
     )
 
@@ -388,12 +443,41 @@ def start_bridge_ui(plan, args, bridge_service):
 
 
 def start_agglayer(plan, args):
+    # Fetch addresses.
+    rollup_manager_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "polygonRollupManagerAddress",
+    )
+
     # Create agglayer config.
     agglayer_config_template = read_file(src="./templates/agglayer-config.toml")
     agglayer_config_artifact = plan.render_templates(
         name="agglayer-config-artifact",
         config={
-            "agglayer-config.toml": struct(template=agglayer_config_template, data=args)
+            "agglayer-config.toml": struct(
+                template=agglayer_config_template,
+                # TODO: Organize those args.
+                data={
+                    "deployment_suffix": args["deployment_suffix"],
+                    "l1_network_id": args["l1_network_id"],
+                    "l1_rpc_url": args["l1_rpc_url"],
+                    "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
+                    # addresses
+                    "rollup_manager_address": rollup_manager_address,
+                    # agglayer db
+                    "zkevm_db_agglayer_hostname": args["zkevm_db_agglayer_hostname"],
+                    "zkevm_db_agglayer_name": args["zkevm_db_agglayer_name"],
+                    "zkevm_db_agglayer_user": args["zkevm_db_agglayer_user"],
+                    "zkevm_db_agglayer_password": args["zkevm_db_agglayer_password"],
+                    # ports
+                    "zkevm_db_postgres_port": args["zkevm_db_postgres_port"],
+                    "zkevm_rpc_http_port": args["zkevm_rpc_http_port"],
+                    "zkevm_agglayer_port": args["zkevm_agglayer_port"],
+                    "zkevm_prometheus_port": args["zkevm_prometheus_port"],
+                },
+            )
         },
     )
 
@@ -422,11 +506,47 @@ def start_agglayer(plan, args):
 
 
 def start_dac(plan, args):
+    # Fetch addresses.
+    rollup_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "rollupAddress",
+    )
+    data_committee_address = service_package.extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        "polygonDataCommitteeAddress",
+    )
+
     # Create DAC config.
     dac_config_template = read_file(src="./templates/dac-config.toml")
     dac_config_artifact = plan.render_templates(
         name="dac-config-artifact",
-        config={"dac-config.toml": struct(template=dac_config_template, data=args)},
+        config={
+            "dac-config.toml": struct(
+                template=dac_config_template,
+                # TODO: Organize those args.
+                data={
+                    "deployment_suffix": args["deployment_suffix"],
+                    "l1_rpc_url": args["l1_rpc_url"],
+                    "l1_ws_url": args["l1_ws_url"],
+                    "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
+                    # addresses
+                    "rollup_address": rollup_address,
+                    "data_committee_address": data_committee_address,
+                    # dac db
+                    "zkevm_db_dac_hostname": args["zkevm_db_dac_hostname"],
+                    "zkevm_db_dac_name": args["zkevm_db_dac_name"],
+                    "zkevm_db_dac_user": args["zkevm_db_dac_user"],
+                    "zkevm_db_dac_password": args["zkevm_db_dac_password"],
+                    # ports
+                    "zkevm_db_postgres_port": args["zkevm_db_postgres_port"],
+                    "zkevm_dac_port": args["zkevm_dac_port"],
+                },
+            )
+        },
     )
 
     # Start DAC service.

--- a/main.star
+++ b/main.star
@@ -37,7 +37,6 @@ def run(plan, args):
     # For now we'll stick with most of the defaults
     if DEPLOYMENT_STAGE.deploy_l1 in args["stages"]:
         plan.print("Executing stage: " + str(DEPLOYMENT_STAGE.deploy_l1))
-
         ethereum_package.run(
             plan,
             {
@@ -232,8 +231,9 @@ def run(plan, args):
             "Executing stage: " + str(DEPLOYMENT_STAGE.deploy_permissionless_node)
         )
 
-        # Note that an additional suffix will be added to the services.
+        # FIXME: This will create an alias of args and not a deep copy!
         permissionless_args = args
+        # Note that an additional suffix will be added to the permissionless services.
         permissionless_args["deployment_suffix"] = "-pless" + args["deployment_suffix"]
         permissionless_args["genesis_artifact"] = genesis_artifact
         zkevm_permissionless_node_package.run(plan, args)

--- a/params.yml
+++ b/params.yml
@@ -4,12 +4,10 @@
 # Suffix appended to service names.
 # Note: It should be a string.
 deployment_suffix: "-001"
-
 # The deployment process is divided into various stages.
 # The `stages` parameter indicates the specific stages you wish the deployment to proceed through.
 # By default, it will execute all the stages.
 stages: [1, 2, 3, 4, 5]
-
 # Docker images and repositories used to spin up services.
 zkevm_prover_image: hermeznetwork/zkevm-prover:v5.0.7
 zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.2-cdk
@@ -19,7 +17,6 @@ zkevm_contracts_branch: v5.0.1-rc.2-fork.8
 zkevm_contracts_repo: https://github.com/0xPolygonHermez/zkevm-contracts.git
 zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
 zkevm_bridge_ui_image: hermeznetwork/zkevm-bridge-ui:latest # TODO: better tags for the bridge ui
-
 # Port configuration.
 zkevm_hash_db_port: 50061
 zkevm_executor_port: 50071
@@ -34,82 +31,64 @@ zkevm_bridge_grpc_port: 9090
 zkevm_bridge_ui_port: 80
 zkevm_agglayer_port: 4444
 zkevm_dac_port: 8484
-
 # Addresses and private keys of the different components.
 # They have been generated using the following command:
 # polycli wallet inspect --mnemonic 'lab code glass agree maid neutral vessel horror deny frequent favorite soft gate galaxy proof vintage once figure diary virtual scissors marble shrug drop' --addresses 8 | tee keys.txt | jq -r '.Addresses[] | [.ETHAddress, .HexPrivateKey] | @tsv' | awk 'BEGIN{split("sequencer,aggregator,claimtxmanager,timelock,admin,loadtest,agglayer,dac",roles,",")} {print "zkevm_l2_" roles[NR] "_address: \"" $1 "\""; print "zkevm_l2_" roles[NR] "_private_key: \"0x" $2 "\"\n"}'
 zkevm_l2_sequencer_address: "0x5b06837A43bdC3dD9F114558DAf4B26ed49842Ed"
 zkevm_l2_sequencer_private_key: "0x183c492d0ba156041a7f31a1b188958a7a22eebadca741a7fe64436092dc3181"
-
 zkevm_l2_aggregator_address: "0xCae5b68Ff783594bDe1b93cdE627c741722c4D4d"
 zkevm_l2_aggregator_private_key: "0x2857ca0e7748448f3a50469f7ffe55cde7299d5696aedd72cfe18a06fb856970"
-
 zkevm_l2_claimtxmanager_address: "0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"
 zkevm_l2_claimtxmanager_private_key: "0x8d5c9ecd4ba2a195db3777c8412f8e3370ae9adffac222a54a84e116c7f8b934"
-
 zkevm_l2_timelock_address: "0x130aA39Aa80407BD251c3d274d161ca302c52B7A"
 zkevm_l2_timelock_private_key: "0x80051baf5a0a749296b9dcdb4a38a264d2eea6d43edcf012d20b5560708cf45f"
-
 zkevm_l2_admin_address: "0xE34aaF64b29273B7D567FCFc40544c014EEe9970"
 zkevm_l2_admin_private_key: "0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
-
 zkevm_l2_loadtest_address: "0x81457240ff5b49CaF176885ED07e3E7BFbE9Fb81"
 zkevm_l2_loadtest_private_key: "0xd7df6d64c569ffdfe7c56e6b34e7a2bdc7b7583db74512a9ffe26fe07faaa5de"
-
 zkevm_l2_agglayer_address: "0x351e560852ee001d5D19b5912a269F849f59479a"
 zkevm_l2_agglayer_private_key: "0x1d45f90c0a9814d8b8af968fa0677dab2a8ff0266f33b136e560fe420858a419"
-
 zkevm_l2_dac_address: "0x5951F5b2604c9B42E478d5e2B2437F44073eF9A6"
 zkevm_l2_dac_private_key: "0x85d836ee6ea6f48bae27b31535e6fc2eefe056f2276b9353aafb294277d8159b"
-
 # Keystore password.
 zkevm_l2_keystore_password: pSnv6Dh5s9ahuzGzH9RoCDrKAMddaX3m
-
 # Database configuration.
 zkevm_db_postgres_port: 5432
-
 # AggLayer db
 zkevm_db_agglayer_hostname: agglayer-db
 zkevm_db_agglayer_name: agglayer_db
 zkevm_db_agglayer_user: agglayer_user
 zkevm_db_agglayer_password: PzycR2uB6PQv8ahj465ExvdyRLkknRNW
-
 # Bridge db
 zkevm_db_bridge_hostname: bridge-db
 zkevm_db_bridge_name: bridge_db
 zkevm_db_bridge_user: bridge_user
 zkevm_db_bridge_password: aXPqaRvgo5DfnTbHtpYS9rMhVpjvb6tY
-
 # DAC db
 zkevm_db_dac_hostname: dac-db
 zkevm_db_dac_name: dac_db
 zkevm_db_dac_user: dac_user
 zkevm_db_dac_password: PzycR2uB6PQv8ahj465ExvdyRLkknRNW
-
 # Event db
 zkevm_db_event_hostname: event-db
 zkevm_db_event_name: event_db
 zkevm_db_event_user: event_user
 zkevm_db_event_password: rJXJN6iUAczh4oz8HRKYbVM8yC7tPeZm
-
 # Pool db
 zkevm_db_pool_hostname: pool-db
 zkevm_db_pool_name: pool_db
 zkevm_db_pool_user: pool_user
 zkevm_db_pool_password: Qso5wMcLAN3oF7EfaawzgWKUUKWM3Vov
-
 # Prover/Executor db
 zkevm_db_prover_hostname: prover-db
 zkevm_db_prover_name: prover_db
 zkevm_db_prover_user: prover_user
 zkevm_db_prover_password: SR5xq2KZPgvQkPDranCRhvkv6pnqfo77
-
 # State db
 zkevm_db_state_hostname: state-db
 zkevm_db_state_name: state_db
 zkevm_db_state_user: state_user
 zkevm_db_state_password: rHTX7EpajF8zYDPatN32rH3B2pn89dmq
-
 # L1 configuration.
 l1_network_id: 271828
 l1_preallocated_mnemonic: code code code code code code code code code code code quality
@@ -118,7 +97,6 @@ l1_ws_url: ws://el-1-geth-lighthouse:8546
 # TODO: If we need to fund the aggregator, sequencer, and admin accounts for posting batches.. How much should we prefund??
 l1_funding_amount: 100ether
 ethereum_explorer: "https://sepolia.etherscan.io/"
-
 # L2 configuration.
 zkevm_deployment_salt: "0x0000000000000000000000000000000000000000000000000000000000000001"
 zkevm_fork_id: 8
@@ -130,15 +108,12 @@ zkevm_rollup_description: kurtosis devnet
 zkevm_rollup_name: kurtosis-test
 zkevm_rollup_real_verifier: false
 polygon_zkevm_explorer: "https://sepolia.etherscan.io/"
-
 # If this is true, we will automatically deploy an ERC20 contract on
 # L1 to be used at the gasTokenAddress
 zkevm_use_gas_token_contract: false
-
 # Permissionless node configuration.
 trusted_sequencer_node_uri: zkevm-node-sequencer-001:6900
 zkevm_aggregator_host: zkevm-node-aggregator-001
 genesis_file: templates/permissionless-node/genesis.json
-
 # Tools versions
 polycli_version: v0.1.42

--- a/params.yml
+++ b/params.yml
@@ -5,6 +5,11 @@
 # Note: It should be a string.
 deployment_suffix: "-001"
 
+# The deployment process is divided into various stages.
+# The `stages` parameter indicates the specific stages you wish the deployment to proceed through.
+# By default, it will execute all the stages.
+stages: [1, 2, 3, 4, 5]
+
 # Docker images and repositories used to spin up services.
 zkevm_prover_image: hermeznetwork/zkevm-prover:v5.0.7
 zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.2-cdk

--- a/params.yml
+++ b/params.yml
@@ -4,10 +4,12 @@
 # Suffix appended to service names.
 # Note: It should be a string.
 deployment_suffix: "-001"
+
 # The deployment process is divided into various stages.
 # The `stages` parameter indicates the specific stages you wish the deployment to proceed through.
 # By default, it will execute all the stages.
 stages: [1, 2, 3, 4, 5]
+
 # Docker images and repositories used to spin up services.
 zkevm_prover_image: hermeznetwork/zkevm-prover:v5.0.7
 zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.2-cdk
@@ -17,6 +19,7 @@ zkevm_contracts_branch: v5.0.1-rc.2-fork.8
 zkevm_contracts_repo: https://github.com/0xPolygonHermez/zkevm-contracts.git
 zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
 zkevm_bridge_ui_image: hermeznetwork/zkevm-bridge-ui:latest # TODO: better tags for the bridge ui
+
 # Port configuration.
 zkevm_hash_db_port: 50061
 zkevm_executor_port: 50071
@@ -31,64 +34,82 @@ zkevm_bridge_grpc_port: 9090
 zkevm_bridge_ui_port: 80
 zkevm_agglayer_port: 4444
 zkevm_dac_port: 8484
+
 # Addresses and private keys of the different components.
 # They have been generated using the following command:
 # polycli wallet inspect --mnemonic 'lab code glass agree maid neutral vessel horror deny frequent favorite soft gate galaxy proof vintage once figure diary virtual scissors marble shrug drop' --addresses 8 | tee keys.txt | jq -r '.Addresses[] | [.ETHAddress, .HexPrivateKey] | @tsv' | awk 'BEGIN{split("sequencer,aggregator,claimtxmanager,timelock,admin,loadtest,agglayer,dac",roles,",")} {print "zkevm_l2_" roles[NR] "_address: \"" $1 "\""; print "zkevm_l2_" roles[NR] "_private_key: \"0x" $2 "\"\n"}'
 zkevm_l2_sequencer_address: "0x5b06837A43bdC3dD9F114558DAf4B26ed49842Ed"
 zkevm_l2_sequencer_private_key: "0x183c492d0ba156041a7f31a1b188958a7a22eebadca741a7fe64436092dc3181"
+
 zkevm_l2_aggregator_address: "0xCae5b68Ff783594bDe1b93cdE627c741722c4D4d"
 zkevm_l2_aggregator_private_key: "0x2857ca0e7748448f3a50469f7ffe55cde7299d5696aedd72cfe18a06fb856970"
+
 zkevm_l2_claimtxmanager_address: "0x5f5dB0D4D58310F53713eF4Df80ba6717868A9f8"
 zkevm_l2_claimtxmanager_private_key: "0x8d5c9ecd4ba2a195db3777c8412f8e3370ae9adffac222a54a84e116c7f8b934"
+
 zkevm_l2_timelock_address: "0x130aA39Aa80407BD251c3d274d161ca302c52B7A"
 zkevm_l2_timelock_private_key: "0x80051baf5a0a749296b9dcdb4a38a264d2eea6d43edcf012d20b5560708cf45f"
+
 zkevm_l2_admin_address: "0xE34aaF64b29273B7D567FCFc40544c014EEe9970"
 zkevm_l2_admin_private_key: "0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
+
 zkevm_l2_loadtest_address: "0x81457240ff5b49CaF176885ED07e3E7BFbE9Fb81"
 zkevm_l2_loadtest_private_key: "0xd7df6d64c569ffdfe7c56e6b34e7a2bdc7b7583db74512a9ffe26fe07faaa5de"
+
 zkevm_l2_agglayer_address: "0x351e560852ee001d5D19b5912a269F849f59479a"
 zkevm_l2_agglayer_private_key: "0x1d45f90c0a9814d8b8af968fa0677dab2a8ff0266f33b136e560fe420858a419"
+
 zkevm_l2_dac_address: "0x5951F5b2604c9B42E478d5e2B2437F44073eF9A6"
 zkevm_l2_dac_private_key: "0x85d836ee6ea6f48bae27b31535e6fc2eefe056f2276b9353aafb294277d8159b"
+
 # Keystore password.
 zkevm_l2_keystore_password: pSnv6Dh5s9ahuzGzH9RoCDrKAMddaX3m
+
 # Database configuration.
 zkevm_db_postgres_port: 5432
+
 # AggLayer db
 zkevm_db_agglayer_hostname: agglayer-db
 zkevm_db_agglayer_name: agglayer_db
 zkevm_db_agglayer_user: agglayer_user
 zkevm_db_agglayer_password: PzycR2uB6PQv8ahj465ExvdyRLkknRNW
+
 # Bridge db
 zkevm_db_bridge_hostname: bridge-db
 zkevm_db_bridge_name: bridge_db
 zkevm_db_bridge_user: bridge_user
 zkevm_db_bridge_password: aXPqaRvgo5DfnTbHtpYS9rMhVpjvb6tY
+
 # DAC db
 zkevm_db_dac_hostname: dac-db
 zkevm_db_dac_name: dac_db
 zkevm_db_dac_user: dac_user
 zkevm_db_dac_password: PzycR2uB6PQv8ahj465ExvdyRLkknRNW
+
 # Event db
 zkevm_db_event_hostname: event-db
 zkevm_db_event_name: event_db
 zkevm_db_event_user: event_user
 zkevm_db_event_password: rJXJN6iUAczh4oz8HRKYbVM8yC7tPeZm
+
 # Pool db
 zkevm_db_pool_hostname: pool-db
 zkevm_db_pool_name: pool_db
 zkevm_db_pool_user: pool_user
 zkevm_db_pool_password: Qso5wMcLAN3oF7EfaawzgWKUUKWM3Vov
+
 # Prover/Executor db
 zkevm_db_prover_hostname: prover-db
 zkevm_db_prover_name: prover_db
 zkevm_db_prover_user: prover_user
 zkevm_db_prover_password: SR5xq2KZPgvQkPDranCRhvkv6pnqfo77
+
 # State db
 zkevm_db_state_hostname: state-db
 zkevm_db_state_name: state_db
 zkevm_db_state_user: state_user
 zkevm_db_state_password: rHTX7EpajF8zYDPatN32rH3B2pn89dmq
+
 # L1 configuration.
 l1_network_id: 271828
 l1_preallocated_mnemonic: code code code code code code code code code code code quality
@@ -97,6 +118,7 @@ l1_ws_url: ws://el-1-geth-lighthouse:8546
 # TODO: If we need to fund the aggregator, sequencer, and admin accounts for posting batches.. How much should we prefund??
 l1_funding_amount: 100ether
 ethereum_explorer: "https://sepolia.etherscan.io/"
+
 # L2 configuration.
 zkevm_deployment_salt: "0x0000000000000000000000000000000000000000000000000000000000000001"
 zkevm_fork_id: 8
@@ -108,12 +130,15 @@ zkevm_rollup_description: kurtosis devnet
 zkevm_rollup_name: kurtosis-test
 zkevm_rollup_real_verifier: false
 polygon_zkevm_explorer: "https://sepolia.etherscan.io/"
+
 # If this is true, we will automatically deploy an ERC20 contract on
 # L1 to be used at the gasTokenAddress
 zkevm_use_gas_token_contract: false
+
 # Permissionless node configuration.
 trusted_sequencer_node_uri: zkevm-node-sequencer-001:6900
 zkevm_aggregator_host: zkevm-node-aggregator-001
 genesis_file: templates/permissionless-node/genesis.json
+
 # Tools versions
 polycli_version: v0.1.42

--- a/templates/agglayer-config.toml
+++ b/templates/agglayer-config.toml
@@ -37,7 +37,7 @@ KMSKeyName = "" # Disable for local
 [L1]
 ChainID = {{.l1_network_id}}
 NodeURL = "{{.l1_rpc_url}}"
-RollupManagerContract = "###zkevm_l1_rollup_manager_addr###"
+RollupManagerContract = "{{.rollup_manager_address}}"
 
 [Telemetry]
 PrometheusAddr = "0.0.0.0:{{.zkevm_prometheus_port}}"

--- a/templates/bridge-config.toml
+++ b/templates/bridge-config.toml
@@ -41,12 +41,12 @@ BridgeVersion = "v1"
     MaxConns = 20
 
 [NetworkConfig]
-GenBlockNumber = "###zkevm_l1_deployment_block###"
-PolygonBridgeAddress = "###zkevm_l1_bridge_addr###"
-PolygonZkEVMGlobalExitRootAddress = "###zkevm_l1_global_exit_root_addr###"
-PolygonRollupManagerAddress = "###zkevm_l1_rollup_manager_addr###"
-PolygonZkEVMAddress = "###zkevm_l1_rollup_addr###"
-L2PolygonBridgeAddresses = ["###zkevm_l1_bridge_addr###"]
+GenBlockNumber = "{{.rollup_manager_block_number}}"
+PolygonBridgeAddress = "{{.zkevm_bridge_address}}"
+PolygonZkEVMGlobalExitRootAddress = "{{.zkevm_global_exit_root_address}}"
+PolygonRollupManagerAddress = "{{.zkevm_rollup_manager_address}}"
+PolygonZkEVMAddress = "{{.zkevm_rollup_address}}"
+L2PolygonBridgeAddresses = ["{{.zkevm_bridge_address}}"]
 
 [ClaimTxManager]
 FrequencyToMonitorTxs = "5s"

--- a/templates/dac-config.toml
+++ b/templates/dac-config.toml
@@ -3,8 +3,8 @@ PrivateKey = {Path = "/etc/zkevm/dac.keystore", Password = "{{.zkevm_l2_keystore
 [L1]
 WsURL = "{{.l1_ws_url}}"
 RpcURL = "{{.l1_rpc_url}}"
-PolygonValidiumAddress = "###rollupAddress###"
-DataCommitteeAddress = "###polygonDataCommitteeAddress###"
+PolygonValidiumAddress = "{{.rollup_address}}"
+DataCommitteeAddress = "{{.polygon_data_committee_address}}"
 Timeout = "1m"
 RetryPeriod = "5s"
 BlockBatchSize = "64"

--- a/templates/run-contract-setup.sh
+++ b/templates/run-contract-setup.sh
@@ -124,7 +124,7 @@ jq --slurpfile c combined.json '.L1Config = {chainId:{{.l1_network_id}}}' genesi
 jq --slurpfile c combined.json '.L1Config.polygonZkEVMGlobalExitRootAddress = $c[0].polygonZkEVMGlobalExitRootAddress' genesis.json > g.json; mv g.json genesis.json
 jq --slurpfile c combined.json '.L1Config.polygonRollupManagerAddress = $c[0].polygonRollupManagerAddress' genesis.json > g.json; mv g.json genesis.json
 jq --slurpfile c combined.json '.L1Config.polTokenAddress = $c[0].polTokenAddress' genesis.json > g.json; mv g.json genesis.json
-jq --slurpfile c combined.json '.L1Config.polygonZkEVMAddress = $c[0].rollupAddress' genesis.json > g.json; mv g.json genesis.jsonx
+jq --slurpfile c combined.json '.L1Config.polygonZkEVMAddress = $c[0].rollupAddress' genesis.json > g.json; mv g.json genesis.json
 
 # The sequencer needs to pay POL when it sequences batches. This gets
 # refunded when the batches are proved. In order for this to work the

--- a/templates/run-contract-setup.sh
+++ b/templates/run-contract-setup.sh
@@ -124,29 +124,7 @@ jq --slurpfile c combined.json '.L1Config = {chainId:{{.l1_network_id}}}' genesi
 jq --slurpfile c combined.json '.L1Config.polygonZkEVMGlobalExitRootAddress = $c[0].polygonZkEVMGlobalExitRootAddress' genesis.json > g.json; mv g.json genesis.json
 jq --slurpfile c combined.json '.L1Config.polygonRollupManagerAddress = $c[0].polygonRollupManagerAddress' genesis.json > g.json; mv g.json genesis.json
 jq --slurpfile c combined.json '.L1Config.polTokenAddress = $c[0].polTokenAddress' genesis.json > g.json; mv g.json genesis.json
-jq --slurpfile c combined.json '.L1Config.polygonZkEVMAddress = $c[0].rollupAddress' genesis.json > g.json; mv g.json genesis.json
-
-# note this particular setting is different for the bridge service!!
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.NetworkConfig.GenBlockNumber = $c[0].deploymentRollupManagerBlockNumber' bridge-config.toml > b.json; mv b.json bridge-config.toml
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.NetworkConfig.PolygonBridgeAddress = $c[0].polygonZkEVMBridgeAddress' bridge-config.toml > b.json; mv b.json bridge-config.toml
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.NetworkConfig.PolygonZkEVMGlobalExitRootAddress = $c[0].polygonZkEVMGlobalExitRootAddress' bridge-config.toml > b.json; mv b.json bridge-config.toml
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.NetworkConfig.PolygonRollupManagerAddress = $c[0].polygonRollupManagerAddress' bridge-config.toml > b.json; mv b.json bridge-config.toml
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.NetworkConfig.PolygonZkEVMAddress = $c[0].rollupAddress' bridge-config.toml > b.json; mv b.json bridge-config.toml
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.NetworkConfig.L2PolygonBridgeAddresses = [$c[0].polygonZkEVMBridgeAddress]' bridge-config.toml > b.json; mv b.json bridge-config.toml
-
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.L1.RollupManagerContract = $c[0].polygonRollupManagerAddress' agglayer-config.toml > a.json; mv a.json agglayer-config.toml
-
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.L1.PolygonValidiumAddress = $c[0].rollupAddress' dac-config.toml > a.json; mv a.json dac-config.toml
-# shellcheck disable=SC2016
-tomlq --slurpfile c combined.json -t '.L1.DataCommitteeAddress = $c[0].polygonDataCommitteeAddress' dac-config.toml > a.json; mv a.json dac-config.toml
+jq --slurpfile c combined.json '.L1Config.polygonZkEVMAddress = $c[0].rollupAddress' genesis.json > g.json; mv g.json genesis.jsonx
 
 # The sequencer needs to pay POL when it sequences batches. This gets
 # refunded when the batches are proved. In order for this to work the

--- a/templates/run-contract-setup.sh
+++ b/templates/run-contract-setup.sh
@@ -94,7 +94,6 @@ cp /opt/zkevm-contracts/deployment/v2/deploy_*.json /opt/zkevm/
 cp /opt/zkevm-contracts/deployment/v2/genesis.json /opt/zkevm/
 cp /opt/zkevm-contracts/deployment/v2/create_rollup_output.json /opt/zkevm/
 cp /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json /opt/zkevm/
-cp /opt/contract-deploy/*-config.* /opt/zkevm/
 popd
 
 pushd /opt/zkevm/ || exit 1


### PR DESCRIPTION
## Description

The deployment process is now divided into various stages. The `stages` parameter indicates the specific stages you wish the deployment to proceed through. By default, it will execute all the stages.

## Use Case

```bash
# Clean up the environment
kurtosis clean -a

# Execute the first stage (deploy L1).
yq e '.stages = [1]' --inplace params.yml
kurtosis run --enclave cdk-v1 --args-file params.yml .
# Do a bunch of things...

# Execute the second stage (configure L1).
yq e '.stages = [2]' --inplace params.yml
kurtosis run --enclave cdk-v1 --args-file params.yml .
# Do a bunch of things...

# Execute the thirs stage (deploy trusted/central environment).
yq e '.stages = [3]' --inplace params.yml
kurtosis run --enclave cdk-v1 --args-file params.yml .
# Do a bunch of things...

# Execute the fourth stage (deploy bridge/agglayer/dac).
yq e '.stages = [4]' --inplace params.yml
kurtosis run --enclave cdk-v1 --args-file params.yml .
# Do a bunch of things...

# Execute the fifth stage (deploy permissionless node).
yq e '.stages = [5]' --inplace params.yml
kurtosis run --enclave cdk-v1 --args-file params.yml .
# Do a bunch of things...
```