### PR TITLE
feat: add reverse proxy to simplify zkevm-bridge-ui setup

### DIFF
--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -34,9 +34,9 @@ def start_bridge_ui(plan, args, config):
                 ),
             },
             env_vars={
-                "ETHEREUM_RPC_URL": config.l1_rpc_url,
-                "POLYGON_ZK_EVM_RPC_URL": config.zkevm_rpc_url,
-                "BRIDGE_API_URL": config.bridge_api_url,
+                "ETHEREUM_RPC_URL": "/l1rpc",
+                "POLYGON_ZK_EVM_RPC_URL": "/l2rpc",
+                "BRIDGE_API_URL": "/bridgeservice",
                 "ETHEREUM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,
                 "POLYGON_ZK_EVM_BRIDGE_CONTRACT_ADDRESS": config.zkevm_bridge_address,
                 "ETHEREUM_FORCE_UPDATE_GLOBAL_EXIT_ROOT": "true",
@@ -51,5 +51,23 @@ def start_bridge_ui(plan, args, config):
                 "ENABLE_REPORT_FORM": "false",
             },
             cmd=["run"],
+        ),
+    )
+
+
+def add_reverse_proxy(plan, args, config_artifact):
+    plan.add_service(
+        name="zkevm-bridge-proxy" + args["deployment_suffix"],
+        config=ServiceConfig(
+            image=args["zkevm_bridge_proxy_image"],
+            ports={
+                "bridge-interface": PortSpec(
+                    number=80,
+                    application_protocol="http",
+                ),
+            },
+            files={
+                "/usr/local/etc/haproxy/": Directory(artifact_names=[config_artifact]),
+            },
         ),
     )

--- a/params.yml
+++ b/params.yml
@@ -8,25 +8,25 @@ deployment_suffix: "-001"
 # The deployment process is divided into various stages.
 
 # Deploy local L1.
-deploy_l1: false
+deploy_l1: true
 
 # Deploy zkevm contracts on L1 (and also fund accounts).
-deploy_zkevm_contracts_on_l1: false
+deploy_zkevm_contracts_on_l1: true
 
 # Deploy zkevm node and cdk peripheral databases.
-deploy_databases: false
+deploy_databases: true
 
 # Deploy cdk central/trusted environment.
-deploy_cdk_central_environment: false
+deploy_cdk_central_environment: true
 
 # Deploy cdk/bridge infrastructure.
 deploy_cdk_bridge_infra: true
 
 # Deploy permissionless node.
-deploy_zkevm_permissionless_node: false
+deploy_zkevm_permissionless_node: true
 
 # Deploy observability stack.
-deploy_observability: false
+deploy_observability: true
 
 # Docker images and repositories used to spin up services.
 zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0

--- a/params.yml
+++ b/params.yml
@@ -8,31 +8,31 @@ deployment_suffix: "-001"
 # The deployment process is divided into various stages.
 
 # Deploy local L1.
-deploy_l1: true
+deploy_l1: false
 
 # Deploy zkevm contracts on L1 (and also fund accounts).
-deploy_zkevm_contracts_on_l1: true
+deploy_zkevm_contracts_on_l1: false
 
 # Deploy zkevm node and cdk peripheral databases.
-deploy_databases: true
+deploy_databases: false
 
 # Deploy cdk central/trusted environment.
-deploy_cdk_central_environment: true
+deploy_cdk_central_environment: false
 
 # Deploy cdk/bridge infrastructure.
 deploy_cdk_bridge_infra: true
 
 # Deploy permissionless node.
-deploy_zkevm_permissionless_node: true
+deploy_zkevm_permissionless_node: false
 
 # Deploy observability stack.
-deploy_observability: true
+deploy_observability: false
 
 # Docker images and repositories used to spin up services.
 zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
 # zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
 
-zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.2
+zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.6
 # zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
 
 zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
@@ -40,10 +40,14 @@ zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
 
 zkevm_contracts_image: leovct/zkevm-contracts # the tag is automatically replaced by the value of /zkevm_rollup_fork_id/
 
-zkevm_agglayer_image: 0xpolygon/agglayer:0.1.1
+zkevm_agglayer_image: 0xpolygon/agglayer:0.1.3
 zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
-zkevm_bridge_ui_image: hermeznetwork/zkevm-bridge-ui:multi-network
 panoptichain_image: minhdvu/panoptichain
+
+# temporary fork https://github.com/praetoriansentry/zkevm-bridge-ui/commit/6eaa899997f70e53947d7b067ff7ae37ef1875f3
+zkevm_bridge_ui_image: nulyjkdhthz/zkevm-bridge-ui:kurtosis
+zkevm_bridge_proxy_image: haproxy:2.9.7
+
 
 # Port configuration.
 zkevm_hash_db_port: 50061

--- a/params.yml
+++ b/params.yml
@@ -32,7 +32,7 @@ deploy_observability: true
 zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
 # zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
 
-zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.6
+zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.2
 # zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
 
 zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
@@ -40,7 +40,7 @@ zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
 
 zkevm_contracts_image: leovct/zkevm-contracts # the tag is automatically replaced by the value of /zkevm_rollup_fork_id/
 
-zkevm_agglayer_image: 0xpolygon/agglayer:0.1.3
+zkevm_agglayer_image: 0xpolygon/agglayer:0.1.1
 zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
 panoptichain_image: minhdvu/panoptichain
 

--- a/templates/bridge-infra/haproxy.cfg
+++ b/templates/bridge-infra/haproxy.cfg
@@ -1,0 +1,52 @@
+# Global settings
+global
+    log stdout format raw local0
+
+# Default settings for all proxies
+defaults
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+# Frontend configuration
+frontend http_in
+    bind *:80
+
+    # CORS settings
+    http-response set-header Access-Control-Allow-Origin "*"
+    http-response set-header Access-Control-Allow-Methods "GET, DELETE, OPTIONS, POST, PUT"
+
+    # Define ACLs for URL matching
+    acl url_l1rpc path_beg /l1rpc
+    acl url_l2rpc path_beg /l2rpc
+    acl url_bridgeservice path_beg /bridgeservice
+
+    # Use backend based on ACL match
+    use_backend backend_l1rpc if url_l1rpc
+    use_backend backend_l2rpc if url_l2rpc
+    use_backend backend_bridgeservice if url_bridgeservice
+    default_backend backend_default
+
+# Backend configuration for /l1rpc
+backend backend_l1rpc
+    http-request set-path /
+    server server1 {{.l1rpc_ip}}:{{.l1rpc_port}}
+
+# Backend configuration for /l2rpc
+backend backend_l2rpc
+    http-request set-path /
+    server server2 {{.l2rpc_ip}}:{{.l2rpc_port}}
+
+# Backend configuration for /bridgeservice
+backend backend_bridgeservice
+    http-request set-path "%[path,regsub(^/bridgeservice/,/)]"
+    server server3 {{.bridgeservice_ip}}:{{.bridgeservice_port}}
+
+# Default backend configuration
+backend backend_default
+    server server4 {{.bridgeui_ip}}:{{.bridgeui_port}}
+


### PR DESCRIPTION
![image](https://github.com/0xPolygon/kurtosis-cdk/assets/429588/a290acb4-86a1-42c9-ad42-a07e7fe40065)

This PR duplicates https://github.com/0xPolygon/kurtosis-cdk/pull/58 - the only difference is that I've also modified the bridge UI to support relative URLs which seems like it's going to be necessary. Either way there are some good benefits here:

- The "add to metamask" button works now. I think because we're not using HTTPS, but we are using 127.0.0.1 which is allowed
- This should fit within the kurtosis networking model and hopefully enables support for mac / wsl / etc

