### PR TITLE
chore: sort packages and flags in `apt-get install` commands

### DIFF
--- a/docker/toolbox.Dockerfile
+++ b/docker/toolbox.Dockerfile
@@ -17,7 +17,7 @@ COPY --from=polycli-builder /opt/polygon-cli/bindings /opt/bindings
 # WARNING (SC1091): (Sourced) file not included in mock.
 # hadolint ignore=DL3008,DL3013,DL4006,SC1091
 RUN apt-get update \
-  && apt-get install --yes --no-install-recommends curl jq git python3-pip \
+  && apt-get install --no-install-recommends --yes curl git jq python3-pip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install --no-cache-dir yq \

--- a/docker/zkevm-contracts.Dockerfile
+++ b/docker/zkevm-contracts.Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /opt
 # WARNING (DL4006): Set the SHELL option -o pipefail before RUN with a pipe in it
 # hadolint ignore=DL3008,DL3013,DL4006
 RUN apt-get update \
-  && apt-get install --yes --no-install-recommends jq python3-pip \
+  && apt-get install --no-install-recommends --yes jq python3-pip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install --break-system-packages --no-cache-dir yq \


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- Sort packages in `apt-get install` command to fix the security issue.
- Also sort the flags in the same command for readability.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/0xPolygon/kurtosis-cdk/security/code-scanning/13