### PR TITLE
ci: update regression test job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
                   exit 1
               fi
 
-              verified_batches=$(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g')
+              verified_batches=$(cast to-dec $(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g'))
               echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
               if (( verified_batches > 5 )); then
@@ -155,7 +155,7 @@ jobs:
                   exit 1
               fi
 
-              verified_batches=$(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g')
+              verified_batches=$(cast to-dec $(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g'))
               echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
               if (( verified_batches > 5 )); then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CHECK_VERIFIED_BATCHES_TIMEOUT_SECONDS: "300" # 5 minutes
+  CHECK_VERIFIED_BATCHES_TIMEOUT_MINUTES: 10
 
 jobs:
   # Deploy the CDK environment in one step, with the gas token feature enabled.
@@ -44,9 +44,9 @@ jobs:
       # Check that batches are being verified.
       - name: Check that batches are being verified
         run: |
-          timeout_seconds="${CHECK_VERIFIED_BATCHES_TIMEOUT_SECONDS:-300}"
+          timeout_minutes="${CHECK_VERIFIED_BATCHES_TIMEOUT_MINUTES}"
           start_time=$(date +%s)
-          end_time=$((start_time + timeout_seconds))
+          end_time=$((start_time + timeout_minutes*60))
 
           export ETH_RPC_URL="$(kurtosis port print cdk-v1 zkevm-node-rpc-001 http-rpc)"
           while true; do
@@ -59,8 +59,8 @@ jobs:
               verified_batches=$(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g')
               echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
-              if (( verified_batches > 0 )); then
-                  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... At least one batch was verified."
+              if (( verified_batches > 5 )); then
+                  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... At least five batches were verified."
                   exit 0
               fi
 
@@ -143,9 +143,9 @@ jobs:
       # Check that batches are being verified.
       - name: Check that batches are being verified
         run: |
-          timeout_seconds="${CHECK_VERIFIED_BATCHES_TIMEOUT_SECONDS:-300}"
+          timeout_minutes="${CHECK_VERIFIED_BATCHES_TIMEOUT_MINUTES}"
           start_time=$(date +%s)
-          end_time=$((start_time + timeout_seconds))
+          end_time=$((start_time + timeout_minutes*60))
 
           export ETH_RPC_URL="$(kurtosis port print cdk-v1 zkevm-node-rpc-001 http-rpc)"
           while true; do
@@ -158,8 +158,8 @@ jobs:
               verified_batches=$(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g')
               echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
-              if (( verified_batches > 0 )); then
-                  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... At least one batch was verified."
+              if (( verified_batches > 5 )); then
+                  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... At least five batches were verified."
                   exit 0
               fi
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -100,7 +100,7 @@ jobs:
           yq -Y --in-place '.cdk_validium_node_image = "cdk-validium-node:local"' params.yml
 
       - name: Deploy Kurtosis CDK package
-        run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+        run: kurtosis run --enclave cdk-v1 --args-file params.yml .
 
       - name: Monitor and report any potential regressions to CI logs
         run: |

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -34,37 +34,47 @@ jobs:
       - name: Build zkevm-agglayer
         run: |
           git clone https://github.com/0xPolygon/agglayer.git
-          cd agglayer
+          pushd agglayer || exit
           git checkout "${{ github.event.inputs.zkevm_agglayer_commit_id }}"
           docker build -t zkevm-agglayer:local -f ./docker/Dockerfile .
+          popd || exit
+          rm -rf agglayer
 
       - name: Build zkevm-bridge-service
         run: |
           git clone https://github.com/0xPolygonHermez/zkevm-bridge-service.git
-          cd zkevm-bridge-service
+          pushd zkevm-bridge-service || exit
           git checkout "${{ github.event.inputs.zkevm_bridge_service_commit_id }}"
           docker build -t zkevm-bridge-service:local -f ./Dockerfile .
+          popd || exit
+          rm -rf zkevm-bridge-service
 
       - name: Build zkevm-bridge-ui
         run: |
           git clone https://github.com/0xPolygonHermez/zkevm-bridge-ui.git
-          cd zkevm-bridge-ui
+          pushd zkevm-bridge-ui || exit
           git checkout "${{ github.event.inputs.zkevm_bridge_ui_commit_id }}"
           docker build -t zkevm-bridge-ui:local -f ./Dockerfile .
+          popd || exit
+          rm -rf zkevm-bridge-ui
 
       - name: Build cdk-data-availability
         run: |
           git clone https://github.com/0xPolygon/cdk-data-availability.git
-          cd cdk-data-availability
+          pushd cdk-data-availability || exit
           git checkout "${{ github.event.inputs.zkevm_dac_commit_id }}"
           docker build -t cdk-data-availability:local -f ./Dockerfile .
+          popd || exit
+          rm -rf cdk-data-availability
 
       - name: Build cdk-validium-node
         run: |
           git clone https://github.com/0xPolygon/cdk-validium-node.git
-          cd cdk-validium-node
+          pushd cdk-validium-node || exit
           git checkout "${{ github.event.inputs.zkevm_node_commit_id }}"
           docker build -t cdk-validium-node:local -f ./Dockerfile .
+          popd || exit
+          rm -rf cdk-validium-node
 
       # Install tools.
       - name: Install kurtosis

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -49,6 +49,7 @@ jobs:
           pushd agglayer || exit
           git checkout "${{ github.event.inputs.zkevm_agglayer_commit_id }}"
           make build
+          mv ./dist/agglayer .
           docker build -t zkevm-agglayer:local -f ./Dockerfile.release .
           popd || exit
           rm -rf agglayer

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -118,9 +118,9 @@ jobs:
 
       - name: Check that batches are being verified
         run: |
-          timeout_seconds="${{ github.event.inputs.bake_time }}"
+          timeout_minutes="${{ github.event.inputs.bake_time }}"
           start_time=$(date +%s)
-          end_time=$((start_time + timeout_seconds*60))
+          end_time=$((start_time + timeout_minutes*60))
 
           export ETH_RPC_URL="$(kurtosis port print cdk-v1 zkevm-node-rpc-001 http-rpc)"
           while true; do

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -40,12 +40,16 @@ jobs:
       - uses: docker/setup-buildx-action@v1
 
       # Build docker images.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
       - name: Build zkevm-agglayer
         run: |
           git clone https://github.com/0xPolygon/agglayer.git
           pushd agglayer || exit
           git checkout "${{ github.event.inputs.zkevm_agglayer_commit_id }}"
-          docker build -t zkevm-agglayer:local -f ./docker/Dockerfile .
+          make build
+          docker build -t zkevm-agglayer:local -f ./Dockerfile.release .
           popd || exit
           rm -rf agglayer
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -36,7 +36,7 @@ jobs:
           git clone https://github.com/0xPolygon/agglayer.git
           cd agglayer
           git checkout "${{ github.event.inputs.zkevm_agglayer_commit_id }}"
-          docker compose -f docker/docker-compose.yaml build --no-cache zkevm-agglayer
+          docker build -t zkevm-agglayer:local -f ./docker/Dockerfile .
 
       - name: Build zkevm-bridge-service
         run: |

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -116,35 +116,27 @@ jobs:
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --args-file params.yml .
 
-      - name: Monitor and report any potential regressions to CI logs
+      - name: Check that batches are being verified
         run: |
-          bake_time="${{ github.event.inputs.bake_time }}"
-          end_minute=$(( $(date +'%M') + bake_time))
+          timeout_seconds="${{ github.event.inputs.bake_time }}"
+          start_time=$(date +%s)
+          end_time=$((start_time + timeout_seconds*60))
 
           export ETH_RPC_URL="$(kurtosis port print cdk-v1 zkevm-node-rpc-001 http-rpc)"
-          INITIAL_STATUS=$(cast rpc zkevm_verifiedBatchNumber 2>/dev/null)
-          incremented=false
-
-          while [ $(date +'%M') -lt $end_minute ]; do
-            # Attempt to connect to the service
-            if STATUS=$(cast rpc zkevm_verifiedBatchNumber 2>/dev/null); then
-              echo "ZKEVM_VERIFIED_BATCH_NUMBER: $STATUS"
-
-              # Check if STATUS has incremented
-              if [ "$STATUS" != "$INITIAL_STATUS" ]; then
-                incremented=true
-                echo "ZKEVM_VERIFIED_BATCH_NUMBER successfully incremented to $STATUS. Exiting..."
-                exit 0
+          while true; do
+              current_time=$(date +%s)
+              if (( current_time > end_time )); then
+                  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ Exiting... Timeout reached. No batches were verified."
+                  exit 1
               fi
-            else
-              echo "Failed to connect, waiting and retrying..."
-              sleep 60
-              continue
-            fi
-            sleep 60
-          done
 
-          if ! $incremented; then
-            echo "ZKEVM_VERIFIED_BATCH_NUMBER did not increment. This may indicate chain experienced a regression. Please investigate."
-            exit 1
-          fi
+              verified_batches=$(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g')
+              echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
+
+              if (( verified_batches > 5 )); then
+                  echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... At least five batches were verified."
+                  exit 0
+              fi
+
+              sleep 10
+          done

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
+          cache: false
       - name: Build zkevm-agglayer
         run: |
           git clone https://github.com/0xPolygon/agglayer.git

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -27,6 +27,15 @@ jobs:
   regression-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Log inputs
+        run: |
+          echo "zkevm_agglayer_commit_id: ${{ github.event.inputs.zkevm_agglayer_commit_id }}"
+          echo "zkevm_bridge_service_commit_id: ${{ github.event.inputs.zkevm_bridge_service_commit_id }}"
+          echo "zkevm_bridge_ui_commit_id: ${{ github.event.inputs.zkevm_bridge_ui_commit_id }}"
+          echo "zkevm_dac_commit_id: ${{ github.event.inputs.zkevm_dac_commit_id }}"
+          echo "zkevm_node_commit_id: ${{ github.event.inputs.zkevm_node_commit_id }}"
+          echo "bake_time: ${{ github.event.inputs.bake_time }}"
+
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -36,8 +36,8 @@ jobs:
           echo "zkevm_node_commit_id: ${{ github.event.inputs.zkevm_node_commit_id }}"
           echo "bake_time: ${{ github.event.inputs.bake_time }}"
 
-      - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
       # Build docker images.
       - uses: actions/setup-go@v5

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -130,7 +130,7 @@ jobs:
                   exit 1
               fi
 
-              verified_batches=$(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g')
+              verified_batches=$(cast to-dec $(cast rpc zkevm_verifiedBatchNumber | sed 's/"//g'))
               echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
               if (( verified_batches > 5 )); then

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -83,11 +83,11 @@ jobs:
       # Deploy components.
       - name: Update params.yml to use local docker images
         run: |
-          yq -Y --in-place '.zkevm_agglayer_image = zkevm-agglayer:local' params.yml
-          yq -Y --in-place '.zkevm_bridge_service_image = zkevm-bridge-service:local' params.yml
-          yq -Y --in-place '.zkevm_bridge_ui_image = zkevm-bridge-ui:local' params.yml
-          yq -Y --in-place '.cdk_da_image = cdk-data-availability:local' params.yml
-          yq -Y --in-place '.cdk_validium_node_image = cdk-validium-node:local' params.yml
+          yq -Y --in-place '.zkevm_agglayer_image = "zkevm-agglayer:local"' params.yml
+          yq -Y --in-place '.zkevm_bridge_service_image = "zkevm-bridge-service:local"' params.yml
+          yq -Y --in-place '.zkevm_bridge_ui_image = "zkevm-bridge-ui:local"' params.yml
+          yq -Y --in-place '.cdk_da_image = "cdk-data-availability:local"' params.yml
+          yq -Y --in-place '.cdk_validium_node_image = "cdk-validium-node:local"' params.yml
 
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,5 +1,6 @@
-name: Regression Tests
-'on':
+name: regression-tests
+
+on:
   workflow_dispatch:
     inputs:
       zkevm_agglayer_commit_id:
@@ -21,61 +22,76 @@ name: Regression Tests
         description: bake time (minutes)
         required: false
         default: 30
+
 jobs:
-  deploy_devnet:
+  regression-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v1
-      - name: Clone and build agglayer
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+
+      # Build docker images.
+      - name: Build zkevm-agglayer
         run: |
           git clone https://github.com/0xPolygon/agglayer.git
           cd agglayer
           git checkout "${{ github.event.inputs.zkevm_agglayer_commit_id }}"
-          docker compose -f docker/docker-compose.yaml build --no-cache agglayer
-      - name: Clone and build zkevm-bridge-service
+          docker compose -f docker/docker-compose.yaml build --no-cache zkevm-agglayer
+
+      - name: Build zkevm-bridge-service
         run: |
           git clone https://github.com/0xPolygonHermez/zkevm-bridge-service.git
           cd zkevm-bridge-service
           git checkout "${{ github.event.inputs.zkevm_bridge_service_commit_id }}"
           docker build -t zkevm-bridge-service:local -f ./Dockerfile .
-      - name: Clone and build zkevm-bridge-ui
+
+      - name: Build zkevm-bridge-ui
         run: |
           git clone https://github.com/0xPolygonHermez/zkevm-bridge-ui.git
           cd zkevm-bridge-ui
           git checkout "${{ github.event.inputs.zkevm_bridge_ui_commit_id }}"
           docker build -t zkevm-bridge-ui:local -f ./Dockerfile .
-      - name: Clone and build cdk-data-availability
+
+      - name: Build cdk-data-availability
         run: |
           git clone https://github.com/0xPolygon/cdk-data-availability.git
           cd cdk-data-availability
           git checkout "${{ github.event.inputs.zkevm_dac_commit_id }}"
-          docker build -t cdk-data-availability:local -f ./Dockerfile .    
-      - name: Clone and build cdk-validium-node
+          docker build -t cdk-data-availability:local -f ./Dockerfile .
+
+      - name: Build cdk-validium-node
         run: |
           git clone https://github.com/0xPolygon/cdk-validium-node.git
           cd cdk-validium-node
           git checkout "${{ github.event.inputs.zkevm_node_commit_id }}"
           docker build -t cdk-validium-node:local -f ./Dockerfile .
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-      - name: Clone internal kurtosis-cdk repo
-        run: |
-          git clone https://github.com/0xPolygon/kurtosis-cdk.git
-          cd kurtosis-cdk
-          git checkout dan/jit_containers_superusers
+
+      # Install tools.
       - name: Install kurtosis
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
           sudo apt install kurtosis-cli
           kurtosis analytics disable
-      - name: Deploy CDK devnet on local github runner
+
+      - name: Install yq
+        run: pip3 install yq
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      # Deploy components.
+      - name: Update params.yml to use local docker images
         run: |
-          cd kurtosis-cdk
-          kurtosis run --enclave cdk-v1 --args-file params.yml .
+          yq -Y --in-place '.zkevm_agglayer_image = zkevm-agglayer:local' params.yml
+          yq -Y --in-place '.zkevm_bridge_service_image = zkevm-bridge-service:local' params.yml
+          yq -Y --in-place '.zkevm_bridge_ui_image = zkevm-bridge-ui:local' params.yml
+          yq -Y --in-place '.cdk_da_image = cdk-data-availability:local' params.yml
+          yq -Y --in-place '.cdk_validium_node_image = cdk-validium-node:local' params.yml
+
+      - name: Deploy Kurtosis CDK package
+        run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+
       - name: Monitor and report any potential regressions to CI logs
         run: |
           bake_time="${{ github.event.inputs.bake_time }}"
@@ -89,7 +105,7 @@ jobs:
             # Attempt to connect to the service
             if STATUS=$(cast rpc zkevm_verifiedBatchNumber 2>/dev/null); then
               echo "ZKEVM_VERIFIED_BATCH_NUMBER: $STATUS"
-              
+
               # Check if STATUS has incremented
               if [ "$STATUS" != "$INITIAL_STATUS" ]; then
                 incremented=true

--- a/doc-drafts/fork-id-migration.org
+++ b/doc-drafts/fork-id-migration.org
@@ -37,11 +37,11 @@ index c2dd446..4caf2d0 100644
 
  # Docker images and repositories used to spin up services.
 -zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
--zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk
--zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
+-cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk
+-cdk_da_image: 0xpolygon/cdk-data-availability:0.0.7
 +zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
-+zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
-+zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.6
++cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
++cdk_da_image: 0xpolygon/cdk-data-availability:0.0.6
  zkevm_agglayer_image: nulyjkdhthz/agglayer:v0.1.0
  # a38e68b5466d1997cea8466dbd4fc8dacd4e11d8
 -zkevm_contracts_branch: develop  # v5.0.1-rc.2-fork.8

--- a/lib/zkevm_dac.star
+++ b/lib/zkevm_dac.star
@@ -1,7 +1,7 @@
 def create_dac_service_config(args, config_artifact, dac_keystore_artifact):
     dac_name = "zkevm-dac" + args["deployment_suffix"]
     dac_service_config = ServiceConfig(
-        image=args["zkevm_dac_image"],
+        image=args["cdk_da_image"],
         ports={
             "dac": PortSpec(args["zkevm_dac_port"], application_protocol="http"),
         },

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -37,7 +37,7 @@ def _create_node_component_service_config(
 def start_synchronizer(plan, args, config_artifact, genesis_artifact):
     synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
     synchronizer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -53,7 +53,7 @@ def start_synchronizer(plan, args, config_artifact, genesis_artifact):
 def create_sequencer_service_config(args, config_artifact, genesis_artifact):
     sequencer_name = "zkevm-node-sequencer" + args["deployment_suffix"]
     sequencer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "rpc": PortSpec(args["zkevm_rpc_http_port"], application_protocol="http"),
             "data-streamer": PortSpec(
@@ -76,7 +76,7 @@ def create_sequence_sender_service_config(
 ):
     sequence_sender_name = "zkevm-node-sequence-sender" + args["deployment_suffix"]
     sequence_sender_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -105,7 +105,7 @@ def create_aggregator_service_config(
 ):
     aggregator_name = "zkevm-node-aggregator" + args["deployment_suffix"]
     aggregator_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "aggregator": PortSpec(
                 args["zkevm_aggregator_port"], application_protocol="grpc"
@@ -132,7 +132,7 @@ def create_aggregator_service_config(
 def create_rpc_service_config(args, config_artifact, genesis_artifact):
     rpc_name = "zkevm-node-rpc" + args["deployment_suffix"]
     rpc_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "http-rpc": PortSpec(
                 args["zkevm_rpc_http_port"], application_protocol="http"
@@ -159,7 +159,7 @@ def create_eth_tx_manager_service_config(
 ):
     eth_tx_manager_name = "zkevm-node-eth-tx-manager" + args["deployment_suffix"]
     eth_tx_manager_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -182,7 +182,7 @@ def create_eth_tx_manager_service_config(
 def create_l2_gas_pricer_service_config(args, config_artifact, genesis_artifact):
     l2_gas_pricer_name = "zkevm-node-l2-gas-pricer" + args["deployment_suffix"]
     l2_gas_pricer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=args["cdk_validium_node_image"],
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(

--- a/params.yml
+++ b/params.yml
@@ -32,11 +32,11 @@ deploy_observability: true
 zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
 # zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
 
-zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.2
-# zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
+cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.6.4-cdk.2
+# cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
 
-zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.7
-# zkevm_dac_image: 0xpolygon/cdk-data-availability:0.0.6
+cdk_da_image: 0xpolygon/cdk-data-availability:0.0.7
+# cdk_da_image: 0xpolygon/cdk-data-availability:0.0.6
 
 zkevm_contracts_image: leovct/zkevm-contracts # the tag is automatically replaced by the value of /zkevm_rollup_fork_id/
 


### PR DESCRIPTION
## Description

- Use the `main` branch instead of @rebelArtists's custom [branch](https://github.com/0xPolygon/kurtosis-cdk/compare/main...dan/jit_containers). This involves a bunch of changes:
  - No need to clone the `kurtosis-cdk` repository and to checkout to a custom branch.
  - The `zkevm-agglayer` docker image is now built using [Dockerfile.release](https://github.com/0xPolygon/agglayer/blob/main/Dockerfile.release) instead of [docker/Dockerfile](https://github.com/0xPolygon/agglayer/blob/main/docker/Dockerfile). Indeed, `Dockerfile.release` is used to build production images of the agglayer. Thus we don't need this fix anymore.
    <img width="1169" alt="Screenshot 2024-04-18 at 10 59 13" src="https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/628fc4a1-3618-4e25-b4d4-527cdbb54541">
  - Update `params.yml` to use local docker images.

- Bump actions versions.
- Log inputs values when the job is starting.
- Update regression check (logic is the same).

- Rename some docker image parameters in `params.yml`:
  - `zkevm_node_image` => `cdk_validium_node_image`
  - `zkevm_dac_image` => `cdk_da_image`

## Test

https://github.com/0xPolygon/kurtosis-cdk/actions/runs/8736377230/job/23971122637