### PR TITLE
fix: kubernetes deployment

### DIFF
--- a/deploy_zkevm_contracts.star
+++ b/deploy_zkevm_contracts.star
@@ -75,6 +75,9 @@ def run(plan, args):
                     ]
                 ),
             },
+            # These two lines are only necessary to deploy to any Kubernetes environment (e.g. GKE).
+            entrypoint=["bash", "-c"],
+            cmd=["sleep infinity"],
             user=User(uid=0, gid=0),  # Run the container as root user.
         ),
     )


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The contract service will run in a pod in Kubernetes. Unfortunately, there is no command specified when starting the service, thus [the pod will terminate](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-terminated) just after startup. As we need this service to be available later in the deployment, we simply add an infinite loop to trick Kubernetes so that the pod [stays alive](https://www.youtube.com/watch?v=I_izvAbhExY&ab_channel=beegees). This has no impact on Docker deployments.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
