### PR TITLE
docs: add `fork12` to zkevm-contracts reference matrix

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -48,16 +48,16 @@ Build the `zkevm-contracts` image.
 
 ```bash
 docker build . \
-  --tag local/zkevm-contracts:fork12 \
-  --build-arg ZKEVM_CONTRACTS_BRANCH=v8.0.0-rc.1-fork.12 \
+  --tag local/zkevm-contracts:fork10 \
+  --build-arg ZKEVM_CONTRACTS_BRANCH=v7.0.0-rc.1-fork.10 \
   --build-arg POLYCLI_VERSION=main \
   --file zkevm-contracts.Dockerfile
 ```
 
 ```bash
 $ docker images --filter "reference=local/zkevm-contracts"
-REPOSITORY              TAG       IMAGE ID       CREATED          SIZE
-local/zkevm-contracts   fork9     54d894c6a5bd   10 minutes ago   2.3GB
+REPOSITORY              TAG      IMAGE ID       CREATED          SIZE
+local/zkevm-contracts   fork10   54d894c6a5bd   10 minutes ago   2.3GB
 ```
 
 Here's a quick reference matrix for mapping fork IDs to branches/releases:


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- Add `fork12` to zkevm-contracts reference matrix.
- Also build and push new [image](https://hub.docker.com/layers/leovct/zkevm-contracts/fork12/images/sha256-8c6028410e6089e99d4696a59032d553bf8a8d9e228dca9a07289c0f6df0674b?context=repo) to Docker hub.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
