### PR TITLE
chore: bump ethereum-package version

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/kurtosis-tech/ethereum-package/main.star@2.2.0"
+    "github.com/kurtosis-tech/ethereum-package/main.star@3.0.0"
 )
 
 GETH_IMAGE = "ethereum/client-go:v1.14.0"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The latest version of Kurtosis [v0.89.0](https://github.com/kurtosis-tech/kurtosis/releases/tag/0.89.0) introduced a breaking change to the way files are stored when using the store statement. This disrupted the operation of the ethereum package. A [patch](https://github.com/kurtosis-tech/ethereum-package/releases/tag/3.0.0) has been released to mitigate the problem.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

Fixes #96 
