### PR TITLE
ci: fix external contributors pr failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@
 name: Deploy Kurtosis CDK
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches: [main]
 
@@ -11,22 +11,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Job that requires project maintainers to approve PR to access Github Action secrets.
-  # https://dvc.ai/blog/testing-external-contributions-using-github-actions-secrets
-  authorize:
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
   # Deploy the CDK environment in one step, with the gas token feature enabled.
   monolithic:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-go@v5
         with:
@@ -35,6 +24,9 @@ jobs:
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
+
+      - name: Enable workload
+        run: yq -Y --in-place '.apply_workload = true' params.yml
 
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
@@ -62,12 +54,9 @@ jobs:
 
   # Deploy the CDK environment incrementally, stage by stage.
   incremental:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -146,12 +135,9 @@ jobs:
 
   # Deploy the CDK environment without specifying any parameter file.
   configless:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -165,12 +151,9 @@ jobs:
 
   # Deploy the CDK environment with the gas token feature enabled.
   gas-token:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -186,12 +169,9 @@ jobs:
 
   # Deploy the CDK environment against a local l1 chain with pre-deployed zkevm contracts.
   pre-deployed-contracts:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -233,12 +213,9 @@ jobs:
 
   # Deploy a standalone permisionless node against Sepolia.
   permisionless-node:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -257,12 +234,9 @@ jobs:
 
   # Deploy the CDK environment in rollup mode (data availability).
   rollup-da-mode:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -278,12 +252,9 @@ jobs:
 
   # Deploy the CDK environment in cdk-validium mode (data availability).
   cdk-validium-da-mode:
-    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@
 name: Deploy Kurtosis CDK
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches: [main]
 
@@ -11,11 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Job that requires project maintainers to approve PR to access Github Action secrets.
+  # https://dvc.ai/blog/testing-external-contributions-using-github-actions-secrets
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ✅
+
   # Deploy the CDK environment in one step, with the gas token feature enabled.
   monolithic:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - uses: actions/setup-go@v5
         with:
@@ -51,9 +62,12 @@ jobs:
 
   # Deploy the CDK environment incrementally, stage by stage.
   incremental:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -132,9 +146,12 @@ jobs:
 
   # Deploy the CDK environment without specifying any parameter file.
   configless:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -148,9 +165,12 @@ jobs:
 
   # Deploy the CDK environment with the gas token feature enabled.
   gas-token:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -166,9 +186,12 @@ jobs:
 
   # Deploy the CDK environment against a local l1 chain with pre-deployed zkevm contracts.
   pre-deployed-contracts:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -210,9 +233,12 @@ jobs:
 
   # Deploy a standalone permisionless node against Sepolia.
   permisionless-node:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -231,9 +257,12 @@ jobs:
 
   # Deploy the CDK environment in rollup mode (data availability).
   rollup-da-mode:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
@@ -249,9 +278,12 @@ jobs:
 
   # Deploy the CDK environment in cdk-validium mode (data availability).
   cdk-validium-da-mode:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install Kurtosis CDK tools
         uses: ./.github/actions/setup-kurtosis-cdk
 
-      - name: Enable workload
-        run: yq -Y --in-place '.apply_workload = true' params.yml
-
       - name: Deploy Kurtosis CDK package
         run: kurtosis run --enclave cdk-v1 --args-file params.yml --image-download always .
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo ✅
+      - run: true
 
   # Deploy the CDK environment in one step, with the gas token feature enabled.
   monolithic:

--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -5,12 +5,20 @@ on:
     branches:
       - main
   workflow_dispatch: {}
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
 
 jobs:
+  # Job that requires project maintainers to approve PR to access Github Action secrets.
+  # https://dvc.ai/blog/testing-external-contributions-using-github-actions-secrets
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   sonarcloud:
     name: SonarCloud
+    needs: authorize
     runs-on: ubuntu-latest
     if: github.repository == '0xPolygon/kurtosis-cdk'
     steps:

--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           # Disabling shallow clone is recommended for improving relevancy of reporting.
           fetch-depth: 0
 

--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -17,16 +17,17 @@ jobs:
       - run: true
 
   sonarcloud:
-    name: SonarCloud
     needs: authorize
     runs-on: ubuntu-latest
+    # Prevent this job to run on forks.
     if: github.repository == '0xPolygon/kurtosis-cdk'
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+          # Disabling shallow clone is recommended for improving relevancy of reporting.
+          fetch-depth: 0
+
+      - uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -14,7 +14,7 @@ jobs:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo ✅
+      - run: true
 
   sonarcloud:
     needs: authorize

--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
   pull_request_target:
+  workflow_dispatch:
 
 jobs:
   # Job that requires project maintainers to approve PR to access Github Action secrets.
@@ -14,7 +14,7 @@ jobs:
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: echo ✅
 
   sonarcloud:
     needs: authorize


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Introduce an `authorize` job that allows code maintainers to approve a pull request to use the GitHub Action secrets. This ensures that any job requiring secrets can function for both internal and external PRs.

This is a test implementation and should only be applied to the security build job for now. If it proves successful, we will extend it to the deploy job, which also requires secret access.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://dvc.ai/blog/testing-external-contributions-using-github-actions-secrets