### PR TITLE
test: speed up l1 block time

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -32,6 +32,7 @@ def run(plan, args):
                 "preregistered_validator_keys_mnemonic": args[
                     "l1_preallocated_mnemonic"
                 ],
+                "seconds_per_slot": 2, # 2 seconds block time instead of 12 by default.
             },
             "additional_services": args["l1_additional_services"],
         },


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Block time is now set to 2s instead of 12s (default).

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
