### PR TITLE
add ETHEREUM_EXPLORER_URL for bridge-ui

### DIFF
--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -119,7 +119,7 @@ def start_bridge_ui(plan, args, bridge_service):
                 "ETHEREUM_FORCE_UPDATE_GLOBAL_EXIT_ROOT": "true",
                 "ETHEREUM_PROOF_OF_EFFICIENCY_CONTRACT_ADDRESS": zkevm_rollup_address,
                 "ETHEREUM_ROLLUP_MANAGER_ADDRESS": zkevm_rollup_manager_address,
-                "ETHEREUM_EXPLORER_URL": "",
+                "ETHEREUM_EXPLORER_URL": args["ethereum_explorer"],
                 "POLYGON_ZK_EVM_EXPLORER_URL": args["polygon_zkevm_explorer"],
                 "POLYGON_ZK_EVM_NETWORK_ID": "1",
                 "ENABLE_FIAT_EXCHANGE_RATES": "false",

--- a/params.yml
+++ b/params.yml
@@ -138,7 +138,7 @@ l1_chain_id: 271828
 l1_preallocated_mnemonic: code code code code code code code code code code code quality
 l1_rpc_url: http://el-1-geth-lighthouse:8545
 l1_ws_url: ws://el-1-geth-lighthouse:8546
-
+ethereum_explorer: "https://sepolia.etherscan.io/"
 ## Rollup configuration.
 
 # The chain id of the new rollup.


### PR DESCRIPTION
```
ZodError: [
  {
    "validation": "url",
    "code": "invalid_string",
    "message": "Invalid url",
    "path": [
      "VITE_ETHEREUM_EXPLORER_URL"
    ]
  }
]
```
Got this error when running the bridge-ui, should be fixed by adding back the ETHEREUM_EXPLORER_URL 