### PR TITLE
feat: bump ethereum-package version

### DIFF
--- a/.github/workflows/docker-image-builder-cron.yml
+++ b/.github/workflows/docker-image-builder-cron.yml
@@ -2,6 +2,9 @@
 name: Docker Image Builder Cron
 
 on:
+  push:
+    paths:
+      - 'docker/**'  # Trigger only when changes are made in the docker folder
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 6 AM Paris time (UTC+2).
   workflow_dispatch:

--- a/.github/workflows/docker-image-builder-cron.yml
+++ b/.github/workflows/docker-image-builder-cron.yml
@@ -2,9 +2,6 @@
 name: Docker Image Builder Cron
 
 on:
-  push:
-    paths:
-      - 'docker/**'  # Trigger only when changes are made in the docker folder
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 6 AM Paris time (UTC+2).
   workflow_dispatch:

--- a/.github/workflows/docker-image-builder-cron.yml
+++ b/.github/workflows/docker-image-builder-cron.yml
@@ -5,7 +5,6 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 6 AM Paris time (UTC+2).
   workflow_dispatch:
-  pull_request: # TODO: Remove this. This is just for testing purposes.
 
 concurrency:
   group: docker-image-builder-cron-${{ github.event.pull_request.number || github.ref }}

--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/kurtosis-tech/ethereum-package/main.star@2.3.0"
+    "github.com/kurtosis-tech/ethereum-package/main.star@3.0.0"
 )
 
 

--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/kurtosis-tech/ethereum-package/main.star@2.2.0"
+    "github.com/kurtosis-tech/ethereum-package/main.star@2.3.0"
 )
 
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The latest version of Kurtosis [v0.89.0](https://github.com/kurtosis-tech/kurtosis/releases/tag/0.89.0) introduced a breaking change to the way files are stored when using the `store` statement. This disrupted the operation of the ethereum package. A [patch](https://github.com/kurtosis-tech/ethereum-package/releases/tag/3.0.0) has been released to mitigate the problem.

The PR also fixes the docker-image-builder cron job triggers.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

Fixes #96 
