### PR TITLE
feat: start services in parallel

### DIFF
--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -1,6 +1,6 @@
 service_package = import_module("./lib/service.star")
-zkevm_bridge_package = import_module("./lib/zkevm_bridge.star")
 zkevm_agglayer_package = import_module("./lib/zkevm_agglayer.star")
+zkevm_bridge_package = import_module("./lib/zkevm_bridge.star")
 
 
 def run(plan, args):

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -1,5 +1,6 @@
 service_package = import_module("./lib/service.star")
 zkevm_bridge_package = import_module("./lib/zkevm_bridge.star")
+zkevm_agglayer_package = import_module("./lib/zkevm_agglayer.star")
 
 
 def run(plan, args):
@@ -11,7 +12,7 @@ def run(plan, args):
         src="/opt/zkevm/claimtxmanager.keystore",
     )
     bridge_config = zkevm_bridge_package.create_bridge_service_config(
-        plan, args, bridge_config, claimtx_keystore_artifact
+        args, bridge_config_artifact, claimtx_keystore_artifact
     )
 
     # Create the agglayer service config.

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -1,24 +1,63 @@
 service_package = import_module("./lib/service.star")
+zkevm_bridge_package = import_module("./lib/zkevm_bridge.star")
 
 
 def run(plan, args):
+    # Create the bridge service config.
+    bridge_config_artifact = create_bridge_config_artifact(plan, args)
+    claimtx_keystore_artifact = plan.store_service_files(
+        name="claimtxmanager-keystore",
+        service_name="contracts" + args["deployment_suffix"],
+        src="/opt/zkevm/claimtxmanager.keystore",
+    )
+    bridge_config = zkevm_bridge_package.create_bridge_service_config(
+        plan, args, bridge_config, claimtx_keystore_artifact
+    )
+
+    # Create the agglayer service config.
+    agglayer_config_artifact = create_agglayer_config_artifact(plan, args)
+    agglayer_keystore_artifact = plan.store_service_files(
+        name="agglayer-keystore",
+        service_name="contracts" + args["deployment_suffix"],
+        src="/opt/zkevm/agglayer.keystore",
+    )
+    agglayer_config = zkevm_agglayer_package.create_agglayer_service_config(
+        args, agglayer_config_artifact, agglayer_keystore_artifact
+    )
+
     # Start the bridge service and the agglayer.
-    bridge_config = create_bridge_service_config(plan, args)
-    agglayer_config = create_agglayer_service_config(plan, args)
     bridge_infra_services = plan.add_services(
         configs=bridge_config | agglayer_config,
         description="Starting bridge infra",
     )
 
     # Start the bridge UI.
+    l1_eth_service = plan.get_service(name="el-1-geth-lighthouse")
+    zkevm_node_rpc = plan.get_service(name="zkevm-node-rpc" + args["deployment_suffix"])
     bridge_service_name = "zkevm-bridge-service" + args["deployment_suffix"]
     bridge_service = bridge_infra_services[bridge_service_name]
-    start_bridge_ui(plan, args, bridge_service)
+    config = struct(
+        l1_eth_service=l1_eth_service,
+        zkevm_rpc_ip_address=zkevm_node_rpc.ip_address,
+        zkevm_rpc_http_port=zkevm_node_rpc.ports["http-rpc"],
+        bridge_service_ip_address=bridge_service.ip_address,
+        bridge_api_http_port=bridge_service.ports["bridge-rpc"],
+        zkevm_bridge_address=service_package.get_key_from_config(
+            plan, args, "polygonZkEVMBridgeAddress"
+        ),
+        zkevm_rollup_address=service_package.get_key_from_config(
+            plan, args, "rollupAddress"
+        ),
+        zkevm_rollup_manager_address=service_package.get_key_from_config(
+            plan, args, "polygonRollupManagerAddress"
+        ),
+    )
+    zkevm_bridge_package.start_bridge_ui(plan, args, config)
 
 
-def create_bridge_service_config(plan, args):
-    # Create bridge config.
+def create_bridge_config_artifact(plan, args):
     bridge_config_template = read_file(src="./templates/bridge-config.toml")
+
     rollup_manager_block_number = service_package.get_key_from_config(
         plan, args, "deploymentRollupManagerBlockNumber"
     )
@@ -31,15 +70,11 @@ def create_bridge_service_config(plan, args):
     zkevm_rollup_manager_address = service_package.get_key_from_config(
         plan, args, "polygonRollupManagerAddress"
     )
-    claimtx_keystore_artifact = plan.store_service_files(
-        name="claimtxmanager-keystore",
-        service_name="contracts" + args["deployment_suffix"],
-        src="/opt/zkevm/claimtxmanager.keystore",
-    )
     zkevm_rollup_address = service_package.get_key_from_config(
         plan, args, "rollupAddress"
     )
-    bridge_config_artifact = plan.render_templates(
+
+    return plan.render_templates(
         name="bridge-config-artifact",
         config={
             "bridge-config.toml": struct(
@@ -69,98 +104,13 @@ def create_bridge_service_config(plan, args):
         },
     )
 
-    # Create bridge service config.
-    bridge_service_name = "zkevm-bridge-service" + args["deployment_suffix"]
-    bridge_service_config = ServiceConfig(
-        image="hermeznetwork/zkevm-bridge-service:v0.4.2",
-        ports={
-            "bridge-rpc": PortSpec(
-                args["zkevm_bridge_rpc_port"], application_protocol="http"
-            ),
-            "bridge-grpc": PortSpec(
-                args["zkevm_bridge_grpc_port"], application_protocol="grpc"
-            ),
-        },
-        files={
-            "/etc/zkevm": Directory(
-                artifact_names=[bridge_config_artifact, claimtx_keystore_artifact]
-            ),
-        },
-        entrypoint=[
-            "/app/zkevm-bridge",
-        ],
-        cmd=["run", "--cfg", "/etc/zkevm/bridge-config.toml"],
-    )
-    return {bridge_service_name: bridge_service_config}
 
-
-def start_bridge_ui(plan, args, bridge_service):
-    # Get bridge UI config.
-    l1_eth_service = plan.get_service(name="el-1-geth-lighthouse")
-    zkevm_node_rpc = plan.get_service(name="zkevm-node-rpc" + args["deployment_suffix"])
-    zkevm_bridge_address = service_package.get_key_from_config(
-        plan, args, "polygonZkEVMBridgeAddress"
-    )
-    zkevm_rollup_manager_address = service_package.get_key_from_config(
-        plan, args, "polygonRollupManagerAddress"
-    )
-    zkevm_rollup_address = service_package.get_key_from_config(
-        plan, args, "rollupAddress"
-    )
-    polygon_zkevm_rpc_http_port = zkevm_node_rpc.ports["http-rpc"]
-    bridge_api_http_port = bridge_service.ports["bridge-rpc"]
-
-    # Start bridge UI.
-    plan.add_service(
-        name="zkevm-bridge-ui" + args["deployment_suffix"],
-        config=ServiceConfig(
-            image=args["zkevm_bridge_ui_image"],
-            ports={
-                "bridge-ui": PortSpec(
-                    args["zkevm_bridge_ui_port"], application_protocol="http"
-                ),
-            },
-            env_vars={
-                "ETHEREUM_RPC_URL": "http://{}:{}".format(
-                    l1_eth_service.ip_address, l1_eth_service.ports["rpc"].number
-                ),
-                "POLYGON_ZK_EVM_RPC_URL": "http://{}:{}".format(
-                    zkevm_node_rpc.ip_address,
-                    polygon_zkevm_rpc_http_port.number,
-                ),
-                "BRIDGE_API_URL": "http://{}:{}".format(
-                    bridge_service.ip_address, bridge_api_http_port.number
-                ),
-                "ETHEREUM_BRIDGE_CONTRACT_ADDRESS": zkevm_bridge_address,
-                "POLYGON_ZK_EVM_BRIDGE_CONTRACT_ADDRESS": zkevm_bridge_address,
-                "ETHEREUM_FORCE_UPDATE_GLOBAL_EXIT_ROOT": "true",
-                "ETHEREUM_PROOF_OF_EFFICIENCY_CONTRACT_ADDRESS": zkevm_rollup_address,
-                "ETHEREUM_ROLLUP_MANAGER_ADDRESS": zkevm_rollup_manager_address,
-                "ETHEREUM_EXPLORER_URL": args["l1_explorer_url"],
-                "POLYGON_ZK_EVM_EXPLORER_URL": args["polygon_zkevm_explorer"],
-                "POLYGON_ZK_EVM_NETWORK_ID": "1",
-                "ENABLE_FIAT_EXCHANGE_RATES": "false",
-                "ENABLE_OUTDATED_NETWORK_MODAL": "false",
-                "ENABLE_DEPOSIT_WARNING": "true",
-                "ENABLE_REPORT_FORM": "false",
-            },
-            cmd=["run"],
-        ),
-    )
-
-
-def create_agglayer_service_config(plan, args):
-    # Create agglayer config.
+def create_agglayer_config_artifact(plan, args):
     agglayer_config_template = read_file(src="./templates/agglayer-config.toml")
     rollup_manager_address = service_package.get_key_from_config(
         plan, args, "polygonRollupManagerAddress"
     )
-    agglayer_keystore_artifact = plan.store_service_files(
-        name="agglayer-keystore",
-        service_name="contracts" + args["deployment_suffix"],
-        src="/opt/zkevm/agglayer.keystore",
-    )
-    agglayer_config_artifact = plan.render_templates(
+    return plan.render_templates(
         name="agglayer-config-artifact",
         config={
             "agglayer-config.toml": struct(
@@ -190,30 +140,3 @@ def create_agglayer_service_config(plan, args):
             )
         },
     )
-
-    # Create agglayer service config.
-    agglayer_name = "zkevm-agglayer" + args["deployment_suffix"]
-    agglayer_service_config = ServiceConfig(
-        image=args["zkevm_agglayer_image"],
-        ports={
-            "agglayer": PortSpec(
-                args["zkevm_agglayer_port"], application_protocol="http"
-            ),
-            "prometheus": PortSpec(
-                args["zkevm_prometheus_port"], application_protocol="http"
-            ),
-        },
-        files={
-            "/etc/zkevm": Directory(
-                artifact_names=[
-                    agglayer_config_artifact,
-                    agglayer_keystore_artifact,
-                ]
-            ),
-        },
-        entrypoint=[
-            "/usr/local/bin/agglayer",
-        ],
-        cmd=["run", "--cfg", "/etc/zkevm/agglayer-config.toml"],
-    )
-    return {agglayer_name: agglayer_service_config}

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -1,5 +1,7 @@
-zkevm_prover_package = import_module("./lib/zkevm_prover.star")
+service_package = import_module("./lib/service.star")
+zkevm_dac_package = import_module("./lib/zkevm_dac.star")
 zkevm_node_package = import_module("./lib/zkevm_node.star")
+zkevm_prover_package = import_module("./lib/zkevm_prover.star")
 
 
 def run(plan, args):
@@ -27,13 +29,46 @@ def run(plan, args):
             config={"genesis.json": struct(template=genesis_file, data={})},
         )
 
-    # Get the config and keystores.
-    config_template = read_file(src="./templates/trusted-node/node-config.toml")
-    config_artifact = plan.render_templates(
-        config={"node-config.toml": struct(template=config_template, data=args)},
+    # Create zkevm node config.
+    node_config_template = read_file(src="./templates/trusted-node/node-config.toml")
+    node_config_artifact = plan.render_templates(
+        config={"node-config.toml": struct(template=node_config_template, data=args)},
         name="trusted-node-config",
     )
 
+    # Create dac config.
+    dac_config_template = read_file(src="./templates/dac-config.toml")
+    dac_config_artifact = plan.render_templates(
+        name="dac-config-artifact",
+        config={
+            "dac-config.toml": struct(
+                template=dac_config_template,
+                data={
+                    "deployment_suffix": args["deployment_suffix"],
+                    "l1_rpc_url": args["l1_rpc_url"],
+                    "l1_ws_url": args["l1_ws_url"],
+                    "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
+                    # addresses
+                    "rollup_address": service_package.get_key_from_config(
+                        plan, args, "rollupAddress"
+                    ),
+                    "polygon_data_committee_address": service_package.get_key_from_config(
+                        plan, args, "polygonDataCommitteeAddress"
+                    ),
+                    # dac db
+                    "zkevm_db_dac_hostname": args["zkevm_db_dac_hostname"],
+                    "zkevm_db_dac_name": args["zkevm_db_dac_name"],
+                    "zkevm_db_dac_user": args["zkevm_db_dac_user"],
+                    "zkevm_db_dac_password": args["zkevm_db_dac_password"],
+                    # ports
+                    "zkevm_db_postgres_port": args["zkevm_db_postgres_port"],
+                    "zkevm_dac_port": args["zkevm_dac_port"],
+                },
+            )
+        },
+    )
+
+    # Get all the keystores.
     sequencer_keystore_artifact = plan.store_service_files(
         name="sequencer-keystore",
         service_name="contracts" + args["deployment_suffix"],
@@ -49,21 +84,32 @@ def run(plan, args):
         service_name="contracts" + args["deployment_suffix"],
         src="/opt/zkevm/proofsigner.keystore",
     )
+    dac_keystore_artifact = plan.store_service_files(
+        name="dac-keystore",
+        service_name="contracts" + args["deployment_suffix"],
+        src="/opt/zkevm/dac.keystore",
+    )
     keystore_artifacts = struct(
         sequencer=sequencer_keystore_artifact,
         aggregator=aggregator_keystore_artifact,
         proofsigner=proofsigner_keystore_artifact,
+        dac=dac_keystore_artifact,
     )
 
     # Start all the zkevm node components.
-    zkevm_node_package.start_synchronizer(plan, args, config_artifact, genesis_artifact)
+    zkevm_node_package.start_synchronizer(
+        plan, args, node_config_artifact, genesis_artifact
+    )
 
     zkevm_node_components_configs = (
         zkevm_node_package.create_zkevm_node_components_config(
-            args, config_artifact, genesis_artifact, keystore_artifacts
+            args, node_config_artifact, genesis_artifact, keystore_artifacts
         )
     )
+    dac_config = zkevm_dac_package.create_dac_service_config(
+        args, dac_config_artifact, dac_keystore_artifact
+    )
     plan.add_services(
-        configs=zkevm_node_components_configs,
+        configs=zkevm_node_components_configs | dac_config,
         description="Starting the rest of the zkevm node components",
     )

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -56,13 +56,7 @@ def run(plan, args):
     )
 
     # Start all the zkevm node components.
-    synchronizer_config = zkevm_node_package.create_synchronizer_service_config(
-        args, config_artifact, genesis_artifact
-    )
-    plan.add_service(
-        config=synchronizer_config,
-        description="Starting the zkevm node synchronizer",
-    )
+    zkevm_node_package.start_synchronizer(plan, args, config_artifact, genesis_artifact)
 
     zkevm_node_components_configs = (
         zkevm_node_package.create_zkevm_node_components_config(

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -51,7 +51,7 @@ def run(plan, args):
 
     dac_config_artifact = create_dac_config_artifact(plan, args)
     dac_config = zkevm_dac_package.create_dac_service_config(
-        args, dac_config_artifact, dac_keystore_artifact
+        args, dac_config_artifact, keystore_artifacts.dac
     )
 
     plan.add_services(

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -56,6 +56,14 @@ def run(plan, args):
     )
 
     # Start all the zkevm node components.
+    synchronizer_config = zkevm_node_package.create_synchronizer_service_config(
+        args, config_artifact, genesis_artifact
+    )
+    plan.add_service(
+        config=synchronizer_config,
+        description="Starting the zkevm node synchronizer",
+    )
+
     zkevm_node_components_configs = (
         zkevm_node_package.create_zkevm_node_components_config(
             args, config_artifact, genesis_artifact, keystore_artifacts
@@ -63,5 +71,5 @@ def run(plan, args):
     )
     plan.add_services(
         configs=zkevm_node_components_configs,
-        description="Starting zkevm node components",
+        description="Starting the rest of the zkevm node components",
     )

--- a/cdk_databases.star
+++ b/cdk_databases.star
@@ -15,9 +15,7 @@ def run(plan, args):
         args, event_db_init_script, prover_db_init_script
     )
     peripheral_db_configs = (
-        zkevm_databases_package.create_peripheral_databases_service_configs(
-            args, event_db_init_script, prover_db_init_script
-        )
+        zkevm_databases_package.create_peripheral_databases_service_configs(args)
     )
     plan.add_services(
         configs=node_db_configs | peripheral_db_configs,

--- a/cdk_databases.star
+++ b/cdk_databases.star
@@ -2,7 +2,7 @@ zkevm_databases_package = import_module("./lib/zkevm_databases.star")
 
 
 def run(plan, args):
-    # Start zkevm node databases.
+    # Start node and peripheral databases.
     event_db_init_script = plan.upload_files(
         name="event-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/event-db-init.sql",
@@ -11,9 +11,15 @@ def run(plan, args):
         name="prover-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/prover-db-init.sql",
     )
-    zkevm_databases_package.start_node_databases(
-        plan, args, event_db_init_script, prover_db_init_script
+    node_db_service_configs = zkevm_databases_package.create_node_db_service_configs(
+        args, event_db_init_script, prover_db_init_script
     )
-
-    # Start cdk peripheral databases.
-    zkevm_databases_package.start_peripheral_databases(plan, args)
+    peripheral_db_service_configs = (
+        zkevm_databases_package.create_node_db_service_configs(
+            args, event_db_init_script, prover_db_init_script
+        )
+    )
+    plan.add_services(
+        configs=node_db_service_configs | peripheral_db_service_configs,
+        description="Starting node and peripheral databases",
+    )

--- a/cdk_databases.star
+++ b/cdk_databases.star
@@ -14,8 +14,10 @@ def run(plan, args):
     node_db_configs = zkevm_databases_package.create_node_db_service_configs(
         args, event_db_init_script, prover_db_init_script
     )
-    peripheral_db_configs = zkevm_databases_package.create_node_db_service_configs(
-        args, event_db_init_script, prover_db_init_script
+    peripheral_db_configs = (
+        zkevm_databases_package.create_peripheral_databases_service_configs(
+            args, event_db_init_script, prover_db_init_script
+        )
     )
     plan.add_services(
         configs=node_db_configs | peripheral_db_configs,

--- a/cdk_databases.star
+++ b/cdk_databases.star
@@ -11,15 +11,13 @@ def run(plan, args):
         name="prover-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/prover-db-init.sql",
     )
-    node_db_service_configs = zkevm_databases_package.create_node_db_service_configs(
+    node_db_configs = zkevm_databases_package.create_node_db_service_configs(
         args, event_db_init_script, prover_db_init_script
     )
-    peripheral_db_service_configs = (
-        zkevm_databases_package.create_node_db_service_configs(
-            args, event_db_init_script, prover_db_init_script
-        )
+    peripheral_db_configs = zkevm_databases_package.create_node_db_service_configs(
+        args, event_db_init_script, prover_db_init_script
     )
     plan.add_services(
-        configs=node_db_service_configs | peripheral_db_service_configs,
+        configs=node_db_configs | peripheral_db_configs,
         description="Starting node and peripheral databases",
     )

--- a/lib/service.star
+++ b/lib/service.star
@@ -11,3 +11,15 @@ def extract_json_key_from_service(plan, service_name, filename, key):
     )
     result = plan.exec(service_name=service_name, recipe=exec_recipe)
     return result["extract.extracted_value"]
+
+
+# Get key from the contracts service.
+# TODO: The contracts service should only run once, save config to artifacts and shut down.
+# We need to use `get_file_artifacts` instead of this method.
+def get_key_from_config(plan, args, key):
+    return extract_json_key_from_service(
+        plan,
+        "contracts" + args["deployment_suffix"],
+        "/opt/zkevm/combined.json",
+        key,
+    )

--- a/lib/zkevm_agglayer.star
+++ b/lib/zkevm_agglayer.star
@@ -1,0 +1,26 @@
+def create_agglayer_service_config(args, config_artifact, agglayer_keystore_artifact):
+    agglayer_name = "zkevm-agglayer" + args["deployment_suffix"]
+    agglayer_service_config = ServiceConfig(
+        image=args["zkevm_agglayer_image"],
+        ports={
+            "agglayer": PortSpec(
+                args["zkevm_agglayer_port"], application_protocol="http"
+            ),
+            "prometheus": PortSpec(
+                args["zkevm_prometheus_port"], application_protocol="http"
+            ),
+        },
+        files={
+            "/etc/zkevm": Directory(
+                artifact_names=[
+                    config_artifact,
+                    agglayer_keystore_artifact,
+                ]
+            ),
+        },
+        entrypoint=[
+            "/usr/local/bin/agglayer",
+        ],
+        cmd=["run", "--cfg", "/etc/zkevm/agglayer-config.toml"],
+    )
+    return {agglayer_name: agglayer_service_config}

--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -1,7 +1,7 @@
 def create_bridge_service_config(args, config_artifact, claimtx_keystore_artifact):
     bridge_service_name = "zkevm-bridge-service" + args["deployment_suffix"]
     bridge_service_config = ServiceConfig(
-        image="hermeznetwork/zkevm-bridge-service:v0.4.2",
+        image=args["zkevm_bridge_service_image"],
         ports={
             "bridge-rpc": PortSpec(
                 args["zkevm_bridge_rpc_port"], application_protocol="http"

--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -1,0 +1,63 @@
+def create_bridge_service_config(args, config_artifact, claimtx_keystore_artifact):
+    bridge_service_name = "zkevm-bridge-service" + args["deployment_suffix"]
+    bridge_service_config = ServiceConfig(
+        image="hermeznetwork/zkevm-bridge-service:v0.4.2",
+        ports={
+            "bridge-rpc": PortSpec(
+                args["zkevm_bridge_rpc_port"], application_protocol="http"
+            ),
+            "bridge-grpc": PortSpec(
+                args["zkevm_bridge_grpc_port"], application_protocol="grpc"
+            ),
+        },
+        files={
+            "/etc/zkevm": Directory(
+                artifact_names=[bridge_config_artifact, claimtx_keystore_artifact]
+            ),
+        },
+        entrypoint=[
+            "/app/zkevm-bridge",
+        ],
+        cmd=["run", "--cfg", "/etc/zkevm/bridge-config.toml"],
+    )
+    return {bridge_service_name: bridge_service_config}
+
+
+def start_bridge_ui(plan, args, config):
+    plan.add_service(
+        name="zkevm-bridge-ui" + args["deployment_suffix"],
+        config=ServiceConfig(
+            image=args["zkevm_bridge_ui_image"],
+            ports={
+                "bridge-ui": PortSpec(
+                    args["zkevm_bridge_ui_port"], application_protocol="http"
+                ),
+            },
+            env_vars={
+                "ETHEREUM_RPC_URL": "http://{}:{}".format(
+                    config.l1_eth_service.ip_address,
+                    config.l1_eth_service.ports["rpc"].number,
+                ),
+                "POLYGON_ZK_EVM_RPC_URL": "http://{}:{}".format(
+                    config.zkevm_rpc_ip_address,
+                    config.zkevm_rpc_http_port,
+                ),
+                "BRIDGE_API_URL": "http://{}:{}".format(
+                    config.bridge_service_ip_address, config.bridge_api_http_port
+                ),
+                "ETHEREUM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,
+                "POLYGON_ZK_EVM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,
+                "ETHEREUM_FORCE_UPDATE_GLOBAL_EXIT_ROOT": "true",
+                "ETHEREUM_PROOF_OF_EFFICIENCY_CONTRACT_ADDRESS": config.zkevm_rollup_address,
+                "ETHEREUM_ROLLUP_MANAGER_ADDRESS": config.zkevm_rollup_manager_address,
+                "ETHEREUM_EXPLORER_URL": args["l1_explorer_url"],
+                "POLYGON_ZK_EVM_EXPLORER_URL": args["polygon_zkevm_explorer"],
+                "POLYGON_ZK_EVM_NETWORK_ID": "1",
+                "ENABLE_FIAT_EXCHANGE_RATES": "false",
+                "ENABLE_OUTDATED_NETWORK_MODAL": "false",
+                "ENABLE_DEPOSIT_WARNING": "true",
+                "ENABLE_REPORT_FORM": "false",
+            },
+            cmd=["run"],
+        ),
+    )

--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -12,7 +12,7 @@ def create_bridge_service_config(args, config_artifact, claimtx_keystore_artifac
         },
         files={
             "/etc/zkevm": Directory(
-                artifact_names=[bridge_config_artifact, claimtx_keystore_artifact]
+                artifact_names=[config_artifact, claimtx_keystore_artifact]
             ),
         },
         entrypoint=[

--- a/lib/zkevm_dac.star
+++ b/lib/zkevm_dac.star
@@ -1,0 +1,18 @@
+def create_dac_service_config(args, config_artifact, dac_keystore_artifact):
+    dac_name = "zkevm-dac" + args["deployment_suffix"]
+    dac_service_config = ServiceConfig(
+        image=args["zkevm_dac_image"],
+        ports={
+            "dac": PortSpec(args["zkevm_dac_port"], application_protocol="http"),
+        },
+        files={
+            "/etc/zkevm": Directory(
+                artifact_names=[config_artifact, dac_keystore_artifact]
+            ),
+        },
+        entrypoint=[
+            "/app/cdk-data-availability",
+        ],
+        cmd=["run", "--cfg", "/etc/zkevm/dac-config.toml"],
+    )
+    return {dac_name: dac_service_config}

--- a/lib/zkevm_databases.star
+++ b/lib/zkevm_databases.star
@@ -1,34 +1,45 @@
 POSTGRES_IMAGE = "postgres:16.2"
 
 
-def _start_postgres_db(
-    plan, name, port, db, user, password, init_script_artifact_name=""
+def _create_postgres_db_service_config(
+    port, db, user, password, init_script_artifact_name=""
 ):
     files = {}
     if init_script_artifact_name != "":
         files["/docker-entrypoint-initdb.d/"] = init_script_artifact_name
-    plan.add_service(
-        name=name,
-        config=ServiceConfig(
-            image=POSTGRES_IMAGE,
-            ports={
-                "postgres": PortSpec(port, application_protocol="postgresql"),
-            },
-            env_vars={
-                "POSTGRES_DB": db,
-                "POSTGRES_USER": user,
-                "POSTGRES_PASSWORD": password,
-            },
-            files=files,
-        ),
+    return ServiceConfig(
+        image=POSTGRES_IMAGE,
+        ports={
+            "postgres": PortSpec(port, application_protocol="postgresql"),
+        },
+        env_vars={
+            "POSTGRES_DB": db,
+            "POSTGRES_USER": user,
+            "POSTGRES_PASSWORD": password,
+        },
+        files=files,
     )
 
 
-def start_node_databases(plan, args, event_db_init_script, prover_db_init_script):
-    # Start event database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_event_hostname"] + args["deployment_suffix"],
+def create_node_db_service_configs(args, event_db_init_script, prover_db_init_script):
+    pool_db_name = args["zkevm_db_pool_hostname"] + args["deployment_suffix"]
+    pool_db_service_config = _create_postgres_db_service_config(
+        port=args["zkevm_db_postgres_port"],
+        db=args["zkevm_db_pool_name"],
+        user=args["zkevm_db_pool_user"],
+        password=args["zkevm_db_pool_password"],
+    )
+
+    state_db_name = args["zkevm_db_state_hostname"] + args["deployment_suffix"]
+    state_db_service_config = _create_postgres_db_service_config(
+        port=args["zkevm_db_postgres_port"],
+        db=args["zkevm_db_state_name"],
+        user=args["zkevm_db_state_user"],
+        password=args["zkevm_db_state_password"],
+    )
+
+    event_db_name = args["zkevm_db_event_hostname"] + args["deployment_suffix"]
+    event_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],
         db=args["zkevm_db_event_name"],
         user=args["zkevm_db_event_user"],
@@ -36,20 +47,8 @@ def start_node_databases(plan, args, event_db_init_script, prover_db_init_script
         init_script_artifact_name=event_db_init_script,
     )
 
-    # Start pool database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_pool_hostname"] + args["deployment_suffix"],
-        port=args["zkevm_db_postgres_port"],
-        db=args["zkevm_db_pool_name"],
-        user=args["zkevm_db_pool_user"],
-        password=args["zkevm_db_pool_password"],
-    )
-
-    # Start prover database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_prover_hostname"] + args["deployment_suffix"],
+    prover_db_name = args["zkevm_db_prover_hostname"] + args["deployment_suffix"]
+    prover_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],
         db=args["zkevm_db_prover_name"],
         user=args["zkevm_db_prover_user"],
@@ -57,44 +56,41 @@ def start_node_databases(plan, args, event_db_init_script, prover_db_init_script
         init_script_artifact_name=prover_db_init_script,
     )
 
-    # Start state database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_state_hostname"] + args["deployment_suffix"],
-        port=args["zkevm_db_postgres_port"],
-        db=args["zkevm_db_state_name"],
-        user=args["zkevm_db_state_user"],
-        password=args["zkevm_db_state_password"],
-    )
+    return {
+        pool_db_name: pool_db_service_config,
+        state_db_name: state_db_service_config,
+        event_db_name: event_db_service_config,
+        prover_db_name: prover_db_service_config,
+    }
 
 
 def start_peripheral_databases(plan, args):
-    # Start bridge database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_bridge_hostname"] + args["deployment_suffix"],
+    bridge_db_name = args["zkevm_db_bridge_hostname"] + args["deployment_suffix"]
+    bridge_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],
         db=args["zkevm_db_bridge_name"],
         user=args["zkevm_db_bridge_user"],
         password=args["zkevm_db_bridge_password"],
     )
 
-    # Start agglayer database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_agglayer_hostname"] + args["deployment_suffix"],
+    agglayer_db_name = args["zkevm_db_agglayer_hostname"] + args["deployment_suffix"]
+    agglayer_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],
         db=args["zkevm_db_agglayer_name"],
         user=args["zkevm_db_agglayer_user"],
         password=args["zkevm_db_agglayer_password"],
     )
 
-    # Start dac database.
-    _start_postgres_db(
-        plan,
-        name=args["zkevm_db_dac_hostname"] + args["deployment_suffix"],
+    dac_db_name = args["zkevm_db_dac_hostname"] + args["deployment_suffix"]
+    dac_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],
         db=args["zkevm_db_dac_name"],
         user=args["zkevm_db_dac_user"],
         password=args["zkevm_db_dac_password"],
     )
+
+    return {
+        bridge_db_name: bridge_db_service_config,
+        agglayer_db_name: agglayer_db_service_config,
+        dac_db_name: dac_db_service_config,
+    }

--- a/lib/zkevm_databases.star
+++ b/lib/zkevm_databases.star
@@ -64,7 +64,7 @@ def create_node_db_service_configs(args, event_db_init_script, prover_db_init_sc
     }
 
 
-def create_peripheral_databases_service_configs(plan, args):
+def create_peripheral_databases_service_configs(args):
     bridge_db_name = args["zkevm_db_bridge_hostname"] + args["deployment_suffix"]
     bridge_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],

--- a/lib/zkevm_databases.star
+++ b/lib/zkevm_databases.star
@@ -64,7 +64,7 @@ def create_node_db_service_configs(args, event_db_init_script, prover_db_init_sc
     }
 
 
-def start_peripheral_databases(plan, args):
+def create_peripheral_databases_service_configs(plan, args):
     bridge_db_name = args["zkevm_db_bridge_hostname"] + args["deployment_suffix"]
     bridge_db_service_config = _create_postgres_db_service_config(
         port=args["zkevm_db_postgres_port"],

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -102,7 +102,7 @@ def create_aggregator_service_config(
     proofsigner_keystore_artifact,
 ):
     aggregator_name = "zkevm-node-aggregator" + args["deployment_suffix"]
-    aggregator_service_config = ServiceConfig(
+    aggregator_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "aggregator": PortSpec(

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -199,9 +199,6 @@ def create_zkevm_node_components_config(
     genesis_artifact,
     keystore_artifacts,
 ):
-    synchronizer_config = create_synchronizer_service_config(
-        args, config_artifact, genesis_artifact
-    )
     sequencer_config = create_sequencer_service_config(
         args, config_artifact, genesis_artifact
     )
@@ -231,8 +228,7 @@ def create_zkevm_node_components_config(
         args, config_artifact, genesis_artifact
     )
     return (
-        synchronizer_config
-        | sequence_sender_config
+        sequence_sender_config
         | sequence_sender_config
         | aggregator_config
         | rpc_config

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -32,7 +32,8 @@ def _create_node_component_service_config(
     )
 
 
-def create_synchronizer_service_config(args, config_artifact, genesis_artifact):
+# The synchronizer is required to run before any other zkevm node component.
+def start_synchronizer(plan, args, config_artifact, genesis_artifact):
     synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
     synchronizer_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
@@ -45,7 +46,7 @@ def create_synchronizer_service_config(args, config_artifact, genesis_artifact):
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
         components=NODE_COMPONENT.synchronizer,
     )
-    return {synchronizer_name: synchronizer_service_config}
+    plan.add_service(name=synchronizer_name, config=synchronizer_service_config)
 
 
 def create_sequencer_service_config(args, config_artifact, genesis_artifact):

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -230,7 +230,7 @@ def create_zkevm_node_components_config(
         args, config_artifact, genesis_artifact
     )
     return (
-        sequence_sender_config
+        sequencer_config
         | sequence_sender_config
         | aggregator_config
         | rpc_config

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -9,8 +9,8 @@ NODE_COMPONENT = struct(
 )
 
 
-def _start_node_component(
-    plan, name, image, ports, config_files, components, http_api={}
+def _create_node_component_service_config(
+    image, ports, config_files, components, http_api={}
 ):
     cmd = [
         "run",
@@ -21,24 +21,20 @@ def _start_node_component(
     ]
     if http_api:
         cmd.append("--http.api=" + http_api)
-    return plan.add_service(
-        name=name,
-        config=ServiceConfig(
-            image=image,
-            ports=ports,
-            files={
-                "/etc/zkevm": config_files,
-            },
-            entrypoint=["/app/zkevm-node"],
-            cmd=cmd,
-        ),
+    return ServiceConfig(
+        image=image,
+        ports=ports,
+        files={
+            "/etc/zkevm": config_files,
+        },
+        entrypoint=["/app/zkevm-node"],
+        cmd=cmd,
     )
 
 
-def start_synchronizer(plan, args, config_artifact, genesis_artifact):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-synchronizer" + args["deployment_suffix"],
+def create_synchronizer_service_config(args, config_artifact, genesis_artifact):
+    synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
+    synchronizer_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
@@ -49,12 +45,12 @@ def start_synchronizer(plan, args, config_artifact, genesis_artifact):
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
         components=NODE_COMPONENT.synchronizer,
     )
+    return {synchronizer_name: synchronizer_service_config}
 
 
-def start_sequencer(plan, args, config_artifact, genesis_artifact):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-sequencer" + args["deployment_suffix"],
+def create_sequencer_service_config(args, config_artifact, genesis_artifact):
+    sequencer_name = "zkevm-node-sequencer" + args["deployment_suffix"]
+    sequencer_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "rpc": PortSpec(args["zkevm_rpc_http_port"], application_protocol="http"),
@@ -70,18 +66,14 @@ def start_sequencer(plan, args, config_artifact, genesis_artifact):
         components=NODE_COMPONENT.sequencer + "," + NODE_COMPONENT.rpc,
         http_api="eth,net,debug,zkevm,txpool,web3",
     )
+    return {sequencer_name: sequencer_service_config}
 
 
-def start_sequence_sender(
-    plan,
-    args,
-    config_artifact,
-    genesis_artifact,
-    sequencer_keystore_artifact,
+def create_sequence_sender_service_config(
+    args, config_artifact, genesis_artifact, sequencer_keystore_artifact
 ):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-sequence-sender" + args["deployment_suffix"],
+    sequence_sender_name = "zkevm-node-sequence-sender" + args["deployment_suffix"]
+    sequence_sender_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
@@ -98,10 +90,10 @@ def start_sequence_sender(
         ),
         components=NODE_COMPONENT.sequence_sender,
     )
+    return {sequence_sender_name: sequence_sender_service_config}
 
 
-def start_aggregator(
-    plan,
+def create_aggregator_service_config(
     args,
     config_artifact,
     genesis_artifact,
@@ -109,9 +101,8 @@ def start_aggregator(
     aggregator_keystore_artifact,
     proofsigner_keystore_artifact,
 ):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-aggregator" + args["deployment_suffix"],
+    aggregator_name = "zkevm-node-aggregator" + args["deployment_suffix"]
+    aggregator_service_config = ServiceConfig(
         image=args["zkevm_node_image"],
         ports={
             "aggregator": PortSpec(
@@ -133,12 +124,12 @@ def start_aggregator(
         ),
         components=NODE_COMPONENT.aggregator,
     )
+    return {aggregator_name: aggregator_service_config}
 
 
-def start_rpc(plan, args, config_artifact, genesis_artifact):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-rpc" + args["deployment_suffix"],
+def create_rpc_service_config(args, config_artifact, genesis_artifact):
+    rpc_name = "zkevm-node-rpc" + args["deployment_suffix"]
+    rpc_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "http-rpc": PortSpec(
@@ -154,19 +145,18 @@ def start_rpc(plan, args, config_artifact, genesis_artifact):
         components=NODE_COMPONENT.rpc,
         http_api="eth,net,debug,zkevm,txpool,web3",
     )
+    return {rpc_name: rpc_service_config}
 
 
-def start_eth_tx_manager(
-    plan,
+def create_eth_tx_manager_service_config(
     args,
     config_artifact,
     genesis_artifact,
     sequencer_keystore_artifact,
     aggregator_keystore_artifact,
 ):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-eth-tx-manager" + args["deployment_suffix"],
+    eth_tx_manager_name = "zkevm-node-eth-tx-manager" + args["deployment_suffix"]
+    eth_tx_manager_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
@@ -184,12 +174,12 @@ def start_eth_tx_manager(
         ),
         components=NODE_COMPONENT.eth_tx_manager,
     )
+    return {eth_tx_manager_name: eth_tx_manager_service_config}
 
 
-def start_l2_gas_pricer(plan, args, config_artifact, genesis_artifact):
-    return _start_node_component(
-        plan,
-        name="zkevm-node-l2-gas-pricer" + args["deployment_suffix"],
+def create_l2_gas_pricer_service_config(args, config_artifact, genesis_artifact):
+    l2_gas_pricer_name = "zkevm-node-l2-gas-pricer" + args["deployment_suffix"]
+    l2_gas_pricer_service_config = _create_node_component_service_config(
         image=args["zkevm_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
@@ -199,4 +189,53 @@ def start_l2_gas_pricer(plan, args, config_artifact, genesis_artifact):
         },
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
         components=NODE_COMPONENT.l2_gas_pricer,
+    )
+    return {l2_gas_pricer_name: l2_gas_pricer_service_config}
+
+
+def create_zkevm_node_components_config(
+    args,
+    config_artifact,
+    genesis_artifact,
+    keystore_artifacts,
+):
+    synchronizer_config = create_synchronizer_service_config(
+        args, config_artifact, genesis_artifact
+    )
+    sequencer_config = create_sequencer_service_config(
+        args, config_artifact, genesis_artifact
+    )
+    sequence_sender_config = create_sequence_sender_service_config(
+        args,
+        config_artifact,
+        genesis_artifact,
+        keystore_artifacts.sequencer,
+    )
+    aggregator_config = create_aggregator_service_config(
+        args,
+        config_artifact,
+        genesis_artifact,
+        keystore_artifacts.sequencer,
+        keystore_artifacts.aggregator,
+        keystore_artifacts.proofsigner,
+    )
+    rpc_config = create_rpc_service_config(args, config_artifact, genesis_artifact)
+    eth_tx_manager_config = create_eth_tx_manager_service_config(
+        args,
+        config_artifact,
+        genesis_artifact,
+        keystore_artifacts.sequencer,
+        keystore_artifacts.aggregator,
+    )
+    l2_gas_pricer_config = create_l2_gas_pricer_service_config(
+        args, config_artifact, genesis_artifact
+    )
+    return (
+        synchronizer_config
+        | sequence_sender_config
+        | sequence_sender_config
+        | aggregator_config
+        | rpc_config
+        | eth_tx_manager_config
+        | l2_gas_pricer_config
     )

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -9,24 +9,6 @@ NODE_COMPONENT = struct(
 )
 
 
-# The synchronizer is required to run before any other zkevm node component.
-# This is why this component does not have a `create_service_config` method.
-def start_synchronizer(plan, args, config_artifact, genesis_artifact):
-    synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
-    synchronizer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
-        ports={
-            "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
-            "prometheus": PortSpec(
-                args["zkevm_prometheus_port"], application_protocol="http"
-            ),
-        },
-        config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
-        components=NODE_COMPONENT.synchronizer,
-    )
-    plan.add_service(name=synchronizer_name, config=synchronizer_service_config)
-
-
 def _create_node_component_service_config(
     image, ports, config_files, components, http_api={}
 ):
@@ -48,6 +30,24 @@ def _create_node_component_service_config(
         entrypoint=["/app/zkevm-node"],
         cmd=cmd,
     )
+
+
+# The synchronizer is required to run before any other zkevm node component.
+# This is why this component does not have a `create_service_config` method.
+def start_synchronizer(plan, args, config_artifact, genesis_artifact):
+    synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
+    synchronizer_service_config = _create_node_component_service_config(
+        image=args["zkevm_node_image"],
+        ports={
+            "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
+            "prometheus": PortSpec(
+                args["zkevm_prometheus_port"], application_protocol="http"
+            ),
+        },
+        config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
+        components=NODE_COMPONENT.synchronizer,
+    )
+    plan.add_service(name=synchronizer_name, config=synchronizer_service_config)
 
 
 def create_sequencer_service_config(args, config_artifact, genesis_artifact):

--- a/main.star
+++ b/main.star
@@ -62,7 +62,6 @@ def run(plan, args):
         central_environment_args = dict(args)
         central_environment_args["genesis_artifact"] = genesis_artifact
         cdk_central_environment_package.run(plan, central_environment_args)
-        cdk_bridge_infra_package.start_dac(plan, args)
     else:
         plan.print("Skipping the deployment of cdk central/trusted environment")
 

--- a/observability.star
+++ b/observability.star
@@ -19,16 +19,16 @@ def start_panoptichain(plan, args):
                     "zkevm_rpc_url": args["zkevm_rpc_url"],
                     "l1_chain_id": args["l1_chain_id"],
                     "zkevm_rollup_chain_id": args["zkevm_rollup_chain_id"],
-                    "zkevm_bridge_address": bridge_package.get_key_from_config(
+                    "zkevm_bridge_address": service_package.get_key_from_config(
                         plan, args, "polygonZkEVMBridgeAddress"
                     ),
-                    "polygon_zkevm_address": bridge_package.get_key_from_config(
+                    "polygon_zkevm_address": service_package.get_key_from_config(
                         plan, args, "rollupAddress"
                     ),
-                    "rollup_manager_address": bridge_package.get_key_from_config(
+                    "rollup_manager_address": service_package.get_key_from_config(
                         plan, args, "polygonRollupManagerAddress"
                     ),
-                    "global_exit_root_address": bridge_package.get_key_from_config(
+                    "global_exit_root_address": service_package.get_key_from_config(
                         plan, args, "polygonZkEVMGlobalExitRootAddress"
                     ),
                     "global_exit_root_l2_address": service_package.extract_json_key_from_service(
@@ -37,7 +37,7 @@ def start_panoptichain(plan, args):
                         "/opt/zkevm/genesis.json",
                         'genesis[] | select(.contractName == "PolygonZkEVMGlobalExitRootL2 proxy") | .address',
                     ),
-                    "pol_token_address": bridge_package.get_key_from_config(
+                    "pol_token_address": service_package.get_key_from_config(
                         plan, args, "polTokenAddress"
                     ),
                 },

--- a/observability.star
+++ b/observability.star
@@ -2,8 +2,9 @@ prometheus_package = import_module(
     "github.com/kurtosis-tech/prometheus-package/main.star"
 )
 grafana_package = import_module("github.com/kurtosis-tech/grafana-package/main.star")
-bridge_package = import_module("./cdk_bridge_infra.star")
+
 service_package = import_module("./lib/service.star")
+bridge_package = import_module("./cdk_bridge_infra.star")
 
 
 def start_panoptichain(plan, args):

--- a/observability.star
+++ b/observability.star
@@ -50,7 +50,7 @@ def start_panoptichain(plan, args):
     return plan.add_service(
         name="panoptichain" + args["deployment_suffix"],
         config=ServiceConfig(
-            image="minhdvu/panoptichain",
+            image=args["panoptichain_image"],
             ports={
                 "prometheus": PortSpec(9090, application_protocol="http"),
             },

--- a/params.yml
+++ b/params.yml
@@ -40,8 +40,9 @@ zkevm_contracts_branch: develop # v5.0.1-rc.2-fork.8
 zkevm_contracts_repo: https://github.com/0xPolygonHermez/zkevm-contracts.git
 
 zkevm_agglayer_image: 0xpolygon/agglayer:0.1.1
-zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2-cdk.1
+zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
 zkevm_bridge_ui_image: hermeznetwork/zkevm-bridge-ui:multi-network
+panoptichain_image: minhdvu/panoptichain
 
 # Port configuration.
 zkevm_hash_db_port: 50061

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -13,11 +13,11 @@ def run(plan, args):
         name="executor-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/prover-db-init.sql",
     )
-    node_db_service_configs = zkevm_databases_package.create_node_db_service_configs(
+    node_db_configs = zkevm_databases_package.create_node_db_service_configs(
         args, event_db_init_script, executor_db_init_script
     )
     plan.add_services(
-        configs=node_db_service_configs,
+        configs=node_db_configs,
         description="Starting node databases",
     )
 

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -53,13 +53,19 @@ def run(plan, args):
         name="permissionless-node-config",
         config={"node-config.toml": struct(template=node_config_template, data=args)},
     )
+
     synchronizer_config = zkevm_node_package.create_synchronizer_service_config(
         args, node_config_artifact, genesis_artifact
     )
+    plan.add_service(
+        config=synchronizer_config,
+        description="Starting the zkevm node synchronizer",
+    )
+
     rpc_config = zkevm_node_package.create_rpc_service_config(
         args, node_config_artifact, genesis_artifact
     )
     plan.add_services(
-        configs=synchronizer_config | rpc_config,
-        description="Starting zkevm node synchronizer and rpc",
+        configs=rpc_config,
+        description="Starting zkevm node rpc",
     )

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -54,7 +54,9 @@ def run(plan, args):
         config={"node-config.toml": struct(template=node_config_template, data=args)},
     )
 
-    zkevm_node_package.start_synchronizer(plan, args, node_config_artifact, genesis_artifact)
+    zkevm_node_package.start_synchronizer(
+        plan, args, node_config_artifact, genesis_artifact
+    )
 
     rpc_config = zkevm_node_package.create_rpc_service_config(
         args, node_config_artifact, genesis_artifact

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -4,7 +4,7 @@ zkevm_prover_package = import_module("./lib/zkevm_prover.star")
 
 
 def run(plan, args):
-    # Start node datatabase.
+    # Start node databases.
     event_db_init_script = plan.upload_files(
         name="event-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/event-db-init.sql",

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -54,7 +54,7 @@ def run(plan, args):
         config={"node-config.toml": struct(template=node_config_template, data=args)},
     )
 
-    zkevm_node_package.start_synchronizer(plan, args, config_artifact, genesis_artifact)
+    zkevm_node_package.start_synchronizer(plan, args, node_config_artifact, genesis_artifact)
 
     rpc_config = zkevm_node_package.create_rpc_service_config(
         args, node_config_artifact, genesis_artifact

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -53,8 +53,11 @@ def run(plan, args):
         name="permissionless-node-config",
         config={"node-config.toml": struct(template=node_config_template, data=args)},
     )
-
-    zkevm_node_package.start_synchronizer(
-        plan, args, node_config_artifact, genesis_artifact
+    synchronizer_config = create_synchronizer_service_config(
+        args, node_config_artifact, genesis_artifact
     )
-    zkevm_node_package.start_rpc(plan, args, node_config_artifact, genesis_artifact)
+    rpc_config = create_rpc_service_config(args, node_config_artifact, genesis_artifact)
+    plan.add_services(
+        configs=synchronizer_config | rpc_config,
+        description="Starting zkevm node synchronizer and rpc",
+    )

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -54,13 +54,7 @@ def run(plan, args):
         config={"node-config.toml": struct(template=node_config_template, data=args)},
     )
 
-    synchronizer_config = zkevm_node_package.create_synchronizer_service_config(
-        args, node_config_artifact, genesis_artifact
-    )
-    plan.add_service(
-        config=synchronizer_config,
-        description="Starting the zkevm node synchronizer",
-    )
+    zkevm_node_package.start_synchronizer(plan, args, config_artifact, genesis_artifact)
 
     rpc_config = zkevm_node_package.create_rpc_service_config(
         args, node_config_artifact, genesis_artifact

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -53,10 +53,12 @@ def run(plan, args):
         name="permissionless-node-config",
         config={"node-config.toml": struct(template=node_config_template, data=args)},
     )
-    synchronizer_config = create_synchronizer_service_config(
+    synchronizer_config = zkevm_node_package.create_synchronizer_service_config(
         args, node_config_artifact, genesis_artifact
     )
-    rpc_config = create_rpc_service_config(args, node_config_artifact, genesis_artifact)
+    rpc_config = zkevm_node_package.create_rpc_service_config(
+        args, node_config_artifact, genesis_artifact
+    )
     plan.add_services(
         configs=synchronizer_config | rpc_config,
         description="Starting zkevm node synchronizer and rpc",

--- a/zkevm_permissionless_node.star
+++ b/zkevm_permissionless_node.star
@@ -4,7 +4,7 @@ zkevm_prover_package = import_module("./lib/zkevm_prover.star")
 
 
 def run(plan, args):
-    # Start node databases.
+    # Start node datatabase.
     event_db_init_script = plan.upload_files(
         name="event-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/event-db-init.sql",
@@ -13,8 +13,12 @@ def run(plan, args):
         name="executor-db-init.sql" + args["deployment_suffix"],
         src="./templates/databases/prover-db-init.sql",
     )
-    zkevm_databases_package.start_node_databases(
-        plan, args, event_db_init_script, executor_db_init_script
+    node_db_service_configs = zkevm_databases_package.create_node_db_service_configs(
+        args, event_db_init_script, executor_db_init_script
+    )
+    plan.add_services(
+        configs=node_db_service_configs,
+        description="Starting node databases",
     )
 
     # Start executor.


### PR DESCRIPTION
## Description

Make use of `plan.add_services` to start components in parallel.

Previously, our libs would create each service individually, in a sequential manner. Now, they only create the service configs. It is then possible to aggregate all those service configs and to create them all at once, in parallel. It's not a significant change in speed (~20s less) but it cleans up the log. The flow is better now.

### Minor changes

- Introduce `zkevm_agglayer`, `zkevm_bridge` and `zkevm_dac` libraries.

## Benchmark

For the first run, use code from `main` and for the second run, use code from `feat/optimizations`.
- Clean the environment.
- Run only the L1 stages (L1 deployment + smart contract deployment).
- Run all the other stages, except the L1 stages and measure the time it takes to deploy the services.

First run

https://github.com/0xPolygon/kurtosis-cdk/actions/runs/8571619722/job/23492278221

![Screenshot 2024-04-05 at 17 02 15](https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/42477b9f-4066-4870-8057-2ccffdffe341)

Second run

https://github.com/0xPolygon/kurtosis-cdk/actions/runs/8570797026/job/23489542206

![Screenshot 2024-04-05 at 17 02 51](https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/f51c5d39-eed3-4371-9287-6192599412c7)

Results

| Branch | Deployment Time (*) |
| ------- | ----- |
| `main` | `151s` |
| `feat/optimizations` |  `130s` |

(*) We only considered the deployment time of the impacted stages: 
- Deploy ZkEVM Node and CDK Peripheral Databases
- Deploy CDK Central Environment
- Deploy CDK Bridge Infrastructure
- Deploy ZkEVM Permissionless Node
