### PR TITLE
ci: prevent `permisionless-node` job to fail on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
 
   # Deploy the CDK environment in one step, with the gas token feature enabled.
   monolithic:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +63,7 @@ jobs:
 
   # Deploy the CDK environment incrementally, stage by stage.
   incremental:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -143,6 +145,7 @@ jobs:
 
   # Deploy the CDK environment without specifying any parameter file.
   configless:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -159,6 +162,7 @@ jobs:
 
   # Deploy the CDK environment with the gas token feature enabled.
   gas-token:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -177,6 +181,7 @@ jobs:
 
   # Deploy the CDK environment against a local l1 chain with pre-deployed zkevm contracts.
   pre-deployed-contracts:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -245,6 +250,7 @@ jobs:
 
   # Deploy the CDK environment in rollup mode (data availability).
   rollup-da-mode:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -263,6 +269,7 @@ jobs:
 
   # Deploy the CDK environment in cdk-validium mode (data availability).
   cdk-validium-da-mode:
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@
 name: Deploy Kurtosis CDK
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches: [main]
 
@@ -11,6 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Job that requires project maintainers to approve PR to access Github Action secrets.
+  # https://dvc.ai/blog/testing-external-contributions-using-github-actions-secrets
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   # Deploy the CDK environment in one step, with the gas token feature enabled.
   monolithic:
     runs-on: ubuntu-latest
@@ -213,6 +221,9 @@ jobs:
 
   # Deploy a standalone permisionless node against Sepolia.
   permisionless-node:
+    needs: authorize
+    # Prevent this job to run on forks.
+    if: github.repository == '0xPolygon/kurtosis-cdk'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Introduce an `authorize` job that allows code maintainers to approve a pull request to use the GitHub Action secrets. This ensures that any job requiring secrets can function for both internal and external PRs.

A test has already been done with the Security Build job. It worked well (#139). We now do the same for the `deploy` workflow which requires secret access to get the RPC URL.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

Follow up of #139 
