### PR TITLE
fix: zkevm-bridge-ui env

### DIFF
--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -42,15 +42,17 @@ def run(plan, args):
     zkevm_node_rpc_service = plan.get_service(
         name="zkevm-node-rpc" + args["deployment_suffix"]
     )
+    # Note: Use `.ip_address` instead of `.hostname` to make it work on macOS.
     zkevm_rpc_url = "http://{}:{}".format(
-        zkevm_node_rpc_service.hostname, zkevm_node_rpc_service.ports["http-rpc"].number
+        zkevm_node_rpc_service.ip_address, zkevm_node_rpc_service.ports["http-rpc"].number
     )
 
     bridge_service = bridge_infra_services[
         "zkevm-bridge-service" + args["deployment_suffix"]
     ]
+    # Note: Use `.ip_address` instead of `.hostname` to make it work on macOS.
     bridge_api_url = "http://{}:{}".format(
-        bridge_service.hostname, bridge_service.ports["bridge-rpc"].number
+        bridge_service.ip_address, bridge_service.ports["bridge-rpc"].number
     )
 
     config = struct(

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -39,14 +39,15 @@ def run(plan, args):
     )
 
     # Start the bridge UI.
-    zkevm_node_rpc = plan.get_service(name="zkevm-node-rpc" + args["deployment_suffix"])
-    bridge_service_name = "zkevm-bridge-service" + args["deployment_suffix"]
-    bridge_service = bridge_infra_services[bridge_service_name]
+    zkevm_node_rpc_service = plan.get_service(name="zkevm-node-rpc" + args["deployment_suffix"])
+    zkevm_rpc_url = "http://{}:{}".format(zkevm_node_rpc_service.hostname, zkevm_node_rpc_service.ports["http-rpc"].number)
+
+    bridge_service = bridge_infra_services["zkevm-bridge-service" + args["deployment_suffix"]]
+    bridge_api_url = "http://{}:{}".format(bridge_service.hostname, bridge_service.ports["bridge-rpc"].number)
+
     config = struct(
-        zkevm_rpc_ip_address=zkevm_node_rpc.ip_address,
-        zkevm_rpc_http_port=zkevm_node_rpc.ports["http-rpc"],
-        bridge_service_ip_address=bridge_service.ip_address,
-        bridge_api_http_port=bridge_service.ports["bridge-rpc"],
+        zkevm_rpc_url=zkevm_rpc_url,
+        bridge_api_url=bridge_api_url,
         zkevm_bridge_address=contract_setup_addresses["zkevm_bridge_address"],
         zkevm_rollup_address=contract_setup_addresses["zkevm_rollup_address"],
         zkevm_rollup_manager_address=contract_setup_addresses[

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -39,11 +39,19 @@ def run(plan, args):
     )
 
     # Start the bridge UI.
-    zkevm_node_rpc_service = plan.get_service(name="zkevm-node-rpc" + args["deployment_suffix"])
-    zkevm_rpc_url = "http://{}:{}".format(zkevm_node_rpc_service.hostname, zkevm_node_rpc_service.ports["http-rpc"].number)
+    zkevm_node_rpc_service = plan.get_service(
+        name="zkevm-node-rpc" + args["deployment_suffix"]
+    )
+    zkevm_rpc_url = "http://{}:{}".format(
+        zkevm_node_rpc_service.hostname, zkevm_node_rpc_service.ports["http-rpc"].number
+    )
 
-    bridge_service = bridge_infra_services["zkevm-bridge-service" + args["deployment_suffix"]]
-    bridge_api_url = "http://{}:{}".format(bridge_service.hostname, bridge_service.ports["bridge-rpc"].number)
+    bridge_service = bridge_infra_services[
+        "zkevm-bridge-service" + args["deployment_suffix"]
+    ]
+    bridge_api_url = "http://{}:{}".format(
+        bridge_service.hostname, bridge_service.ports["bridge-rpc"].number
+    )
 
     config = struct(
         zkevm_rpc_url=zkevm_rpc_url,

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -44,7 +44,8 @@ def run(plan, args):
     )
     # Note: Use `.ip_address` instead of `.hostname` to make it work on macOS.
     zkevm_rpc_url = "http://{}:{}".format(
-        zkevm_node_rpc_service.ip_address, zkevm_node_rpc_service.ports["http-rpc"].number
+        zkevm_node_rpc_service.ip_address,
+        zkevm_node_rpc_service.ports["http-rpc"].number,
     )
 
     bridge_service = bridge_infra_services[

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -39,6 +39,12 @@ def run(plan, args):
     )
 
     # Start the bridge UI.
+    l1_el_1_service = plan.get_service("el-1-geth-lighthouse")
+    # Note: We do not rely on args["l1_rpc_url"] because macOS browser can not resolve hostnames.
+    l1_rpc_url = "http://{}:{}".format(
+        l1_el_1_service.ip_address, l1_el_1_service.ports["rpc"].number
+    )
+
     zkevm_node_rpc_service = plan.get_service(
         name="zkevm-node-rpc" + args["deployment_suffix"]
     )
@@ -57,6 +63,7 @@ def run(plan, args):
     )
 
     config = struct(
+        l1_rpc_url=l1_rpc_url,
         zkevm_rpc_url=zkevm_rpc_url,
         bridge_api_url=bridge_api_url,
         zkevm_bridge_address=contract_setup_addresses["zkevm_bridge_address"],

--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -35,13 +35,8 @@ def start_bridge_ui(plan, args, config):
             },
             env_vars={
                 "ETHEREUM_RPC_URL": args["l1_rpc_url"],
-                "POLYGON_ZK_EVM_RPC_URL": "http://{}:{}".format(
-                    config.zkevm_rpc_ip_address,
-                    config.zkevm_rpc_http_port,
-                ),
-                "BRIDGE_API_URL": "http://{}:{}".format(
-                    config.bridge_service_ip_address, config.bridge_api_http_port
-                ),
+                "POLYGON_ZK_EVM_RPC_URL": config.zkevm_rpc_url,
+                "BRIDGE_API_URL": config.bridge_api_url,
                 "ETHEREUM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,
                 "POLYGON_ZK_EVM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,
                 "ETHEREUM_FORCE_UPDATE_GLOBAL_EXIT_ROOT": "true",

--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -34,7 +34,7 @@ def start_bridge_ui(plan, args, config):
                 ),
             },
             env_vars={
-                "ETHEREUM_RPC_URL": args["l1_rpc_url"],
+                "ETHEREUM_RPC_URL": config.l1_rpc_url,
                 "POLYGON_ZK_EVM_RPC_URL": config.zkevm_rpc_url,
                 "BRIDGE_API_URL": config.bridge_api_url,
                 "ETHEREUM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,

--- a/params.yml
+++ b/params.yml
@@ -155,8 +155,8 @@ zkevm_rollup_fork_id: 9
 # The consensus contract name of the new rollup.
 zkevm_rollup_consensus: PolygonValidiumEtrog
 
-polygon_zkevm_explorer: "https://explorer.private/"
-l1_explorer_url: "https://sepolia.etherscan.io/"
+polygon_zkevm_explorer: https://explorer.private/
+l1_explorer_url: https://sepolia.etherscan.io/
 
 # If this is true, we will automatically deploy an ERC20 contract on
 # L1 to be used at the gasTokenAddress


### PR DESCRIPTION
## Description

- Fix the zkevm RPC URL and the bridge API URL in the environment variables of the zkevm bridge ui (introduced in #45).
- Revert #59 because it breaks the setup on macOS - we need to find out a better way to handle those problems using a gateway/proxy in front of the zkevm-bridge-ui app.

## Test

![Screenshot 2024-04-15 at 12 13 32](https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/fbea370c-fc2c-43dd-8f24-e400b622d3bc)
