### PR TITLE
[bug] fix eth star dependency

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/ethpandaops/ethereum-package/main.star@4.0.0"
+    "github.com/kurtosis-tech/ethereum-package/main.star@3.0.0"
 )
 
 GETH_IMAGE = "ethereum/client-go:v1.14.0"


### PR DESCRIPTION
## Description
fix ethereum.star dependency which is breaking all local kurtosis-cdk runs. the ethpandaops package appears unstable..

## References (if applicable)
current error logs, which are resolved by the package switch in this PR: 
`root@dan-cdk-tests:~/kurtosis-cdk# kurtosis run --enclave cdk-v1 --args-file cdk-erigon-sequencer-params.yml --image-download always .
INFO[2024-06-20T19:20:22Z] Engine running in Kubernetes cluster, to connect to the engine from outside the cluster run 'kurtosis gateway' to open a local gateway to the engine 
INFO[2024-06-20T19:20:22Z] Creating a new enclave for Starlark to run inside... 
INFO[2024-06-20T19:20:43Z] Enclave 'cdk-v1' created successfully        
INFO[2024-06-20T19:20:43Z] Executing Starlark package at '/root/kurtosis-cdk' as the passed argument '.' looks like a directory 
INFO[2024-06-20T19:20:43Z] Compressing package 'github.com/0xPolygon/kurtosis-cdk' at '.' for upload 
INFO[2024-06-20T19:20:44Z] Uploading and executing package 'github.com/0xPolygon/kurtosis-cdk' 
There was an error interpreting Starlark code 
Evaluation error: Cannot construct 'run_sh' from the provided arguments.
        Caused by: run_sh: unexpected keyword argument "name"
        at [github.com/0xPolygon/kurtosis-cdk/main.star:63:44]: run
        at [github.com/0xPolygon/kurtosis-cdk/ethereum.star:10:25]: run
        at [github.com/ethpandaops/ethereum-package/main.star@4.0.0:127:55]: run
        at [github.com/ethpandaops/ethereum-package/src/participant_network.star:88:78]: launch_participant_network
        at [github.com/ethpandaops/ethereum-package/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star:89:26]: generate_el_cl_genesis_data
        at [0:0]: run_sh`
        
**TESTS**
confirmed after updating dependency errors disappears.. 

