### PR TITLE
ci: hide `cast send` output in `batch_verification_monitor.sh`

### DIFF
--- a/.github/actions/monitor-cdk-verified-batches/batch_verification_monitor.sh
+++ b/.github/actions/monitor-cdk-verified-batches/batch_verification_monitor.sh
@@ -25,22 +25,27 @@ start_time=$(date +%s)
 end_time=$((start_time + timeout))
 
 rpc_url="$(kurtosis port print cdk-v1 $rpc_service http-rpc)"
-pk="0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625"
 
 while true; do
   verified_batches="$(cast to-dec "$(cast rpc --rpc-url "$rpc_url" zkevm_verifiedBatchNumber | sed 's/"//g')")"
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
-  # This is here to take up somce space within the batch in order to make sure the batches actually increase during the duration of the test
-  cast send --legacy --rpc-url "$rpc_url" --private-key "$pk" --gas-limit 643528 --create 0x600160015B810190630000000456
+  # This is here to take up somce space within the batch in order to make sure the batches actually increase during the duration of the test.
+  cast send \
+    --legacy \
+    --rpc-url "$rpc_url" \
+    --private-key "0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625" \
+    --gas-limit 643528 \
+    --create 0x600160015B810190630000000456 \
+    >/dev/null 2>&1
 
   current_time=$(date +%s)
-  if (( current_time > end_time )); then
+  if ((current_time > end_time)); then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ Exiting... Timeout reached!"
     exit 1
   fi
 
-  if (( verified_batches > verified_batches_target )); then
+  if ((verified_batches > verified_batches_target)); then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... $verified_batches batches were verified!"
     exit 0
   fi

--- a/.github/actions/monitor-cdk-verified-batches/batch_verification_monitor.sh
+++ b/.github/actions/monitor-cdk-verified-batches/batch_verification_monitor.sh
@@ -30,7 +30,7 @@ while true; do
   verified_batches="$(cast to-dec "$(cast rpc --rpc-url "$rpc_url" zkevm_verifiedBatchNumber | sed 's/"//g')")"
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Verified Batches: $verified_batches"
 
-  # This is here to take up somce space within the batch in order to make sure the batches actually increase during the duration of the test.
+  # The aim is to take up some space in the batch, so that the number of batches actually increases during the test.
   cast send \
     --legacy \
     --rpc-url "$rpc_url" \


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Improve the readability of logs.

<img width="1695" alt="Screenshot 2024-08-01 at 16 55 46" src="https://github.com/user-attachments/assets/3328f5b2-ec65-4e97-9d7f-ca8ac903251e">

For reference: https://github.com/0xPolygon/kurtosis-cdk/actions/runs/10192893388/job/28196535749#step:5:11

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

x