### PR TITLE
fix: config for sequencer uri on permissionless node

### DIFF
--- a/templates/permissionless-node/node-config.toml
+++ b/templates/permissionless-node/node-config.toml
@@ -75,7 +75,7 @@ WriteTimeout = "60s"
 BatchRequestsEnabled = true
 BatchRequestsLimit = 500
 MaxRequestsPerIPAndSecond = 5000
-SequencerNodeURI = "{{.sequencer_name}}{{.deployment_suffix}}:{{.zkevm_data_streamer_port}}"
+SequencerNodeURI = ""
 EnableL2SuggestedGasPricePolling = true
         [RPC.WebSockets]
                 Enabled = true


### PR DESCRIPTION
## Description
This config change fixes permissionless nodes not being able to reach the sequencer when deploying multiple permissionless nodes with varying suffixes by inferring the sequencer address from the smart contract directly.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
![Screenshot from 2024-07-09 11-18-57](https://github.com/0xPolygon/kurtosis-cdk/assets/125336262/ac8c09dc-94c0-465a-8a63-40d1078c3f9b)
