### PR TITLE
Set public port for Blockscot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,9 +138,9 @@ jobs:
 
       - name: Deploy Blockscout stack
         run: |
-          yq -Y --in-place '.deploy_blockscout = true' params.yml
+          yq -Y --in-place '.deploy_l2_blockscout = true' params.yml
           kurtosis run --enclave cdk-v1 --args-file params.yml .
-          yq -Y --in-place '.deploy_blockscout = false' params.yml # reset
+          yq -Y --in-place '.deploy_l2_blockscout = false' params.yml # reset
 
       - name: Deploy ETH load balancer
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,12 @@ jobs:
           kurtosis run --enclave cdk-v1 --args-file params.yml .
           yq -Y --in-place '.deploy_observability = false' params.yml # reset
 
+      - name: Deploy Blockscout stack
+        run: |
+          yq -Y --in-place '.deploy_blockscout = true' params.yml
+          kurtosis run --enclave cdk-v1 --args-file params.yml .
+          yq -Y --in-place '.deploy_blockscout = false' params.yml # reset
+
       - name: Deploy ETH load balancer
         run: |
           yq -Y --in-place '.deploy_blutgang = true' params.yml

--- a/blockscout.star
+++ b/blockscout.star
@@ -1,0 +1,189 @@
+def start_blockscout(plan, rpc_url, ws_url, args):
+    # https://github.com/blockscout/frontend/blob/v1.29.2/docs/ENVS.md
+    # https://docs.blockscout.com/for-developers/information-and-settings/env-variables
+    # https://github.com/blockscout/blockscout-rs/tree/main/stats#env
+
+    bs_db_user = args["zkevm_db_blockscout_user"]
+    bs_db_password = args["zkevm_db_blockscout_password"]
+    bs_db_host = args["zkevm_db_blockscout_hostname"] + args["deployment_suffix"]
+    bs_db_port = args["zkevm_db_postgres_port"]
+    bs_db_name = args["zkevm_db_blockscout_name"]
+    bs_connection_string = (
+        "postgresql://"
+        + bs_db_user
+        + ":"
+        + bs_db_password
+        + "@"
+        + bs_db_host
+        + ":"
+        + str(bs_db_port)
+        + "/"
+        + bs_db_name
+    )
+
+    bs_backed_service_name = "blockscout-be" + args["deployment_suffix"]
+    bs_backend_service = plan.add_service(
+        name=bs_backed_service_name,
+        config=ServiceConfig(
+            image=args["blockscout_be_image"],
+            ports={
+                "blockscout": PortSpec(4004, application_protocol="http", wait="1m"),
+            },
+            env_vars={
+                "PORT": "4004",
+                "NETWORK": "POE",
+                "SUBNETWORK": "Polygon CDK",
+                "CHAIN_ID": str(args["zkevm_rollup_chain_id"]),
+                "COIN": "ETH",
+                "ETHEREUM_JSONRPC_VARIANT": "geth",
+                "ETHEREUM_JSONRPC_HTTP_URL": rpc_url,
+                "ETHEREUM_JSONRPC_TRACE_URL": rpc_url,
+                "ETHEREUM_JSONRPC_WS_URL": ws_url,
+                "ETHEREUM_JSONRPC_HTTP_INSECURE": "true",
+                "DATABASE_URL": bs_connection_string,
+                "ECTO_USE_SSL": "false",
+                "MIX_ENV": "prod",
+                "LOGO": "/images/blockscout_logo.svg",
+                "LOGO_FOOTER": "/images/blockscout_logo.svg",
+                "SUPPORTED_CHAINS": "[]",
+                "SHOW_OUTDATED_NETWORK_MODAL": "false",
+                "DISABLE_INDEXER": "false",
+                "INDEXER_ZKEVM_BATCHES_ENABLED": "true",
+                "API_V2_ENABLED": "true",
+                "BLOCKSCOUT_PROTOCOL": "http",
+            },
+            cmd=[
+                "/bin/sh",
+                "-c",
+                'bin/blockscout eval "Elixir.Explorer.ReleaseTasks.create_and_migrate()" && bin/blockscout start',
+            ],
+        ),
+    )
+    plan.exec(
+        description="""
+        Allow 30s for blockscout to start indexing,
+        otherwise bs/Stats crashes because it expects to find content on DB
+        """,
+        service_name=bs_backed_service_name,
+        recipe=ExecRecipe(
+            command=["/bin/sh", "-c", "sleep 30"],
+        ),
+    )
+
+    st_db_user = args["zkevm_db_blockscout_stats_user"]
+    st_db_password = args["zkevm_db_blockscout_stats_password"]
+    st_db_host = args["zkevm_db_blockscout_stats_hostname"] + args["deployment_suffix"]
+    st_db_port = args["zkevm_db_postgres_port"]
+    st_db_name = args["zkevm_db_blockscout_stats_name"]
+    st_connection_string = (
+        "postgresql://"
+        + st_db_user
+        + ":"
+        + st_db_password
+        + "@"
+        + st_db_host
+        + ":"
+        + str(st_db_port)
+        + "/"
+        + st_db_name
+    )
+
+    bs_stats_service = plan.add_service(
+        name="blockscout-stats" + args["deployment_suffix"],
+        config=ServiceConfig(
+            image=args["blockscout_stats_image"],
+            ports={
+                "blockscout": PortSpec(
+                    # Did not find a way to set the port with an env var so far
+                    8050,
+                    application_protocol="http",
+                    wait="30s",
+                ),
+            },
+            env_vars={
+                "STATS__DB_URL": st_connection_string,
+                "STATS__BLOCKSCOUT_DB_URL": bs_connection_string,
+                "STATS__CREATE_DATABASE": "true",
+                "STATS__RUN_MIGRATIONS": "true",
+                "STATS__SERVER__HTTP__CORS__ENABLED": "false",
+            },
+        ),
+    )
+
+    bs_visualize_service = plan.add_service(
+        name="blockscout-visualize" + args["deployment_suffix"],
+        config=ServiceConfig(
+            image=args["blockscout_visualizer_image"],
+            ports={
+                "blockscout": PortSpec(8050, application_protocol="http"),
+            },
+        ),
+    )
+
+    bs_frontend_service = plan.add_service(
+        name="blockscout-fe" + args["deployment_suffix"],
+        config=ServiceConfig(
+            image=args["blockscout_fe_image"],
+            ports={
+                "blockscout": PortSpec(
+                    args["blockscout_public_port"],
+                    application_protocol="http",
+                    wait="30s",
+                ),
+            },
+            public_ports={
+                "blockscout": PortSpec(
+                    args["blockscout_public_port"],
+                    application_protocol="http",
+                    wait="30s",
+                ),
+            },
+            env_vars={
+                "PORT": str(args["blockscout_public_port"]),
+                "NEXT_PUBLIC_NETWORK_NAME": "CDK zkEVM",
+                "NEXT_PUBLIC_NETWORK_ID": str(args["zkevm_rollup_chain_id"]),
+                "NEXT_PUBLIC_API_HOST": bs_backend_service.ip_address,
+                "NEXT_PUBLIC_API_PORT": str(
+                    bs_backend_service.ports["blockscout"].number
+                ),
+                "NEXT_PUBLIC_API_PROTOCOL": "http",
+                "NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL": "ws",
+                "NEXT_PUBLIC_STATS_API_HOST": "http://{}:{}".format(
+                    bs_stats_service.ip_address,
+                    bs_stats_service.ports["blockscout"].number,
+                ),
+                "NEXT_PUBLIC_VISUALIZE_API_HOST": "http://{}:{}".format(
+                    bs_visualize_service.ip_address,
+                    bs_visualize_service.ports["blockscout"].number,
+                ),
+                "NEXT_PUBLIC_APP_PROTOCOL": "http",
+                "NEXT_PUBLIC_APP_HOST": "127.0.0.1",
+                "NEXT_PUBLIC_APP_PORT": str(args["blockscout_public_port"]),
+                "NEXT_PUBLIC_USE_NEXT_JS_PROXY": "true",
+                "NEXT_PUBLIC_AD_BANNER_PROVIDER": "none",
+                "NEXT_PUBLIC_AD_TEXT_PROVIDER": "none",
+            },
+        ),
+    )
+
+    return (bs_backend_service, bs_frontend_service)
+
+
+def run(plan, args):
+    rpc_url = None
+    ws_url = None
+    for service in plan.get_services():
+        if service.name == "zkevm-node-rpc" + args["deployment_suffix"]:
+            rpc_url = "http://{}:{}".format(
+                service.ip_address, service.ports["http-rpc"].number
+            )
+            ws_url = "ws://{}:{}".format(
+                service.ip_address, service.ports["ws-rpc"].number
+            )
+            break
+
+    if not (rpc_url and ws_url):
+        fail("Could not find the zkevm-node-rpc service")
+
+    # Start blockscout.
+    start_blockscout(plan, rpc_url, ws_url, args)

--- a/docs/quickstart/breakdown-deployment.md
+++ b/docs/quickstart/breakdown-deployment.md
@@ -99,9 +99,9 @@ yq -Y --in-place '.deploy_observability = false' params.yml # reset
 ### Deploy Blockscout stack
 
 ```sh
-yq -Y --in-place '.deploy_blockscout = true' params.yml
+yq -Y --in-place '.deploy_l2_blockscout = true' params.yml
 kurtosis run --enclave cdk-v1 --args-file params.yml .
-yq -Y --in-place '.deploy_blockscout = false' params.yml # reset
+yq -Y --in-place '.deploy_l2_blockscout = false' params.yml # reset
 ```
 
 ### Deploy ETH load balancer

--- a/docs/quickstart/breakdown-deployment.md
+++ b/docs/quickstart/breakdown-deployment.md
@@ -96,6 +96,14 @@ kurtosis run --enclave cdk-v1 --args-file params.yml .
 yq -Y --in-place '.deploy_observability = false' params.yml # reset
 ```
 
+### Deploy Blockscout stack
+
+```sh
+yq -Y --in-place '.deploy_blockscout = true' params.yml
+kurtosis run --enclave cdk-v1 --args-file params.yml .
+yq -Y --in-place '.deploy_blockscout = false' params.yml # reset
+```
+
 ### Deploy ETH load balancer
 
 ```sh

--- a/input_parser.star
+++ b/input_parser.star
@@ -27,6 +27,7 @@ DEFAULT_ARGS = {
     "zkevm_bridge_ui_port": 80,
     "zkevm_agglayer_port": 4444,
     "zkevm_dac_port": 8484,
+    "blockscout_public_port": 50101,  # IANA registered ports up to 49151
     "zkevm_l2_sequencer_address": "0x5b06837A43bdC3dD9F114558DAf4B26ed49842Ed",
     "zkevm_l2_sequencer_private_key": "0x183c492d0ba156041a7f31a1b188958a7a22eebadca741a7fe64436092dc3181",
     "zkevm_l2_aggregator_address": "0xCae5b68Ff783594bDe1b93cdE627c741722c4D4d",

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -68,6 +68,7 @@ description: |-
   zkevm_bridge_ui_port: 80
   zkevm_agglayer_port: 4444
   zkevm_dac_port: 8484
+  blockscout_public_port: 50101
 
   # Addresses and private keys of the different components.
   # They have been generated using the following command:

--- a/main.star
+++ b/main.star
@@ -20,7 +20,7 @@ def run(
     deploy_cdk_central_environment=True,
     deploy_zkevm_permissionless_node=False,
     deploy_observability=True,
-    deploy_blockscout=False,
+    deploy_l2_blockscout=False,
     deploy_blutgang=False,
     apply_workload=False,
     args={},
@@ -35,7 +35,7 @@ def run(
         deploy_cdk_bridge_infra(bool): Deploy cdk/bridge infrastructure.
         deploy_zkevm_permissionless_node(bool): Deploy permissionless node.
         deploy_observability(bool): Deploys observability stack.
-        deploy_blockscout(bool): Deploys Blockscout stack.
+        deploy_l2_blockscout(bool): Deploys Blockscout stack.
         args(json): Configures other aspects of the environment.
     Returns:
         A full deployment of Polygon CDK.
@@ -118,7 +118,7 @@ def run(
         plan.print("Skipping the deployment of the observability stack")
 
     # Deploy observability stack
-    if deploy_blockscout:
+    if deploy_l2_blockscout:
         plan.print("Deploying Blockscout stack")
         import_module(blockscout_package).run(plan, args)
     else:

--- a/main.star
+++ b/main.star
@@ -6,6 +6,7 @@ cdk_central_environment_package = "./cdk_central_environment.star"
 cdk_bridge_infra_package = "./cdk_bridge_infra.star"
 zkevm_permissionless_node_package = "./zkevm_permissionless_node.star"
 observability_package = "./observability.star"
+blockscout_package = "./blockscout.star"
 workload_package = "./workload.star"
 blutgang_package = "./cdk_blutgang.star"
 
@@ -19,6 +20,7 @@ def run(
     deploy_cdk_central_environment=True,
     deploy_zkevm_permissionless_node=False,
     deploy_observability=True,
+    deploy_blockscout=False,
     deploy_blutgang=False,
     apply_workload=False,
     args={},
@@ -33,6 +35,7 @@ def run(
         deploy_cdk_bridge_infra(bool): Deploy cdk/bridge infrastructure.
         deploy_zkevm_permissionless_node(bool): Deploy permissionless node.
         deploy_observability(bool): Deploys observability stack.
+        deploy_blockscout(bool): Deploys Blockscout stack.
         args(json): Configures other aspects of the environment.
     Returns:
         A full deployment of Polygon CDK.
@@ -113,6 +116,13 @@ def run(
         import_module(observability_package).run(plan, observability_args)
     else:
         plan.print("Skipping the deployment of the observability stack")
+
+    # Deploy observability stack
+    if deploy_blockscout:
+        plan.print("Deploying Blockscout stack")
+        import_module(blockscout_package).run(plan, args)
+    else:
+        plan.print("Skipping the deployment of Blockscout stack")
 
     # Apply workload
     if apply_workload:

--- a/observability.star
+++ b/observability.star
@@ -4,7 +4,6 @@ prometheus_package = import_module(
 grafana_package = import_module("github.com/kurtosis-tech/grafana-package/main.star")
 
 service_package = import_module("./lib/service.star")
-bridge_package = import_module("./cdk_bridge_infra.star")
 
 
 def start_panoptichain(plan, args):
@@ -42,160 +41,6 @@ def start_panoptichain(plan, args):
     )
 
 
-def start_blockscout(plan, args):
-    # https://github.com/blockscout/frontend/blob/v1.29.2/docs/ENVS.md
-    # https://docs.blockscout.com/for-developers/information-and-settings/env-variables
-    # https://github.com/blockscout/blockscout-rs/tree/main/stats#env
-
-    bs_db_user = args["zkevm_db_blockscout_user"]
-    bs_db_password = args["zkevm_db_blockscout_password"]
-    bs_db_host = args["zkevm_db_blockscout_hostname"] + args["deployment_suffix"]
-    bs_db_port = args["zkevm_db_postgres_port"]
-    bs_db_name = args["zkevm_db_blockscout_name"]
-    bs_connection_string = (
-        "postgresql://"
-        + bs_db_user
-        + ":"
-        + bs_db_password
-        + "@"
-        + bs_db_host
-        + ":"
-        + str(bs_db_port)
-        + "/"
-        + bs_db_name
-    )
-
-    bs_backed_service_name = "blockscout-be" + args["deployment_suffix"]
-    bs_backend_service = plan.add_service(
-        name=bs_backed_service_name,
-        config=ServiceConfig(
-            image=args["blockscout_be_image"],
-            ports={
-                "blockscout": PortSpec(4004, application_protocol="http", wait="1m"),
-            },
-            env_vars={
-                "PORT": "4004",
-                "NETWORK": "POE",
-                "SUBNETWORK": "Polygon CDK",
-                "CHAIN_ID": str(args["zkevm_rollup_chain_id"]),
-                "COIN": "ETH",
-                "ETHEREUM_JSONRPC_VARIANT": "geth",
-                "ETHEREUM_JSONRPC_HTTP_URL": args["zkevm_rpc_url"],
-                "DATABASE_URL": bs_connection_string,
-                "ECTO_USE_SSL": "false",
-                "MIX_ENV": "prod",
-                "LOGO": "/images/blockscout_logo.svg",
-                "LOGO_FOOTER": "/images/blockscout_logo.svg",
-                "SUPPORTED_CHAINS": "[]",
-                "SHOW_OUTDATED_NETWORK_MODAL": "false",
-                "DISABLE_INDEXER": "false",
-                "INDEXER_ZKEVM_BATCHES_ENABLED": "true",
-                "API_V2_ENABLED": "true",
-                "BLOCKSCOUT_PROTOCOL": "http",
-            },
-            cmd=[
-                "/bin/sh",
-                "-c",
-                'bin/blockscout eval "Elixir.Explorer.ReleaseTasks.create_and_migrate()" && bin/blockscout start',
-            ],
-        ),
-    )
-    plan.exec(
-        description="""
-        Allow 30s for blockscout to start indexing,
-        otherwise bs/Stats crashes because it expects to find content on DB
-        """,
-        service_name=bs_backed_service_name,
-        recipe=ExecRecipe(
-            command=["/bin/sh", "-c", "sleep 30"],
-        ),
-    )
-
-    st_db_user = args["zkevm_db_blockscout_stats_user"]
-    st_db_password = args["zkevm_db_blockscout_stats_password"]
-    st_db_host = args["zkevm_db_blockscout_stats_hostname"] + args["deployment_suffix"]
-    st_db_port = args["zkevm_db_postgres_port"]
-    st_db_name = args["zkevm_db_blockscout_stats_name"]
-    st_connection_string = (
-        "postgresql://"
-        + st_db_user
-        + ":"
-        + st_db_password
-        + "@"
-        + st_db_host
-        + ":"
-        + str(st_db_port)
-        + "/"
-        + st_db_name
-    )
-
-    bs_stats_service = plan.add_service(
-        name="blockscout-stats" + args["deployment_suffix"],
-        config=ServiceConfig(
-            image=args["blockscout_stats_image"],
-            ports={
-                "blockscout": PortSpec(
-                    # Did not find a way to set the port with an env var so far
-                    8050,
-                    application_protocol="http",
-                    wait="30s",
-                ),
-            },
-            env_vars={
-                "STATS__DB_URL": st_connection_string,
-                "STATS__BLOCKSCOUT_DB_URL": bs_connection_string,
-                "STATS__CREATE_DATABASE": "true",
-                "STATS__RUN_MIGRATIONS": "true",
-                "STATS__SERVER__HTTP__CORS__ENABLED": "false",
-            },
-        ),
-    )
-
-    bs_visualize_service = plan.add_service(
-        name="blockscout-visualize" + args["deployment_suffix"],
-        config=ServiceConfig(
-            image=args["blockscout_visualizer_image"],
-            ports={
-                "blockscout": PortSpec(8050, application_protocol="http"),
-            },
-        ),
-    )
-
-    bs_frontend_service = plan.add_service(
-        name="blockscout-fe" + args["deployment_suffix"],
-        config=ServiceConfig(
-            image=args["blockscout_fe_image"],
-            ports={
-                "blockscout": PortSpec(8050, application_protocol="http", wait="30s"),
-            },
-            env_vars={
-                "PORT": "8050",
-                "NEXT_PUBLIC_NETWORK_NAME": "CDK zkEVM",
-                "NEXT_PUBLIC_NETWORK_ID": str(args["zkevm_rollup_chain_id"]),
-                "NEXT_PUBLIC_API_HOST": bs_backend_service.ip_address,
-                "NEXT_PUBLIC_API_PORT": str(
-                    bs_backend_service.ports["blockscout"].number
-                ),
-                "NEXT_PUBLIC_API_PROTOCOL": "http",
-                "NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL": "ws",
-                "NEXT_PUBLIC_STATS_API_HOST": "http://{}:{}".format(
-                    bs_stats_service.ip_address,
-                    bs_stats_service.ports["blockscout"].number,
-                ),
-                "NEXT_PUBLIC_VISUALIZE_API_HOST": "http://{}:{}".format(
-                    bs_visualize_service.ip_address,
-                    bs_visualize_service.ports["blockscout"].number,
-                ),
-                "NEXT_PUBLIC_APP_PROTOCOL": "http",
-                "NEXT_PUBLIC_APP_HOST": "127.0.0.1",
-                "NEXT_PUBLIC_APP_PORT": "8050",
-            },
-        ),
-    )
-
-    return (bs_backend_service, bs_frontend_service)
-
-
 def run(plan, args):
     for service in plan.get_services():
         if service.name == "zkevm-node-rpc" + args["deployment_suffix"]:
@@ -205,9 +50,6 @@ def run(plan, args):
 
     # Start panoptichain.
     start_panoptichain(plan, args)
-
-    # Start blockscout.
-    start_blockscout(plan, args)
 
     metrics_jobs = []
     for service in plan.get_services():

--- a/params.yml
+++ b/params.yml
@@ -24,7 +24,7 @@ deploy_zkevm_permissionless_node: false
 deploy_observability: true
 
 # Deploy Blockscout stack.
-deploy_blockscout: false
+deploy_l2_blockscout: false
 
 # Deploy eth load balancer.
 deploy_blutgang: false

--- a/params.yml
+++ b/params.yml
@@ -23,6 +23,9 @@ deploy_zkevm_permissionless_node: false
 # Deploy observability stack.
 deploy_observability: true
 
+# Deploy Blockscout stack.
+deploy_blockscout: false
+
 # Deploy eth load balancer.
 deploy_blutgang: false
 
@@ -71,6 +74,7 @@ args:
   zkevm_bridge_ui_port: 80
   zkevm_agglayer_port: 4444
   zkevm_dac_port: 8484
+  blockscout_public_port: 50101
 
   # Addresses and private keys of the different components.
   # They have been generated using the following command:


### PR DESCRIPTION
## Description
That should make Blockscout  work on MAC as well, by using a public_port since that can't be achieved through a proxy though.
It also fixes/improves some configurations, remove ads, etc.

Now Blockscout is disabled by default, you need to enable it on params.yaml or just on command line:
`kurtosis run . '{"deploy_blockscout":true}'`