### PR TITLE
ci: prevent docker image builder cron job to run on forks

### DIFF
--- a/.github/workflows/docker-image-builder-cron.yml
+++ b/.github/workflows/docker-image-builder-cron.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   zkevm-contracts:
+    if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
 
     strategy:
@@ -60,6 +61,7 @@ jobs:
           push: true
 
   zkevm-bridge-ui:
+    if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -94,6 +96,7 @@ jobs:
           push: true
 
   toolbox:
+    if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-image-builder-cron.yml
+++ b/.github/workflows/docker-image-builder-cron.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   zkevm-contracts:
+    # Prevent this job to run on forks.
     if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
 
@@ -61,6 +62,7 @@ jobs:
           push: true
 
   zkevm-bridge-ui:
+    # Prevent this job to run on forks.
     if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +98,7 @@ jobs:
           push: true
 
   toolbox:
+    # Prevent this job to run on forks.
     if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

This workflow should only run on the main repository. On top of that, the jobs will fail on forks because `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` will not be defined.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/leovct/kurtosis-cdk/actions/runs/9345127975