### PR TITLE
feat: introduce data availability mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -290,7 +290,7 @@ jobs:
 
       # Deploy components.
       - name: Set validium data availability mode
-        run: yq -Y --in-place '.args.data_availability_mode = "validium"' params.yml
+        run: yq -Y --in-place '.args.data_availability_mode = "cdk-validium"' params.yml
 
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --image-download always .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -236,3 +236,32 @@ jobs:
           yq -Y --in-place '(.deploy_l1 = false) | (.deploy_zkevm_contracts_on_l1 = false)' params.yml
 
           kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
+
+  # Deploy the CDK environment in rollup mode (data availability).
+  # By default the da mode is set to validium.
+  rollup-data-availability-mode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install tools.
+      - name: Install kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli=${{ env.KURTOSIS_VERSION }}
+          kurtosis analytics disable
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      # Deploy components.
+      - name: Set rollup data availability mode
+        run: yq -Y --in-place '.args.data_availability_mode = rollup' params.yml
+
+      - name: Deploy Kurtosis CDK package
+        run: kurtosis run --enclave cdk-v1 --image-download always .
+
+      - name: Check that batches are being verified
+        working-directory: ./scripts
+        run: ./batch_verification_monitor.sh ${{ env.BATCH_VERIFICATION_MONITOR_TARGET }} ${{ env.BATCH_VERIFICATION_MONITOR_TIMEOUT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,6 +251,9 @@ jobs:
           sudo apt install kurtosis-cli=${{ env.KURTOSIS_VERSION }}
           kurtosis analytics disable
 
+      - name: Install yq
+        run: pip3 install yq
+
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1
 
@@ -278,6 +281,9 @@ jobs:
           sudo apt update
           sudo apt install kurtosis-cli=${{ env.KURTOSIS_VERSION }}
           kurtosis analytics disable
+
+      - name: Install yq
+        run: pip3 install yq
 
       - name: Install foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,8 +238,7 @@ jobs:
           kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 
   # Deploy the CDK environment in rollup mode (data availability).
-  # By default the da mode is set to validium.
-  rollup-data-availability-mode:
+  rollup-da-mode:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -258,6 +257,34 @@ jobs:
       # Deploy components.
       - name: Set rollup data availability mode
         run: yq -Y --in-place '.args.data_availability_mode = rollup' params.yml
+
+      - name: Deploy Kurtosis CDK package
+        run: kurtosis run --enclave cdk-v1 --image-download always .
+
+      - name: Check that batches are being verified
+        working-directory: ./scripts
+        run: ./batch_verification_monitor.sh ${{ env.BATCH_VERIFICATION_MONITOR_TARGET }} ${{ env.BATCH_VERIFICATION_MONITOR_TIMEOUT }}
+
+  # Deploy the CDK environment in validium mode (data availability).
+  validium-da-mode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install tools.
+      - name: Install kurtosis
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt update
+          sudo apt install kurtosis-cli=${{ env.KURTOSIS_VERSION }}
+          kurtosis analytics disable
+
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      # Deploy components.
+      - name: Set validium data availability mode
+        run: yq -Y --in-place '.args.data_availability_mode = validium' params.yml
 
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --image-download always .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -259,7 +259,7 @@ jobs:
 
       # Deploy components.
       - name: Set rollup data availability mode
-        run: yq -Y --in-place '.args.data_availability_mode = rollup' params.yml
+        run: yq -Y --in-place '.args.data_availability_mode = "rollup"' params.yml
 
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --image-download always .
@@ -290,7 +290,7 @@ jobs:
 
       # Deploy components.
       - name: Set validium data availability mode
-        run: yq -Y --in-place '.args.data_availability_mode = validium' params.yml
+        run: yq -Y --in-place '.args.data_availability_mode = "validium"' params.yml
 
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --image-download always .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -268,8 +268,8 @@ jobs:
         working-directory: ./scripts
         run: ./batch_verification_monitor.sh ${{ env.BATCH_VERIFICATION_MONITOR_TARGET }} ${{ env.BATCH_VERIFICATION_MONITOR_TIMEOUT }}
 
-  # Deploy the CDK environment in validium mode (data availability).
-  validium-da-mode:
+  # Deploy the CDK environment in cdk-validium mode (data availability).
+  cdk-validium-da-mode:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -289,7 +289,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       # Deploy components.
-      - name: Set validium data availability mode
+      - name: Set cdk-validium data availability mode
         run: yq -Y --in-place '.args.data_availability_mode = "cdk-validium"' params.yml
 
       - name: Deploy Kurtosis CDK package

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ claimable-txs.json
 proof.json
 
 # default parameters
-default-args.yml
+input-parser-args.yml
 kurtosis-args.yml
 params-args.yml
 

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -55,23 +55,28 @@ def run(plan, args):
         plan, args, node_config_artifact, genesis_artifact
     )
 
-    # Start the rest of the zkevm node components along with the dac.
+    # Start the rest of the zkevm node components.
     keystore_artifacts = get_keystores_artifacts(plan, args)
     zkevm_node_components_configs = (
         zkevm_node_package.create_zkevm_node_components_config(
             args, node_config_artifact, genesis_artifact, keystore_artifacts
         )
     )
-
-    dac_config_artifact = create_dac_config_artifact(plan, args, db_configs)
-    dac_config = zkevm_dac_package.create_dac_service_config(
-        args, dac_config_artifact, keystore_artifacts.dac
-    )
-
     plan.add_services(
-        configs=zkevm_node_components_configs | dac_config,
+        configs=zkevm_node_components_configs,
         description="Starting the rest of the zkevm node components",
     )
+
+    # Start the DAC if in validium mode.
+    if args["data_availability_mode"] == "validium":
+        dac_config_artifact = create_dac_config_artifact(plan, args, db_configs)
+        dac_config = zkevm_dac_package.create_dac_service_config(
+            args, dac_config_artifact, keystore_artifacts.dac
+        )
+        plan.add_services(
+            configs=dac_config,
+            description="Starting the DAC",
+        )
 
 
 def get_keystores_artifacts(plan, args):

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -42,8 +42,7 @@ def run(plan, args):
                 template=node_config_template,
                 data=args
                 | {
-                    "is_cdk_validium": args["zkevm_rollup_consensus"]
-                    == "PolygonValidiumEtrog",
+                    "is_cdk_validium": args["data_availability_mode"] == "validium",
                 }
                 | db_configs,
             )

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -1,3 +1,4 @@
+data_availability_package = import_module("./lib/data_availability.star")
 service_package = import_module("./lib/service.star")
 zkevm_dac_package = import_module("./lib/zkevm_dac.star")
 zkevm_node_package = import_module("./lib/zkevm_node.star")
@@ -42,7 +43,7 @@ def run(plan, args):
                 template=node_config_template,
                 data=args
                 | {
-                    "is_cdk_validium": args["data_availability_mode"] == "validium",
+                    "is_cdk_validium": data_availability_package.is_cdk_validium(args),
                 }
                 | db_configs,
             )
@@ -68,7 +69,7 @@ def run(plan, args):
     )
 
     # Start the DAC if in validium mode.
-    if args["data_availability_mode"] == "validium":
+    if data_availability_package.is_cdk_validium(args):
         dac_config_artifact = create_dac_config_artifact(plan, args, db_configs)
         dac_config = zkevm_dac_package.create_dac_service_config(
             args, dac_config_artifact, keystore_artifacts.dac

--- a/deploy_zkevm_contracts.star
+++ b/deploy_zkevm_contracts.star
@@ -1,3 +1,5 @@
+data_availability_package = import_module("./lib/data_availability.star")
+
 ARTIFACTS = [
     {
         "name": "deploy_parameters.json",
@@ -29,8 +31,12 @@ def run(plan, args):
                     template=template,
                     data=args
                     | {
-                        "is_cdk_validium": args["data_availability_mode"] == "validium",
-                        "zkevm_rollup_consensus": get_consensus_contract(args),
+                        "is_cdk_validium": data_availability_package.is_cdk_validium(
+                            args
+                        ),
+                        "zkevm_rollup_consensus": data_availability_package.get_consensus_contract(
+                            args
+                        ),
                     },
                 )
             },
@@ -94,12 +100,3 @@ def run(plan, args):
             ]
         ),
     )
-
-
-def get_consensus_contract(args):
-    # Map data availability modes to consensus contracts.
-    consensus_contracts = {
-        "rollup": "PolygonZkEVMEtrog",
-        "validium": "PolygonValidiumEtrog",
-    }
-    return consensus_contracts.get(args["data_availability_mode"])

--- a/deploy_zkevm_contracts.star
+++ b/deploy_zkevm_contracts.star
@@ -28,7 +28,10 @@ def run(plan, args):
                 artifact_cfg["name"]: struct(
                     template=template,
                     data=args
-                    | {"zkevm_rollup_consensus": get_consensus_contract(args)},
+                    | {
+                        "is_cdk_validium": args["data_availability_mode"] == "validium",
+                        "zkevm_rollup_consensus": get_consensus_contract(args),
+                    },
                 )
             },
         )

--- a/deploy_zkevm_contracts.star
+++ b/deploy_zkevm_contracts.star
@@ -24,7 +24,13 @@ def run(plan, args):
         template = read_file(src=artifact_cfg["file"])
         artifact = plan.render_templates(
             name=artifact_cfg["name"],
-            config={artifact_cfg["name"]: struct(template=template, data=args)},
+            config={
+                artifact_cfg["name"]: struct(
+                    template=template,
+                    data=args
+                    | {"zkevm_rollup_consensus": get_consensus_contract(args)},
+                )
+            },
         )
         artifacts.append(artifact)
 
@@ -85,3 +91,12 @@ def run(plan, args):
             ]
         ),
     )
+
+
+def get_consensus_contract(args):
+    # Map data availability modes to consensus contracts.
+    consensus_contracts = {
+        "rollup": "PolygonZkEVMEtrog",
+        "validium": "PolygonValidiumEtrog",
+    }
+    return consensus_contracts.get(args["data_availability_mode"])

--- a/doc-drafts/da-mode.md
+++ b/doc-drafts/da-mode.md
@@ -1,0 +1,15 @@
+# Data Availability Modes in Kurtosis CDK
+
+Kurtosis CDK supports two modes of data availability for deploying blockchain solutions: `rollup` and `validium`. The choice between these modes depends on your specific requirements for data availability and security.
+
+The two options are:
+
+- `rollup`: Transaction data is stored on-chain on Layer 1 (L1). This approach leverages the security of the main L1 chain (e.g. Ethereum) to ensure data integrity and availability.
+
+> In this mode, the components will run the `zkevm_node_image` and the consensus contract will be `PolygonZkEVMEtrog`.
+
+- `validium`: Transaction data is stored off-chain using a dedicated Data Availability (DA) layer and a Data Availability Committee (DAC). This approach reduces the load on the main chain and can offer improved scalability and lower costs.
+
+> In this mode, the components will run the `cdk_node_image`, the consensus contract will be `PolygonValidiumEtrog` and the DAC will be deployed and configured.
+
+For more detailed information and technical specifications, refer to the [Polygon Knowledge Layer](https://docs.polygon.technology/cdk/spec/validium-vs-rollup/).

--- a/docs/how-to/migrate/forkid-7-to-9.md
+++ b/docs/how-to/migrate/forkid-7-to-9.md
@@ -42,9 +42,6 @@ This document shows you how to migrate from fork 7 to fork 9 using the Kurtosis 
     # The fork id of the new rollup. It indicates the prover (zkROM/executor) version.
     -  zkevm_rollup_fork_id: 9
     +  zkevm_rollup_fork_id: 7
-
-    # The consensus contract name of the new rollup.
-    zkevm_rollup_consensus: PolygonValidiumEtrog
     ```
 
 3. Now kick-off a full redeploy:

--- a/input_parser.star
+++ b/input_parser.star
@@ -1,6 +1,6 @@
 DEFAULT_ARGS = {
     "deployment_suffix": "-001",
-    "data_availability_mode": "validium",
+    "data_availability_mode": "cdk-validium",
     "zkevm_prover_image": "hermeznetwork/zkevm-prover:v6.0.0",
     "zkevm_node_image": "hermeznetwork/zkevm-node:v0.6.5",
     "cdk_node_image": "0xpolygon/cdk-validium-node:0.6.5-cdk",

--- a/input_parser.star
+++ b/input_parser.star
@@ -1,7 +1,9 @@
 DEFAULT_ARGS = {
     "deployment_suffix": "-001",
+    "data_availability_mode": "validium",
     "zkevm_prover_image": "hermeznetwork/zkevm-prover:v6.0.0",
-    "zkevm_node_image": "0xpolygon/cdk-validium-node:0.6.5-cdk",
+    "zkevm_node_image": "hermeznetwork/zkevm-node:v0.6.5",
+    "cdk_node_image": "0xpolygon/cdk-validium-node:0.6.5-cdk",
     "zkevm_da_image": "0xpolygon/cdk-data-availability:0.0.7",
     "zkevm_contracts_image": "leovct/zkevm-contracts",
     "zkevm_agglayer_image": "0xpolygon/agglayer:0.1.3",
@@ -51,7 +53,6 @@ DEFAULT_ARGS = {
     "l1_additional_services": [],
     "zkevm_rollup_chain_id": 10101,
     "zkevm_rollup_fork_id": 9,
-    "zkevm_rollup_consensus": "PolygonValidiumEtrog",
     "polygon_zkevm_explorer": "https://explorer.private/",
     "l1_explorer_url": "https://sepolia.etherscan.io/",
     "zkevm_use_gas_token_contract": False,

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -30,8 +30,8 @@ description: |-
   # The type of data availability to use.
   # Options:
   # - 'rollup': Transaction data is stored on-chain on L1.
-  # - 'validium': Transaction data is stored off-chain using a DA layer and a DAC.
-  data_availability_mode: validium
+  # - 'cdk-validium': Transaction data is stored off-chain using the CDK DA layer and a DAC.
+  data_availability_mode: cdk-validium
 
   # Docker images and repositories used to spin up services.
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -27,12 +27,19 @@ description: |-
   # Note: It should be a string.
   deployment_suffix: "-001"
 
+  # The type of data availability to use.
+  # Options:
+  # - 'rollup': Transaction data is stored on-chain on L1.
+  # - 'validium': Transaction data is stored off-chain using a DA layer and a DAC.
+  data_availability_mode: validium
+
   # Docker images and repositories used to spin up services.
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
   # zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
 
-  zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.5-cdk
-  # zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
+  zkevm_node_image: hermeznetwork/zkevm-node:v0.6.5
+  cdk_node_image: 0xpolygon/cdk-validium-node:0.6.5-cdk
+  # cdk_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
 
   zkevm_da_image: 0xpolygon/cdk-data-availability:0.0.7
   # zkevm_da_image: 0xpolygon/cdk-data-availability:0.0.6
@@ -42,7 +49,7 @@ description: |-
   zkevm_agglayer_image: 0xpolygon/agglayer:0.1.3
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
   panoptichain_image: minhdvu/panoptichain
-  
+
   # temporary fork https://github.com/praetoriansentry/zkevm-bridge-ui/commit/6eaa899997f70e53947d7b067ff7ae37ef1875f3
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   zkevm_bridge_proxy_image: haproxy:2.9.7
@@ -119,9 +126,6 @@ description: |-
 
   # The fork id of the new rollup. It indicates the prover (zkROM/executor) version.
   zkevm_rollup_fork_id: 9
-
-  # The consensus contract name of the new rollup.
-  zkevm_rollup_consensus: PolygonValidiumEtrog
 
   polygon_zkevm_explorer: https://explorer.private/
   l1_explorer_url: https://sepolia.etherscan.io/

--- a/lib/data_availability.star
+++ b/lib/data_availability.star
@@ -1,0 +1,35 @@
+# The types of data availability (DA) modes supported in Kurtosis CDK.
+# In the future, we would like to support external DA protocols such as Avail, Celestia and Near.
+DATA_AVAILABILITY_MODES = struct(
+    # In rollup mode, transaction data is stored on-chain on L1.
+    rollup="rollup",
+    # In cdk-validium mode, transaction data is stored off-chain using the CDK DA layer and a DAC.
+    cdk_validium="cdk-validium",
+)
+
+# Map data availability modes to node images.
+NODE_IMAGES = {
+    DATA_AVAILABILITY_MODES.rollup: "zkevm_node_image",
+    DATA_AVAILABILITY_MODES.cdk_validium: "cdk_node_image",
+}
+
+# Map data availability modes to consensus contracts.
+CONSENSUS_CONTRACTS = {
+    DATA_AVAILABILITY_MODES.rollup: "PolygonZkEVMEtrog",
+    DATA_AVAILABILITY_MODES.cdk_validium: "PolygonValidiumEtrog",
+}
+
+
+def get_node_image(args):
+    return NODE_IMAGES.get(args["data_availability_mode"])
+
+
+def get_consensus_contract(args):
+    return CONSENSUS_CONTRACTS.get(args["data_availability_mode"])
+
+
+def is_cdk_validium(args):
+    return (
+        args["data_availability_mode"]
+        == data_availability_package.DATA_AVAILABILITY_MODES.cdk_validium
+    )

--- a/lib/data_availability.star
+++ b/lib/data_availability.star
@@ -7,12 +7,6 @@ DATA_AVAILABILITY_MODES = struct(
     cdk_validium="cdk-validium",
 )
 
-# Map data availability modes to node images.
-NODE_IMAGES = {
-    DATA_AVAILABILITY_MODES.rollup: "zkevm_node_image",
-    DATA_AVAILABILITY_MODES.cdk_validium: "cdk_node_image",
-}
-
 # Map data availability modes to consensus contracts.
 CONSENSUS_CONTRACTS = {
     DATA_AVAILABILITY_MODES.rollup: "PolygonZkEVMEtrog",
@@ -21,7 +15,12 @@ CONSENSUS_CONTRACTS = {
 
 
 def get_node_image(args):
-    return NODE_IMAGES.get(args["data_availability_mode"])
+    # Map data availability modes to node images.
+    node_images = {
+        DATA_AVAILABILITY_MODES.rollup: args["zkevm_node_image"],
+        DATA_AVAILABILITY_MODES.cdk_validium: args["cdk_node_image"],
+    }
+    return node_images.get(args["data_availability_mode"])
 
 
 def get_consensus_contract(args):

--- a/lib/data_availability.star
+++ b/lib/data_availability.star
@@ -29,7 +29,4 @@ def get_consensus_contract(args):
 
 
 def is_cdk_validium(args):
-    return (
-        args["data_availability_mode"]
-        == data_availability_package.DATA_AVAILABILITY_MODES.cdk_validium
-    )
+    return args["data_availability_mode"] == DATA_AVAILABILITY_MODES.cdk_validium

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,16 +1,21 @@
 def get_contract_setup_addresses(plan, args):
+    extract = {
+        "zkevm_bridge_address": "fromjson | .polygonZkEVMBridgeAddress",
+        "zkevm_rollup_address": "fromjson | .rollupAddress",
+        "zkevm_rollup_manager_address": "fromjson | .polygonRollupManagerAddress",
+        "zkevm_rollup_manager_block_number": "fromjson | .deploymentRollupManagerBlockNumber",
+        "zkevm_global_exit_root_address": "fromjson | .polygonZkEVMGlobalExitRootAddress",
+        "zkevm_global_exit_root_l2_address": "fromjson | .polygonZkEVMGlobalExitRootL2Address",
+        "pol_token_address": "fromjson | .polTokenAddress",
+    }
+    if args["data_availability_mode"] == "validium":
+        extract[
+            "polygon_data_committee_address"
+        ] = "fromjson | .polygonDataCommitteeAddress"
+
     exec_recipe = ExecRecipe(
         command=["/bin/sh", "-c", "cat /opt/zkevm/combined.json"],
-        extract={
-            "zkevm_bridge_address": "fromjson | .polygonZkEVMBridgeAddress",
-            "zkevm_rollup_address": "fromjson | .rollupAddress",
-            "zkevm_rollup_manager_address": "fromjson | .polygonRollupManagerAddress",
-            "zkevm_rollup_manager_block_number": "fromjson | .deploymentRollupManagerBlockNumber",
-            "zkevm_global_exit_root_address": "fromjson | .polygonZkEVMGlobalExitRootAddress",
-            "zkevm_global_exit_root_l2_address": "fromjson | .polygonZkEVMGlobalExitRootL2Address",
-            "polygon_data_committee_address": "fromjson | .polygonDataCommitteeAddress",
-            "pol_token_address": "fromjson | .polTokenAddress",
-        },
+        extract=extract,
     )
     service_name = "contracts"
     if "zkevm_rollup_manager_address" in args:

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,3 +1,6 @@
+data_availability_package = import_module("./lib/data_availability.star")
+
+
 def get_contract_setup_addresses(plan, args):
     extract = {
         "zkevm_bridge_address": "fromjson | .polygonZkEVMBridgeAddress",
@@ -8,7 +11,7 @@ def get_contract_setup_addresses(plan, args):
         "zkevm_global_exit_root_l2_address": "fromjson | .polygonZkEVMGlobalExitRootL2Address",
         "pol_token_address": "fromjson | .polTokenAddress",
     }
-    if args["data_availability_mode"] == "validium":
+    if data_availability_package.is_cdk_validium(args):
         extract[
             "polygon_data_committee_address"
         ] = "fromjson | .polygonDataCommitteeAddress"

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,4 +1,4 @@
-data_availability_package = import_module("./lib/data_availability.star")
+data_availability_package = import_module("./data_availability.star")
 
 
 def get_contract_setup_addresses(plan, args):

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -1,4 +1,4 @@
-data_availability_package = import_module("./lib/data_availability.star")
+data_availability_package = import_module("./data_availability.star")
 
 NODE_COMPONENTS = struct(
     synchronizer="synchronizer",

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -37,7 +37,7 @@ def _create_node_component_service_config(
 def start_synchronizer(plan, args, config_artifact, genesis_artifact):
     synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
     synchronizer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -53,7 +53,7 @@ def start_synchronizer(plan, args, config_artifact, genesis_artifact):
 def create_sequencer_service_config(args, config_artifact, genesis_artifact):
     sequencer_name = "zkevm-node-sequencer" + args["deployment_suffix"]
     sequencer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "rpc": PortSpec(args["zkevm_rpc_http_port"], application_protocol="http"),
             "data-streamer": PortSpec(
@@ -76,7 +76,7 @@ def create_sequence_sender_service_config(
 ):
     sequence_sender_name = "zkevm-node-sequence-sender" + args["deployment_suffix"]
     sequence_sender_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -105,7 +105,7 @@ def create_aggregator_service_config(
 ):
     aggregator_name = "zkevm-node-aggregator" + args["deployment_suffix"]
     aggregator_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "aggregator": PortSpec(
                 args["zkevm_aggregator_port"], application_protocol="grpc"
@@ -132,7 +132,7 @@ def create_aggregator_service_config(
 def create_rpc_service_config(args, config_artifact, genesis_artifact):
     rpc_name = "zkevm-node-rpc" + args["deployment_suffix"]
     rpc_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "http-rpc": PortSpec(
                 args["zkevm_rpc_http_port"], application_protocol="http"
@@ -159,7 +159,7 @@ def create_eth_tx_manager_service_config(
 ):
     eth_tx_manager_name = "zkevm-node-eth-tx-manager" + args["deployment_suffix"]
     eth_tx_manager_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -182,7 +182,7 @@ def create_eth_tx_manager_service_config(
 def create_l2_gas_pricer_service_config(args, config_artifact, genesis_artifact):
     l2_gas_pricer_name = "zkevm-node-l2-gas-pricer" + args["deployment_suffix"]
     l2_gas_pricer_service_config = _create_node_component_service_config(
-        image=args["zkevm_node_image"],
+        image=get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -237,3 +237,12 @@ def create_zkevm_node_components_config(
         | eth_tx_manager_config
         | l2_gas_pricer_config
     )
+
+
+def get_node_image(args):
+    # Map data availability modes to node images.
+    node_images = {
+        "rollup": args["zkevm_node_image"],
+        "validium": args["cdk_node_image"],
+    }
+    return node_images.get(args["data_availability_mode"])

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -1,4 +1,6 @@
-NODE_COMPONENT = struct(
+data_availability_package = import_module("./lib/data_availability.star")
+
+NODE_COMPONENTS = struct(
     synchronizer="synchronizer",
     sequencer="sequencer",
     sequence_sender="sequence-sender",
@@ -37,7 +39,7 @@ def _create_node_component_service_config(
 def start_synchronizer(plan, args, config_artifact, genesis_artifact):
     synchronizer_name = "zkevm-node-synchronizer" + args["deployment_suffix"]
     synchronizer_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -45,7 +47,7 @@ def start_synchronizer(plan, args, config_artifact, genesis_artifact):
             ),
         },
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
-        components=NODE_COMPONENT.synchronizer,
+        components=NODE_COMPONENTS.synchronizer,
     )
     plan.add_service(name=synchronizer_name, config=synchronizer_service_config)
 
@@ -53,7 +55,7 @@ def start_synchronizer(plan, args, config_artifact, genesis_artifact):
 def create_sequencer_service_config(args, config_artifact, genesis_artifact):
     sequencer_name = "zkevm-node-sequencer" + args["deployment_suffix"]
     sequencer_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "rpc": PortSpec(args["zkevm_rpc_http_port"], application_protocol="http"),
             "data-streamer": PortSpec(
@@ -65,7 +67,7 @@ def create_sequencer_service_config(args, config_artifact, genesis_artifact):
             ),
         },
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
-        components=NODE_COMPONENT.sequencer + "," + NODE_COMPONENT.rpc,
+        components=NODE_COMPONENTS.sequencer + "," + NODE_COMPONENTS.rpc,
         http_api="eth,net,debug,zkevm,txpool,web3",
     )
     return {sequencer_name: sequencer_service_config}
@@ -76,7 +78,7 @@ def create_sequence_sender_service_config(
 ):
     sequence_sender_name = "zkevm-node-sequence-sender" + args["deployment_suffix"]
     sequence_sender_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -90,7 +92,7 @@ def create_sequence_sender_service_config(
                 sequencer_keystore_artifact,
             ]
         ),
-        components=NODE_COMPONENT.sequence_sender,
+        components=NODE_COMPONENTS.sequence_sender,
     )
     return {sequence_sender_name: sequence_sender_service_config}
 
@@ -105,7 +107,7 @@ def create_aggregator_service_config(
 ):
     aggregator_name = "zkevm-node-aggregator" + args["deployment_suffix"]
     aggregator_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "aggregator": PortSpec(
                 args["zkevm_aggregator_port"], application_protocol="grpc"
@@ -124,7 +126,7 @@ def create_aggregator_service_config(
                 proofsigner_keystore_artifact,
             ]
         ),
-        components=NODE_COMPONENT.aggregator,
+        components=NODE_COMPONENTS.aggregator,
     )
     return {aggregator_name: aggregator_service_config}
 
@@ -132,7 +134,7 @@ def create_aggregator_service_config(
 def create_rpc_service_config(args, config_artifact, genesis_artifact):
     rpc_name = "zkevm-node-rpc" + args["deployment_suffix"]
     rpc_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "http-rpc": PortSpec(
                 args["zkevm_rpc_http_port"], application_protocol="http"
@@ -144,7 +146,7 @@ def create_rpc_service_config(args, config_artifact, genesis_artifact):
             ),
         },
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
-        components=NODE_COMPONENT.rpc,
+        components=NODE_COMPONENTS.rpc,
         http_api="eth,net,debug,zkevm,txpool,web3",
     )
     return {rpc_name: rpc_service_config}
@@ -159,7 +161,7 @@ def create_eth_tx_manager_service_config(
 ):
     eth_tx_manager_name = "zkevm-node-eth-tx-manager" + args["deployment_suffix"]
     eth_tx_manager_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -174,7 +176,7 @@ def create_eth_tx_manager_service_config(
                 aggregator_keystore_artifact,
             ]
         ),
-        components=NODE_COMPONENT.eth_tx_manager,
+        components=NODE_COMPONENTS.eth_tx_manager,
     )
     return {eth_tx_manager_name: eth_tx_manager_service_config}
 
@@ -182,7 +184,7 @@ def create_eth_tx_manager_service_config(
 def create_l2_gas_pricer_service_config(args, config_artifact, genesis_artifact):
     l2_gas_pricer_name = "zkevm-node-l2-gas-pricer" + args["deployment_suffix"]
     l2_gas_pricer_service_config = _create_node_component_service_config(
-        image=get_node_image(args),
+        image=data_availability_package.get_node_image(args),
         ports={
             "pprof": PortSpec(args["zkevm_pprof_port"], application_protocol="http"),
             "prometheus": PortSpec(
@@ -190,7 +192,7 @@ def create_l2_gas_pricer_service_config(args, config_artifact, genesis_artifact)
             ),
         },
         config_files=Directory(artifact_names=[config_artifact, genesis_artifact]),
-        components=NODE_COMPONENT.l2_gas_pricer,
+        components=NODE_COMPONENTS.l2_gas_pricer,
     )
     return {l2_gas_pricer_name: l2_gas_pricer_service_config}
 
@@ -237,12 +239,3 @@ def create_zkevm_node_components_config(
         | eth_tx_manager_config
         | l2_gas_pricer_config
     )
-
-
-def get_node_image(args):
-    # Map data availability modes to node images.
-    node_images = {
-        "rollup": args["zkevm_node_image"],
-        "validium": args["cdk_node_image"],
-    }
-    return node_images.get(args["data_availability_mode"])

--- a/params.yml
+++ b/params.yml
@@ -40,8 +40,9 @@ args:
   # The type of data availability to use.
   # Options:
   # - 'rollup': Transaction data is stored on-chain on L1.
-  # - 'validium': Transaction data is stored off-chain using a DA layer and a DAC.
-  data_availability_mode: validium
+  # - 'cdk-validium': Transaction data is stored off-chain using the CDK DA layer and a DAC.
+  # In the future, we would like to support external DA protocols such as avail, celestia and near.
+  data_availability_mode: cdk-validium
 
   # Docker images and repositories used to spin up services.
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0

--- a/params.yml
+++ b/params.yml
@@ -37,12 +37,19 @@ args:
   # Note: It should be a string.
   deployment_suffix: "-001"
 
+  # The type of data availability to use.
+  # Options:
+  # - 'rollup': Transaction data is stored on-chain on L1.
+  # - 'validium': Transaction data is stored off-chain using a DA layer and a DAC.
+  data_availability_mode: validium
+
   # Docker images and repositories used to spin up services.
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.0
   # zkevm_prover_image: hermeznetwork/zkevm-prover:v4.0.19
 
-  zkevm_node_image: 0xpolygon/cdk-validium-node:0.6.5-cdk
-  # zkevm_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
+  zkevm_node_image: hermeznetwork/zkevm-node:v0.6.5
+  cdk_node_image: 0xpolygon/cdk-validium-node:0.6.5-cdk
+  # cdk_node_image: 0xpolygon/cdk-validium-node:0.5.13-cdk.3
 
   zkevm_da_image: 0xpolygon/cdk-data-availability:0.0.7
   # zkevm_da_image: 0xpolygon/cdk-data-availability:0.0.6
@@ -135,9 +142,6 @@ args:
   # zkevm_global_exit_root_l2_address: ""
   # # The address of the Polygon data committee contract on L1.
   # polygon_data_committee_address: ""
-
-  # The consensus contract name of the new rollup.
-  zkevm_rollup_consensus: PolygonValidiumEtrog
 
   polygon_zkevm_explorer: https://explorer.private/
   l1_explorer_url: https://sepolia.etherscan.io/

--- a/scripts/compare_default_params.sh
+++ b/scripts/compare_default_params.sh
@@ -4,13 +4,13 @@
 # The true reference for default parameters is params.yml.
 
 echo "Dumping default parameters..."
-sed -n '/DEFAULT_ARGS = {/,/}/ { s/DEFAULT_ARGS = //; s/}/}/; p; }' input_parser.star | yq --yaml-output > default-args.yml
+sed -n '/DEFAULT_ARGS = {/,/}/ { s/DEFAULT_ARGS = //; s/}/}/; p; }' input_parser.star | yq --yaml-output > input-parser-args.yml
 # shellcheck disable=SC2016
 sed -n '/```yml/,/```/ { /```yml/d; /```/d; p;}' kurtosis.yml | yq --yaml-output > kurtosis-args.yml
 yq --yaml-output .args params.yml > params-args.yml
 
-echo; echo "Diff default-args.yml <> params-args.yml"
-diff default-args.yml params-args.yml
+echo; echo "Diff input-parser-args.yml <> params-args.yml"
+diff input-parser-args.yml params-args.yml
 
 echo; echo "Diff kurtosis-args.yml <> params-args.yml"
 diff kurtosis-args.yml params-args.yml

--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -151,6 +151,7 @@ cast send \
     'approve(address,uint256)(bool)' \
     "$(jq -r '.rollupAddress' combined.json)" 1000000000000000000000000000
 
+{{if .is_cdk_validium}}
 # The DAC needs to be configured with a required number of signatures.
 # Right now the number of DAC nodes is not configurable.
 # If we add more nodes, we'll need to make sure the urls and keys are sorted.
@@ -170,6 +171,7 @@ cast send \
     "$(jq -r '.rollupAddress' combined.json)" \
     'setDataAvailabilityProtocol(address)' \
     "$(jq -r '.polygonDataCommitteeAddress' combined.json)"
+{{end}}
 
 # Grant the aggregator role to the agglayer so that it can also verify batches.
 # cast keccak "TRUSTED_AGGREGATOR_ROLE"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Introduce a new parameter `data_availability_mode` in `params.yml` to specify the type of data availability to use.

The two options are:

- `rollup`: Transaction data is stored on-chain on L1.
> In this mode, the components will run the `zkevm_node_image` and the consensus contract will be `PolygonZkEVMEtrog`.

- `validium`: Transaction data is stored off-chain using a DA layer and a DAC. 
> In this mode, the components will run the `cdk_node_image`, the consensus contract will be `PolygonValidiumEtrog` and the DAC will be deployed and configured.

Also two new CI jobs `rollup-da-mode` and `validium-da-mode` and a doc regarding da-modes have been added

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://polygon.atlassian.net/browse/DVT-1518
- Closes https://github.com/0xPolygon/kurtosis-cdk/issues/117
