### PR TITLE
feat: enable to deploy l1 additional services

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -14,10 +14,6 @@ def run(plan, args):
                     "l1_preallocated_mnemonic"
                 ],
             },
-            "additional_services": [
-                "blockscout",  # block explorer
-                "dora",  # beaconchain explorer
-                "el_forkmon",  # fork monitor tool
-            ],
+            "additional_services": args["l1_additional_services"],
         },
     )

--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/kurtosis-tech/ethereum-package/main.star@2.1.0"
+    "github.com/kurtosis-tech/ethereum-package/main.star@2.2.0"
 )
 
 

--- a/ethereum.star
+++ b/ethereum.star
@@ -14,6 +14,10 @@ def run(plan, args):
                     "l1_preallocated_mnemonic"
                 ],
             },
-            "additional_services": [],
+            "additional_services": [
+                "blockscout",  # block explorer
+                "dora",  # beaconchain explorer
+                "el_forkmon",  # fork monitor tool
+            ],
         },
     )

--- a/params.yml
+++ b/params.yml
@@ -147,11 +147,12 @@ args:
   l1_preallocated_mnemonic: code code code code code code code code code code code quality
   l1_rpc_url: http://el-1-geth-lighthouse:8545
   l1_ws_url: ws://el-1-geth-lighthouse:8546
-  l1_additional_services:
-    # https://github.com/kurtosis-tech/ethereum-package/tree/main?tab=readme-ov-file#configuration
-    #- blockscout # block explorer
-    #- dora  # beaconchain explorer
-    #- el_forkmon # fork monitor tool
+  # https://github.com/kurtosis-tech/ethereum-package/tree/main?tab=readme-ov-file#configuration
+  l1_additional_services: [
+    # blockscout, # block explorer
+    # dora, # beaconchain explorer
+    # el_forkmon, # fork monitor tool
+  ]
 
   ## Rollup configuration.
 

--- a/params.yml
+++ b/params.yml
@@ -147,6 +147,11 @@ args:
   l1_preallocated_mnemonic: code code code code code code code code code code code quality
   l1_rpc_url: http://el-1-geth-lighthouse:8545
   l1_ws_url: ws://el-1-geth-lighthouse:8546
+  l1_additional_services:
+    # https://github.com/kurtosis-tech/ethereum-package/tree/main?tab=readme-ov-file#configuration
+    #- blockscout # block explorer
+    #- dora  # beaconchain explorer
+    #- el_forkmon # fork monitor tool
 
   ## Rollup configuration.
 


### PR DESCRIPTION
## Description

- Enable to deploy L1 additional services via `params.yml`.

## References (if applicable)

- Here is a quick example with:
  - L1 block explorer (blockscout)
  - L1 beaconchain explorer (dora)
  - L1 fork/reorg monitor (forkmon)

```yaml
# params.yml

args:
 l1_additional_services: [
    blockscout, # block explorer
    dora, # beaconchain explorer
    el_forkmon, # fork monitor tool
  ]
```

<img width="1784" alt="Screenshot 2024-04-20 at 01 09 47" src="https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/ed56269a-17d3-47da-b280-71d7998314be">

<img width="1781" alt="Screenshot 2024-04-20 at 01 09 54" src="https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/69be9545-1d21-4607-990d-a94d08379547">

<img width="1785" alt="Screenshot 2024-04-20 at 01 09 58" src="https://github.com/0xPolygon/kurtosis-cdk/assets/28714795/f66d967b-fada-421e-86f5-6454e8d36d96">
