### PR TITLE
feat: zkevm contracts caching solution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,18 +17,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Install tools.
+      - name: Install kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli
+          kurtosis analytics disable
+
       - name: Install yq
         run: |
           pip3 install yq
 
+      # Deploy components
       - name: Enable gas token feature
         run: yq -Y --in-place '.zkevm_use_gas_token_contract = true' params.yml
 
-      - name: Deploy kurtosis package
-        uses: kurtosis-tech/kurtosis-github-action@v1
-        with:
-          path: .
-          args: params.yml
+      - name: Deploy components
+        run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 
   # Deploy the CDK environment incrementally, stage by stage.
   incremental_cdk:
@@ -68,7 +74,7 @@ jobs:
       - name: Deploy ZkEVM Contracts on L1
         run: |
           yq -Y --in-place '.deploy_zkevm_contracts_on_l1 = true' params.yml
-          kurtosis run --enclave cdk-v1 --args-file params.yml .
+          kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
           yq -Y --in-place '.deploy_zkevm_contracts_on_l1 = false' params.yml # reset
 
       - name: Deploy ZkEVM Node and CDK Peripheral Databases

--- a/README.org
+++ b/README.org
@@ -1,5 +1,23 @@
 * Polygon CDK Kurtosis Package
 
+A [[https://github.com/kurtosis-tech/kurtosis][Kurtosis]] package that deploys a private, portable, and modular Polygon CDK devnet.
+
+** Table of Contents
+
+- [[#For Users]]
+  - [[#Deploy the CDK Stack]]
+  - [[#Set Up a Permissionless Node]]
+  - [[#Troubleshooting: Mac users]]
+- [[#For Developers]]
+  - [[#Break Down the Deployment Into Stages]]
+  - [[#ZkEVM Contracts Caching Solution]]
+- [[#License]]
+- [[#Contribution]]
+
+** For Users
+
+*** Deploy the CDK stack
+
 [[file:docs/architecture.png]]
 
 To get started you'll want to get everything [[https://docs.kurtosis.com/install/][installed]]. Once that's
@@ -7,7 +25,7 @@ good and installed on your system, you can ~cd~ into this directory
 and run:
 
 #+begin_src bash
-kurtosis run --enclave cdk-v1 --args-file params.yml .
+kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 #+end_src
 
 This command will take a few minutes but will basically run an entire
@@ -101,7 +119,7 @@ which stopps everything and deletes it.
 kurtosis clean -a
 #+end_src
 
-** Permissionless Node
+*** Set Up a Permissionless Node
 
 In addition to the core stack, you can also attach and synchronize a
 permissionless node. Of course, you'll need the CDK stack running from
@@ -122,7 +140,7 @@ node to the ~cdk-v1~ enclave:
 kurtosis run --enclave cdk-v1 --args-file params.yml --main-file zkevm_permissionless_node.star .
 #+end_src
 
-*** Remote Permissionless Testing
+**** Remote Permissionless Testing
 
 You can use the permissionless package to sync data from a production
 network as well. First you'll need to get the genesis file and it
@@ -157,8 +175,30 @@ synchronizing with ths command:
 kurtosis run --enclave cdk-v1 --args-file params.yml --main-file zkevm_permissionless_node.star .
 #+end_src
 
+*** Troubleshooting: Mac users
+
+First, ensure that you have [[https://docs.docker.com/desktop/install/mac-install/][Docker Engine]] installed, with a version equal to or higher than 4.27. This is necessary for running the zk Prover on a Mac.
+
+Second, make sure you can access containers using their private IPs. To check that, run the following commands:
+
+#+begin_src bash
+docker run --rm --name nginx -d nginx
+curl -m 1 -I $(docker inspect nginx --format '{{.NetworkSettings.IPAddress}}')
+#+end_src
+
+If the last command fails, then it means you need to set up [[https://github.com/chipmk/docker-mac-net-connect?tab=readme-ov-file#installation][docker-mac-net-connect]].
+
+#+begin_quote
+Unlike Docker on Linux, Docker-for-Mac does not expose container networks directly on the macOS host.
+Docker-for-Mac works by running a Linux VM under the hood (using hyperkit) and creates containers within that VM.
+Docker-for-Mac supports connecting to containers over Layer 4 (port binding), but not Layer 3 (by IP address).
+#+end_quote
+
+Once installed, you may need to [[https://docs.docker.com/desktop/uninstall/][uninstall]] and [[https://docs.docker.com/desktop/install/mac-install/][reinstall]] Docker Engine.
 
 ** For Developers
+
+*** Break Down the Deployment Into Stages
 
 Rather than executing the deployment process as a monolithic operation, you can break it down into stages and run each stage separately.
 
@@ -193,7 +233,7 @@ yq -Yi '.deploy_l1 = false' params.yml # reset
 
 # Deploy ZkEVM Contracts on L1
 yq -Yi '.deploy_zkevm_contracts_on_l1 = true' params.yml
-kurtosis run --enclave cdk-v1 --args-file params.yml .
+kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 yq -Yi '.deploy_zkevm_contracts_on_l1 = false' params.yml # reset
 # Perform additional tasks...
 
@@ -221,26 +261,23 @@ kurtosis run --enclave cdk-v1 --args-file params.yml .
 yq -Yi '.deploy_zkevm_permissionless_node = false' params.yml # reset
 #+end_src
 
-** Troubleshooting: Mac users
+*** ZkEVM Contracts Caching Solution
 
-First, ensure that you have [[https://docs.docker.com/desktop/install/mac-install/][Docker Engine]] installed, with a version equal to or higher than 4.27. This is necessary for running the zk Prover on a Mac.
+We manually build zkevm contracts images to make the deployment of the Kurtosis package as fast as possible.
 
-Second, make sure you can access containers using their private IPs. To check that, run the following commands:
+Indeed, most of the deployment time is spent downloading npm dependencies and compiling the zkevm contracts.
+
+We maintain a list of images at [[https://hub.docker.com/r/leovct/zkevm-contracts][leovct/zkevm-contracts]] for fork ids 6, 7, 8 and 9.
+
+If you wish to use a custom image, you can build your own using the /Dockerfile/. All you need to modify is the /zkevm_contracts_image/ field in /params.yml/.
+
+You can follow the steps and manually build and push the different zkevm contract images to your preferred registry, or you can simply trigger this [[https://github.com/leovct/zkevm-contracts/actions/workflows/build-zkevm-contracts-images.yml][workflow]].
 
 #+begin_src bash
-docker run --rm --name nginx -d nginx
-curl -m 1 -I $(docker inspect nginx --format '{{.NetworkSettings.IPAddress}}')
+docker login
+docker buildx create --name container --driver=docker-container
+./docs/zkevm-contracts-images-builder.sh $USER
 #+end_src
-
-If the last command fails, then it means you need to set up [[https://github.com/chipmk/docker-mac-net-connect?tab=readme-ov-file#installation][docker-mac-net-connect]].
-
-#+begin_quote
-Unlike Docker on Linux, Docker-for-Mac does not expose container networks directly on the macOS host.
-Docker-for-Mac works by running a Linux VM under the hood (using hyperkit) and creates containers within that VM.
-Docker-for-Mac supports connecting to containers over Layer 4 (port binding), but not Layer 3 (by IP address).
-#+end_quote
-
-Once installed, you may need to [[https://docs.docker.com/desktop/uninstall/][uninstall]] and [[https://docs.docker.com/desktop/install/mac-install/][reinstall]] Docker Engine.
 
 ** License
 
@@ -255,7 +292,7 @@ at your option.
 
 The SPDX license identifier for this project is ~MIT OR Apache-2.0~.
 
-*** Contribution
+** Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the

--- a/docs/fork-id-migration.org
+++ b/docs/fork-id-migration.org
@@ -46,7 +46,6 @@ index c2dd446..4caf2d0 100644
  # a38e68b5466d1997cea8466dbd4fc8dacd4e11d8
 -zkevm_contracts_branch: develop  # v5.0.1-rc.2-fork.8
 +zkevm_contracts_branch: v4.0.0-fork.7  # v5.0.1-rc.2-fork.8
- zkevm_contracts_repo: https://github.com/0xPolygonHermez/zkevm-contracts.git
 -zkevm_rollup_fork_id: 9
 +zkevm_rollup_fork_id: 7
  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
@@ -56,7 +55,7 @@ index c2dd446..4caf2d0 100644
 After making those changes we should be able to kick off a full redeployment:
 
 #+begin_src bash
-kurtosis run --enclave cdk-v1 --args-file params.yml .
+kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 #+end_src
 
 After running this command, let's confirm onchain that this is running
@@ -265,7 +264,7 @@ sure to remove the ~HaltOnBatchNumber~ setting that we added earlier
 in the process
 
 #+begin_src bash
-kurtosis run --enclave cdk-v1 --args-file params.yml .
+kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 #+end_src
 
 At this point, the core services are running and if everything went

--- a/docs/gas-token.org
+++ b/docs/gas-token.org
@@ -27,7 +27,7 @@ After setting the ~zkevm_use_gas_token_contract~, you should be all
 set to run Kurtosis.
 
 #+begin_src bash
-kurtosis run --enclave cdk-v1 --args-file params.yml .
+kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 #+end_src
 
 This will take a few minutes as the full set of contracts will be

--- a/docs/zkevm-contracts-images-builder.sh
+++ b/docs/zkevm-contracts-images-builder.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# The repository of the image.
+# The image will be called $repository/zkevm-contracts.
+repository="$1"
+
+build_and_push_zkevm_contracts_image() {
+  fork="$1"
+  branch="$2"
+
+  echo "Building and pushing $repository/zkevm-contracts:$fork..."
+  docker buildx build . \
+    --tag "$repository/zkevm-contracts:$fork" \
+    --build-arg "ZKEVM_CONTRACTS_BRANCH=$branch" \
+    --build-arg "POLYCLI_VERSION=v0.1.42" \
+    --file ./docs/zkevm-contracts.Dockerfile \
+    --platform linux/amd64,linux/arm64 \
+    --builder container \
+    --push
+}
+
+build_and_push_zkevm_contracts_image "fork4" "v1.1.0-fork.4"
+build_and_push_zkevm_contracts_image "fork5" "v2.0.0-fork.5"
+build_and_push_zkevm_contracts_image "fork6" "v3.0.0-fork.6"
+build_and_push_zkevm_contracts_image "fork7" "v4.0.0-fork.7"
+build_and_push_zkevm_contracts_image "fork8" "v5.0.1-rc.2-fork.8"
+build_and_push_zkevm_contracts_image "fork9" "develop"

--- a/docs/zkevm-contracts.Dockerfile
+++ b/docs/zkevm-contracts.Dockerfile
@@ -1,0 +1,35 @@
+FROM golang:1.21 AS polycli-builder
+ARG POLYCLI_VERSION
+WORKDIR /opt/polygon-cli
+RUN git clone --branch $POLYCLI_VERSION https://github.com/maticnetwork/polygon-cli.git . \
+  && CGO_ENABLED=0 go build -o polycli main.go
+
+
+FROM node:20-bookworm
+LABEL author="devtools@polygon.technology"
+LABEL description="Helper image to build zkevm contracts"
+
+# STEP 1: Download zkevm contracts dependencies and compile contracts.
+ARG ZKEVM_CONTRACTS_BRANCH
+WORKDIR /opt/zkevm-contracts
+RUN git clone --branch ${ZKEVM_CONTRACTS_BRANCH} https://github.com/0xPolygonHermez/zkevm-contracts . \
+  && npm install --ignore-scripts \
+  && npx hardhat compile
+
+# STEP 2: Install tools.
+COPY --from=polycli-builder /opt/polygon-cli/polycli /usr/bin/polycli
+WORKDIR /opt
+# WARNING (DL3008): Pin versions in apt get install.
+# WARNING (DL4006): Set the SHELL option -o pipefail before RUN with a pipe in it
+# WARNING (SC1091): (Sourced) file not included in mock.
+# hadolint ignore=DL3008,DL4006,SC1091
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends jq python3-pip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip3 install --break-system-packages yq \
+  && curl --silent --location --proto "=https" https://foundry.paradigm.xyz | bash \
+  && /root/.foundry/bin/foundryup \
+  && cp /root/.foundry/bin/* /usr/local/bin
+
+USER node

--- a/params.yml
+++ b/params.yml
@@ -31,13 +31,14 @@ deploy_observability: true
 # Docker images and repositories used to spin up services.
 zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
 # zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
+
 zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.2
 # zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
+
 zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
 # zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.6
-zkevm_contracts_branch: develop # v5.0.1-rc.2-fork.8
-# zkevm_contracts_branch: v4.0.0-fork.7  # v5.0.1-rc.2-fork.8
-zkevm_contracts_repo: https://github.com/0xPolygonHermez/zkevm-contracts.git
+
+zkevm_contracts_image: leovct/zkevm-contracts # the tag is automatically replaced by the value of /zkevm_rollup_fork_id/
 
 zkevm_agglayer_image: 0xpolygon/agglayer:0.1.1
 zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2-cdk.1


### PR DESCRIPTION
## Description

- Build zkevm contracts images for both `linux/amd64` and `linux/arm64`, for fork ids 4, 5, 6, 7, 8 and 9. These images contain all the `npm` dependencies and the compiled contracts. They weight around 2GB and have a compressed size of around 700/900MB. The images are hosted on the [Docker Hub](https://hub.docker.com/r/leovct/zkevm-contracts/tags) under my username for now, but [we are planning to move them to GCR](https://polygon.atlassian.net/browse/DVT-1435) in the future.

- A README section has been added to explain how to build the images. The process is manual, you can either use a script or trigger a Github action [workflow](https://github.com/leovct/zkevm-contracts/actions/workflows/build-zkevm-contracts-images.yml).

- Update the contract deployment script by removing the dependencies download and the contract compilation steps.

- Add TOC to README.

## Test

- [x] Deploy the environment on `linux/amd64` => CI workflows
- [x] Deploy the environment on `linux/arm64` => Manual deployment on my mac


