### PR TITLE
Remove `zkevm.sequencer-non-empty-batch-seal-time` from config

### DIFF
--- a/templates/cdk-erigon/config.yml
+++ b/templates/cdk-erigon/config.yml
@@ -37,10 +37,8 @@ zkevm.executor-urls: zkevm-stateless-executor{{.deployment_suffix}}:{{.zkevm_exe
 zkevm.executor-strict: false
 # end {{end}}
 
-
 zkevm.sequencer-batch-seal-time: 12s # 12s
 zkevm.sequencer-block-seal-time: 6s # 6s
-zkevm.sequencer-non-empty-batch-seal-time: 3s # 3s
 
 zkevm.pool-manager-url: "http://zkevm-pool-manager{{.deployment_suffix}}:{{.zkevm_pool_manager_port}}"
 


### PR DESCRIPTION
## Description
Remove the `zkevm.sequencer-non-empty-batch-seal-time` from configuration, since that flag got obsoleted through the [PR](https://github.com/0xPolygonHermez/cdk-erigon/pull/909) on the CDK Erigon.

## References (if applicable)
- https://github.com/0xPolygonHermez/cdk-erigon/pull/909/files#diff-7aa83061ca1c69a8ab9203da49a7581bad6e7cc80ecb96582e7fb09c0b8f6534L474-L477 
