### PR TITLE
docs: typo in script

### DIFF
--- a/docs/quickstart/breakdown-deployment.md
+++ b/docs/quickstart/breakdown-deployment.md
@@ -74,9 +74,9 @@ yq -Y --in-place '.deploy_cdk_central_environment = false' params.yml # reset
 ### Deploy CDK bridge infrastructure
 
 ```sh
-yq -Y --in-place '.deploy_zkevm_permissionless_node = true' params.yml
+yq -Y --in-place '.deploy_cdk_bridge_infra = true' params.yml
 kurtosis run --enclave cdk-v1 --args-file params.yml .
-yq -Y --in-place '.deploy_zkevm_permissionless_node = false' params.yml # reset
+yq -Y --in-place '.deploy_cdk_bridge_infra = false' params.yml # reset
 # Perform additional tasks...
 ```
 


### PR DESCRIPTION
## Description

The https://docs.polygon.technology/cdk/get-started/quickstart/breakdown-deployment/#deploy-cdk-bridge-infrastructure docs is spinning up the permissionless node.

I added the correct parameter.

Issue raised by user: https://github.com/0xPolygon/polygon-docs/discussions/390#discussioncomment-9504165

