### PR TITLE
docs: fix the command to deploy the legacy stack in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The command above deploys the CDK stack with [cdk-erigon](https://github.com/0xP
 Note that it is also possible to deploy the CDK stack using the legacy sequencer and the legacy node, referred to as the [zkevm-node](https://github.com/0xPolygonHermez/zkevm-node). In this scenario, you may need to adjust the various commands slightly; instead of targeting the `cdk-erigon-node-001` service, you should target the `zkevm-node-rpc-001`.
 
 ```bash
-kurtosis run --enclave cdk-v1 --args-file params.yml . '{"args": {"sequencer_type": "zkevm", "l1_seconds_per_slot": 1}}'
+kurtosis run --enclave cdk-v1 --args-file params.yml . \
+  '{"deploy_cdk_erigon_node": false, "args": {"sequencer_type": "zkevm", "l1_seconds_per_slot": 1}}'
 ```
 
 <details>


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Fix the command to deploy the legacy stack (zkevm-node).

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
