### PR TITLE
feature: fully customizable cdk devnets

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,135 @@
+name: REGRESSION TESTER - SUPERUSERS
+on:
+  workflow_dispatch:
+    inputs:
+      zkevm_agglayer_commit_id:
+        description: '0xPolygon/agglayer (commit id)'
+        required: true
+      zkevm_bridge_service_commit_id:
+        description: '0xPolygonHermez/zkevm-bridge-service (commit id)'
+        required: true
+      zkevm_bridge_ui_commit_id:
+        description: '0xPolygonHermez/zkevm-bridge-ui (commit id)'
+        required: true
+      zkevm_dac_commit_id:
+        description: '0xPolygon/cdk-data-availability (commit id)'
+        required: true
+      zkevm_node_commit_id:
+        description: '0xPolygon/cdk-validium-node (commit id)'
+        required: true
+      bake_time:
+        description: 'bake time (minutes)'
+        required: true
+
+jobs:
+  deploy_devnet:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.before }}
+
+    - name: Set up Docker
+      uses: docker/setup-buildx-action@v1
+      
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+
+    - name: Clone internal kurtosis-cdk repo
+      run: |
+        git clone https://github.com/0xPolygon/kurtosis-cdk.git
+        cd kurtosis-cdk
+        git checkout dan/jit_containers_superusers
+
+    - name: Clone and build agglayer
+      run: |
+        git clone https://github.com/0xPolygon/agglayer.git
+        cd agglayer
+        git checkout "${{ github.event.inputs.zkevm_agglayer_commit_id }}"
+        docker compose -f docker/docker-compose.yaml build --no-cache agglayer
+        sleep 10
+
+    - name: Clone and build zkevm-bridge-service
+      run: |
+        git clone https://github.com/0xPolygonHermez/zkevm-bridge-service.git
+        cd zkevm-bridge-service
+        git checkout "${{ github.event.inputs.zkevm_bridge_service_commit_id }}"
+        docker build -t zkevm-bridge-service:local -f ./Dockerfile .
+        sleep 10
+
+    - name: Clone and build zkevm-bridge-ui
+      run: |
+        git clone https://github.com/0xPolygonHermez/zkevm-bridge-ui.git
+        cd zkevm-bridge-ui
+        git checkout "${{ github.event.inputs.zkevm_bridge_ui_commit_id }}"
+        docker build -t zkevm-bridge-ui:local -f ./Dockerfile .
+        sleep 10
+
+    - name: Clone and build cdk-data-availability
+      run: |
+        git clone https://github.com/0xPolygon/cdk-data-availability.git
+        cd cdk-data-availability
+        git checkout "${{ github.event.inputs.zkevm_dac_commit_id }}"
+        docker build -t cdk-data-availability:local -f ./Dockerfile .
+        sleep 10      
+
+    - name: Clone and build cdk-validium-node
+      run: |
+        git clone https://github.com/0xPolygon/cdk-validium-node.git
+        cd cdk-validium-node
+        git checkout "${{ github.event.inputs.zkevm_node_commit_id }}"
+        docker build -t cdk-validium-node:local -f ./Dockerfile .
+        sleep 10
+    
+    - name: Install kurtosis
+      run: |
+        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        sudo apt update
+        sudo apt install kurtosis-cli
+    
+    - name: Run kurtosis agent in background
+      run: |  
+        kurtosis gateway &  # Run cmd in background
+        sleep 10
+    
+    - name: Deploy CDK devnet on local github runner
+      run: |
+        cd kurtosis-cdk
+        kurtosis engine restart
+        kurtosis run --enclave cdk-v1 --args-file params.yml .
+    
+    - name: Monitor and report any potential regressions to CI logs
+      run: |
+        bake_time="${{ github.event.inputs.bake_time }}"
+        end_minute=$(( $(date +'%M') + bake_time))
+        export ETH_RPC_URL="$(kurtosis port print cdk-v1 zkevm-node-rpc-001 http-rpc)"
+        INITIAL_STATUS=$(cast rpc zkevm_verifiedBatchNumber 2>/dev/null)
+        incremented=false
+        
+        while [ $(date +'%M') -lt $end_minute ]; do
+          # Attempt to connect to the service
+          if STATUS=$(cast rpc zkevm_verifiedBatchNumber 2>/dev/null); then
+            echo "ZKEVM_VERIFIED_BATCH_NUMBER: $STATUS"
+            
+            # Check if STATUS has incremented
+            if [ "$STATUS" != "$INITIAL_STATUS" ]; then
+              incremented=true
+            fi
+          else
+            echo "Failed to connect, waiting and retrying..."
+            sleep 60
+            continue
+          fi
+          sleep 60
+        done
+        
+        if ! $incremented; then
+          echo "ZKEVM_VERIFIED_BATCH_NUMBER did not increment. This may indicate chain experienced a regression. Please investigate."
+          exit 1
+        fi
+    
+    - name: Finally, remove all devnet resources locally
+      run: |
+        cd kurtosis-cdk
+        kurtosis clean -a


### PR DESCRIPTION
**purpose:**
- enable just-in-time (JIT) container builds for all repos comprising Polygon CDK (simple git actions UI workflow)
- fully automatic CDK devnet provisioning via kurtosis + k8s + docker (<15min to fully provision and test integrity of chain with proposed changes)
- user can specify bake-time of devnet tests

**tests:**
- e2e successful CDK devnet deployment to local github runner (fully ephemeral):
https://github.com/rebelArtists/bor/actions/runs/8626255148/job/23644165975

**visuals:**
<img width="1188" alt="image" src="https://github.com/0xPolygon/kurtosis-cdk/assets/100106211/de8fa82c-8de2-4896-988d-d72299ed4066">
