### PR TITLE
chore: update port names

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If the number of verified batches is increasing, then it means the system works 
 To access the `zkevm-bridge` user interface, open this URL in your web browser.
 
 ```bash
-open $(kurtosis port print cdk-v1 zkevm-bridge-proxy-001 bridge-interface)
+open $(kurtosis port print cdk-v1 zkevm-bridge-proxy-001 web-ui)
 ```
 
 When everything is done, you might want to clean up with this command which stops everything and deletes it.

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -148,9 +148,9 @@ def create_reverse_proxy_config_artifact(plan, args):
                     "l2rpc_ip": l2rpc_service.ip_address,
                     "l2rpc_port": l2rpc_service.ports["http-rpc"].number,
                     "bridgeservice_ip": bridge_service.ip_address,
-                    "bridgeservice_port": bridge_service.ports["bridge-rpc"].number,
+                    "bridgeservice_port": bridge_service.ports["rpc"].number,
                     "bridgeui_ip": bridgeui_service.ip_address,
-                    "bridgeui_port": bridgeui_service.ports["bridge-ui"].number,
+                    "bridgeui_port": bridgeui_service.ports["web-ui"].number,
                 },
             )
         },

--- a/docs/how-to/use-native-token.md
+++ b/docs/how-to/use-native-token.md
@@ -2,7 +2,7 @@
 comments: true
 ---
 
-This document show you how you to set up and test a native token in a CDK stack. 
+This document show you how you to set up and test a native token in a CDK stack.
 
 ## Summary
 
@@ -11,7 +11,7 @@ This document show you how you to set up and test a native token in a CDK stack.
 
     Even when employing a gas token within a layer, it remains feasible to transfer L1 ETH to that layer. In such instances, the ETH is recorded within an ERC20 contract known as W-ETH, functioning as another instance of an ERC20 token.
 
-The diagram below illustrates the interchange of assets between layers, focusing on LY as a layer of interest. 
+The diagram below illustrates the interchange of assets between layers, focusing on LY as a layer of interest.
 
 It depicts several scenarios, such as bridging an ERC20 token from mainnet to another ERC20 token in LY, bridging L1 ETH to the LY gas token, or bridging a wrapped ERC20 token living on LX to LY ETH.
 
@@ -33,8 +33,8 @@ It depicts several scenarios, such as bridging an ERC20 token from mainnet to an
     !!! tip
         For full set up and deploy instructions, check out the [quickstart](../quickstart/deploy-stack.md) documentation.
 
-    It takes a few minutes to compile and deploy the full set of contracts. 
-    
+    It takes a few minutes to compile and deploy the full set of contracts.
+
     The screenshot below shows the full set of deployed services and highlights the bridge UI, L1 RPC, and L2 RPC services which we will focus on throughout this document.
 
     ![Deployed services](../img/how-to/gas-token-img/services.png)
@@ -72,10 +72,10 @@ It depicts several scenarios, such as bridging an ERC20 token from mainnet to an
 
 ### Open the bridge UI
 
-Run the following command to get the bridge UI URL and then open the URL in your browser. 
+Run the following command to get the bridge UI URL and then open the URL in your browser.
 
 ```sh
-kurtosis port print cdk-v1 zkevm-bridge-proxy-001 bridge-interface
+kurtosis port print cdk-v1 zkevm-bridge-proxy-001 web-ui
 ```
 
 ### Add L1 and L2 RPCs to your wallet
@@ -96,7 +96,7 @@ As the URLs use HTTP, instead of HTTPS, you need to [manually add them to MetaMa
 
 ### Import an account
 
-If you used the [pre-allocated mnemonic](https://github.com/0xPolygon/kurtosis-cdk/blob/be17ee3ec3b67d086a0155f3deab5ad009034c8b/params.yml#L147), you need to [import an account](https://support.metamask.io/hc/en-us/articles/360015489331-How-to-import-an-account#h_01G01W07NV7Q94M7P1EBD5BYM4) using a private key. 
+If you used the [pre-allocated mnemonic](https://github.com/0xPolygon/kurtosis-cdk/blob/be17ee3ec3b67d086a0155f3deab5ad009034c8b/params.yml#L147), you need to [import an account](https://support.metamask.io/hc/en-us/articles/360015489331-How-to-import-an-account#h_01G01W07NV7Q94M7P1EBD5BYM4) using a private key.
 
 The first derived private key from the `code...quality` mnemonic is
 `42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa`.
@@ -137,7 +137,7 @@ The first derived private key from the `code...quality` mnemonic is
 
     ![Token bridging processing](../img/how-to/gas-token-img/06_bridge.png)
 
-4. After some time, the transaction should complete. 
+4. After some time, the transaction should complete.
 
     ![Bridging complete](../img/how-to/gas-token-img/07_bridge.png)
 
@@ -173,8 +173,8 @@ The first derived private key from the `code...quality` mnemonic is
     ![Balance of receiving account](../img/how-to/gas-token-img/11_bridge.png)
 
     !!! warning
-        - As of 2024-03-27, there might be a small bug in the bridge UI which causes the transaction not to be claimable on L1 with the UI. 
-        - Essentially the bridge UI is selecting the wrong destination network so the proof will not validate. 
+        - As of 2024-03-27, there might be a small bug in the bridge UI which causes the transaction not to be claimable on L1 with the UI.
+        - Essentially the bridge UI is selecting the wrong destination network so the proof will not validate.
         - That being said, it's possible to claim directly using the smart contracts.
 
 2. Click **Finalize**.
@@ -183,7 +183,7 @@ The first derived private key from the `code...quality` mnemonic is
 
 ## Using cast to withdraw assets from the bridge
 
-The following work-in-progress cast script processes a bridge claim. 
+The following work-in-progress cast script processes a bridge claim.
 
 Feel free to go through line-by-line and tweak where necessary.
 
@@ -203,7 +203,7 @@ bridge_addr="$(kurtosis service exec cdk-v1 contracts-001 "cat /opt/zkevm/combin
 
 # Grab the endpoints for l1 and the bridge service
 l1_rpc_url=$(kurtosis port print cdk-v1 el-1-geth-lighthouse rpc)
-bridge_api_url="$(kurtosis port print cdk-v1 zkevm-bridge-service-001 bridge-rpc)"
+bridge_api_url="$(kurtosis port print cdk-v1 zkevm-bridge-service-001 rpc)"
 
 # The signature for claiming is long - just putting it into a var
 claim_sig="claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)"
@@ -267,7 +267,7 @@ You should see something like this:
 
 ![Output from cast bridging script](../img/how-to/gas-token-img/14_bridge.png)
 
-Confirm the claim went through using MetaMask and the bridge UI. 
+Confirm the claim went through using MetaMask and the bridge UI.
 
 ![MetaMask confirmation](../img/how-to/gas-token-img/15_bridge.png)
 

--- a/lib/zkevm_bridge.star
+++ b/lib/zkevm_bridge.star
@@ -3,10 +3,10 @@ def create_bridge_service_config(args, config_artifact, claimtx_keystore_artifac
     bridge_service_config = ServiceConfig(
         image=args["zkevm_bridge_service_image"],
         ports={
-            "bridge-rpc": PortSpec(
+            "rpc": PortSpec(
                 args["zkevm_bridge_rpc_port"], application_protocol="http"
             ),
-            "bridge-grpc": PortSpec(
+            "grpc": PortSpec(
                 args["zkevm_bridge_grpc_port"], application_protocol="grpc"
             ),
         },
@@ -29,7 +29,7 @@ def start_bridge_ui(plan, args, config_artifact):
         config=ServiceConfig(
             image=args["zkevm_bridge_ui_image"],
             ports={
-                "bridge-ui": PortSpec(
+                "web-ui": PortSpec(
                     args["zkevm_bridge_ui_port"], application_protocol="http"
                 ),
             },
@@ -51,7 +51,7 @@ def start_reverse_proxy(plan, args, config_artifact):
         config=ServiceConfig(
             image=args["zkevm_bridge_proxy_image"],
             ports={
-                "bridge-interface": PortSpec(
+                "web-ui": PortSpec(
                     number=80,
                     application_protocol="http",
                 ),

--- a/lib/zkevm_prover.star
+++ b/lib/zkevm_prover.star
@@ -24,10 +24,10 @@ def _start_service(plan, type, args, config_artifact):
         config=ServiceConfig(
             image=args["zkevm_prover_image"],
             ports={
-                "hash-db-server": PortSpec(
+                "hash-db": PortSpec(
                     args["zkevm_hash_db_port"], application_protocol="grpc"
                 ),
-                "executor-server": PortSpec(
+                "executor": PortSpec(
                     args["zkevm_executor_port"], application_protocol="grpc"
                 ),
             },

--- a/scripts/bridge-manual-claim.sh
+++ b/scripts/bridge-manual-claim.sh
@@ -13,7 +13,7 @@ bridge_addr="$(kurtosis service exec cdk-v1 contracts-001 "cat /opt/zkevm/combin
 
 # Grab the endpoints for l1 and the bridge service
 l1_rpc_url=$(kurtosis port print cdk-v1 el-1-geth-lighthouse rpc)
-bridge_api_url="$(kurtosis port print cdk-v1 zkevm-bridge-service-001 bridge-rpc)"
+bridge_api_url="$(kurtosis port print cdk-v1 zkevm-bridge-service-001 rpc)"
 
 # The signature for claiming is long - just putting it into a var
 claim_sig="claimAsset(bytes32[32],bytes32[32],uint256,bytes32,bytes32,uint32,address,uint32,address,uint256,bytes)"

--- a/workload.star
+++ b/workload.star
@@ -19,7 +19,7 @@ def run(plan, args):
         "zkevm-bridge-service" + args["deployment_suffix"]
     )
     zkevm_bridge_api_url = "http://{}:{}".format(
-        zkevm_bridge_service.ip_address, zkevm_bridge_service.ports["bridge-rpc"].number
+        zkevm_bridge_service.ip_address, zkevm_bridge_service.ports["rpc"].number
     )
 
     workload_script_artifact = plan.render_templates(


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

**🚨 Breaking Change! 🚨**

Kubernetes adheres to [RFC-6335](https://www.rfc-archive.org/getrfc.php?rfc=6335#gsc.tab=0), which specifies a character limit for port names ranging from 1 to 15 characters. However, some of the port names defined in the Kurtosis CDK exceed this 15-character limit. This PR addresses this issue by shortening the port names and updating some of the ports with more appropriate names.

- `zkevm-bridge-service`: 
  - `bridge-rpc` => `rpc`
  - `bridge-grpc` => `grpc`
- `zkevm-bridge-ui`: `bridge-ui` => `web-ui`
- `zkevm-bridge-proxy`: `bridge-interface` => `web-ui`
-  `zkevm-prover` / `zkevm-executor`:
    - `hash-db-server` => `hash-db`
    - `executor-server` => `executor` 

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://polygon.atlassian.net/browse/DVT-1520
