### PR TITLE
chore: remove contracts forge build hack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install yq
+        run: |
+          pip3 install yq
+
       - name: Enable gas token feature
         run: yq -Y --in-place '.zkevm_use_gas_token_contract = true' params.yml
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Deploy the CDK environment in one step.
+  # Deploy the CDK environment in one step, with the gas token feature enabled.
   monolithic_cdk:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Enable gas token feature
+        run: yq -Y --in-place '.zkevm_use_gas_token_contract = true' params.yml
 
       - name: Deploy kurtosis package
         uses: kurtosis-tech/kurtosis-github-action@v1

--- a/templates/run-contract-setup.sh
+++ b/templates/run-contract-setup.sh
@@ -69,10 +69,6 @@ npx hardhat compile
 {{if .zkevm_use_gas_token_contract}}
 2>&1 echo "Deploying Gas Token"
 printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
-
-# FIXME: This contract requires the `0.5.12` solc version which is not available on linux/arm.
-rm contracts/mocks/DaiMock.sol
-
 forge build
 forge create --json \
       --rpc-url "{{.l1_rpc_url}}" \


### PR DESCRIPTION
- Remove the hack as the [patch](https://github.com/0xPolygonHermez/zkevm-contracts/pull/226) as already been merged into `zkevm-contracts@develop`.
- Add a CI workflow to test the gas token feature.