### PR TITLE
fix(cdk-erigon): add admin contract addr

### DIFF
--- a/lib/service.star
+++ b/lib/service.star
@@ -10,6 +10,7 @@ def get_contract_setup_addresses(plan, args):
         "zkevm_global_exit_root_address": "fromjson | .polygonZkEVMGlobalExitRootAddress",
         "zkevm_global_exit_root_l2_address": "fromjson | .polygonZkEVMGlobalExitRootL2Address",
         "pol_token_address": "fromjson | .polTokenAddress",
+        "zkevm_admin_address": "fromjson | .admin",
     }
     if data_availability_package.is_cdk_validium(args):
         extract[


### PR DESCRIPTION
## Description
cdk-erigon should mandate the admin contract address be in config (fixed here: https://github.com/0xPolygonHermez/cdk-erigon/pull/673).

## References (if applicable)
PR which enforces the requirement in cdk-erigon: https://github.com/0xPolygonHermez/cdk-erigon/pull/673
