### PR TITLE
chore: update tool check script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
       label: System information
       description: |
         Specify the OS version and the CPU model and architecture.
-      placeholder: Ubuntu 22.04 - amd64
+      placeholder: e.g. Ubuntu 22.04 - amd64
     validations:
       required: true
 
@@ -27,23 +27,14 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: kurtosis_cli_version
+  - type: textarea
+    id: tools_versions
     attributes:
-      label: Kurtosis CLI version
-      placeholder: e.g. 0.88.19
+      label: Tools versions
+      placeholder: |
+        Paste the output of the tool check script.
       description: |
-        Retrieve the kurtosis CLI version using `kurtosis version`.
-    validations:
-      required: true
-
-  - type: input
-    id: kurtosis_engine_version
-    attributes:
-      label: Kurtosis engine version
-      placeholder: e.g. 0.88.19
-      description: |
-        Retrieve the kurtosis engine version using `kurtosis engine status`.
+        Retrieve the tools versions using `./scripts/tool_check.sh`.
     validations:
       required: true
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Update the tool check script to make sure users have installed the required versions of kurtosis and docker. It is easy to have the wrong combination of versions, which unfortunately makes our package unusable...

This PR also updates the bug report template to ask users to run the tool check script.

### Tests

Before updating kurtosis to the latest version...

```bash
$ ./scripts/tool_check.sh
Checking that you have the necessary tools to deploy the Kurtosis CDK package...
❌ kurtosis 0.88.19 is installed, but only version 0.89 is supported.
```

After updating kurtosis...

```bash
$ ./scripts/tool_check.sh
Checking that you have the necessary tools to deploy the Kurtosis CDK package...
✅ kurtosis 0.89.3 is installed, meets the requirement (=0.89).
✅ docker 26.0.0 is installed, meets the requirement (>=24.7).

You might as well need the following tools to interact with the environment...
✅ jq 1.7.1 is installed.
✅ yq 3.2.3 is installed, meets the requirement (>=3.2).
✅ cast 0.2.0 is installed.
✅ polycli v0.1.43-1-gd122be7 is installed.

🎉 You are ready to go!
```

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/0xPolygon/polygon-docs/discussions/419#discussioncomment-9338299