### PR TITLE
docs: fix licenses links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,13 @@ Copyright (c) 2024 PT Services DMCC
 
 Licensed under either:
 
-- Apache License, Version 2.0, ([[./LICENSE-APACHE][LICENSE-APACHE]] or http://www.apache.org/licenses/LICENSE-2.0), or
-- MIT license ([[./LICENSE-MIT][LICENSE-MIT]] or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](./LICENSE_APACHE) or http://www.apache.org/licenses/LICENSE-2.0), or
+- MIT license ([LICENSE-MIT](./LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 as your option.
 
-The SPDX license identifier for this project is ~MIT OR Apache-2.0~.
+The SPDX license identifier for this project is `MIT` OR `Apache-2.0`.
 
 ## Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally
-submitted for inclusion in the work by you, as defined in the
-Apache-2.0 license, shall be dual licensed as above, without any
-additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Clean up an old `.org` artifact.

Follow up of #64 that removed `README.org` in favor or `README.md`.