### PR TITLE
chore: streamline dbs deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       
       - name: List first CDK L2 chain databases (erigon)
         run: |
-          postgres1_port=$(kurtosis port print cdk-v1 postgres-001 postgres | cut -d':' -f3)
+          postgres1_port=$(kurtosis port print ${{ env.ENCLAVE_NAME }} postgres-001 postgres | cut -d':' -f3)
           PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres1_port" --username master_user --dbname master --list
 
       - name: Attach a second CDK L2 chain (erigon)
@@ -51,7 +51,7 @@ jobs:
       
       - name: List second CDK L2 chain databases (erigon)
         run: |
-          postgres2_port=$(kurtosis port print cdk-v1 postgres-002 postgres | cut -d':' -f3)
+          postgres2_port=$(kurtosis port print ${{ env.ENCLAVE_NAME }} postgres-002 postgres | cut -d':' -f3)
           PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres2_port" --username master_user --dbname master --list
 
       - name: Update the agglayer config
@@ -113,7 +113,7 @@ jobs:
       
       - name: List first CDK L2 chain databases (zkevm)
         run: |
-          postgres1_port=$(kurtosis port print cdk-v1 postgres-001 postgres | cut -d':' -f3)
+          postgres1_port=$(kurtosis port print ${{ env.ENCLAVE_NAME }} postgres-001 postgres | cut -d':' -f3)
           PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres1_port" --username master_user --dbname master --list
 
       - name: Attach a second CDK L2 chain (erigon)
@@ -126,7 +126,7 @@ jobs:
       
       - name: List second CDK L2 chain databases (erigon)
         run: |
-          postgres2_port=$(kurtosis port print cdk-v1 postgres-002 postgres | cut -d':' -f3)
+          postgres2_port=$(kurtosis port print ${{ env.ENCLAVE_NAME }} postgres-002 postgres | cut -d':' -f3)
           PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres2_port" --username master_user --dbname master --list
 
       - name: Update the agglayer config

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,11 @@ jobs:
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+      
+      - name: List first CDK L2 chain databases (erigon)
+        run: |
+          postgres1_port=$(kurtosis port print cdk-v1 postgres-001 postgres | cut -d':' -f3)
+          PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres1_port" --username master_user --dbname master --list
 
       - name: Attach a second CDK L2 chain (erigon)
         run: |
@@ -43,6 +48,11 @@ jobs:
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+      
+      - name: List second CDK L2 chain databases (erigon)
+        run: |
+          postgres2_port=$(kurtosis port print cdk-v1 postgres-002 postgres | cut -d':' -f3)
+          PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres2_port" --username master_user --dbname master --list
 
       - name: Update the agglayer config
         run: |
@@ -100,6 +110,11 @@ jobs:
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+      
+      - name: List first CDK L2 chain databases (zkevm)
+        run: |
+          postgres1_port=$(kurtosis port print cdk-v1 postgres-001 postgres | cut -d':' -f3)
+          PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres1_port" --username master_user --dbname master --list
 
       - name: Attach a second CDK L2 chain (erigon)
         run: |
@@ -108,6 +123,11 @@ jobs:
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+      
+      - name: List second CDK L2 chain databases (erigon)
+        run: |
+          postgres2_port=$(kurtosis port print cdk-v1 postgres-002 postgres | cut -d':' -f3)
+          PGPASSWORD=master_password psql --host 127.0.0.1 --port "$postgres2_port" --username master_user --dbname master --list
 
       - name: Update the agglayer config
         run: |

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -6,7 +6,9 @@ databases = import_module("./databases.star")
 
 def run(plan, args):
     contract_setup_addresses = service_package.get_contract_setup_addresses(plan, args)
-    db_configs = databases.get_db_configs(args["deployment_suffix"])
+    db_configs = databases.get_db_configs(
+        args["deployment_suffix"], args["sequencer_type"]
+    )
 
     # Create the bridge service config.
     bridge_config_artifact = create_bridge_config_artifact(

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -9,7 +9,10 @@ databases = import_module("./databases.star")
 
 
 def run(plan, args):
-    db_configs = databases.get_db_configs(args["deployment_suffix"])
+    db_configs = databases.get_db_configs(
+        args["deployment_suffix"], args["sequencer_type"]
+    )
+
     # Start prover.
     prover_config_template = read_file(
         src="./templates/trusted-node/prover-config.json"

--- a/databases.star
+++ b/databases.star
@@ -32,8 +32,8 @@ CENTRAL_ENV_DBS = {
         "password": "redacted",
     },
     "aggregator_syncer_db": {
-        "name": "syncer_db",
-        "user": "syncer_user",
+        "name": "aggregator_syncer_db",
+        "user": "aggregator_syncer_db_user",
         "password": "redacted",
     },
     "bridge_db": {

--- a/databases.star
+++ b/databases.star
@@ -23,17 +23,6 @@ POSTGRES_MASTER_PASSWORD = "master_password"
 # Which automatically wipes all CDK databases and reapplies proper db permissions
 # TO DO: add env var support for credentials
 
-# The prover database is a component of both central environment and permissionless zkEVM node environment.
-# Therefore, it is defined separately.
-PROVER_DB = {
-    "prover_db": {
-        "name": "prover_db",
-        "user": "prover_user",
-        "password": "redacted",
-        "init": read_file(src="./templates/databases/prover-db-init.sql"),
-    }
-}
-
 # Databases that make up the central environment of an L2 chain, including sequencer, aggregator,
 # prover, bridge service, and DAC.
 CENTRAL_ENV_DBS = {
@@ -57,7 +46,18 @@ CENTRAL_ENV_DBS = {
         "user": "dac_user",
         "password": "redacted",
     },
-} | PROVER_DB
+}
+
+# The prover database is a component of both central environment and permissionless zkEVM node environment.
+# Therefore, it is defined separately.
+PROVER_DB = {
+    "prover_db": {
+        "name": "prover_db",
+        "user": "prover_user",
+        "password": "redacted",
+        "init": read_file(src="./templates/databases/prover-db-init.sql"),
+    }
+}
 
 # Databases required for a zkevm node to function as either a sequencer or a permissionless node.
 ZKEVM_NODE_DBS = {
@@ -77,7 +77,7 @@ ZKEVM_NODE_DBS = {
         "user": "state_user",
         "password": "redacted",
     },
-} | PROVER_DB
+}
 
 # Databases required for a cdk erigon node to function as either a sequencer or a permissionless node.
 CDK_ERIGON_DBS = {
@@ -87,6 +87,8 @@ CDK_ERIGON_DBS = {
         "password": "redacted",
     }
 }
+
+DATABASES = CENTRAL_ENV_DBS | PROVER_DB | ZKEVM_NODE_DBS | CDK_ERIGON_DBS
 
 
 def run(plan, suffix, sequencer_type):

--- a/main.star
+++ b/main.star
@@ -71,12 +71,16 @@ def run(
     else:
         plan.print("Skipping the deployment of helper service to retrieve rollup data")
 
-    # Deploy zkevm node and cdk peripheral databases.
+    # Deploy databases.
     if deploy_databases:
-        plan.print("Deploying zkevm node and cdk peripheral databases")
-        import_module(databases_package).run(plan, suffix=args["deployment_suffix"])
+        plan.print("Deploying databases")
+        import_module(databases_package).run(
+            plan,
+            suffix=args["deployment_suffix"],
+            sequencer_type=args["sequencer_type"],
+        )
     else:
-        plan.print("Skipping the deployment of zkevm node and cdk peripheral databases")
+        plan.print("Skipping the deployment of databases")
 
     # Get the genesis file.
     genesis_artifact = ""

--- a/src/additional_services/pless_zkevm_node.star
+++ b/src/additional_services/pless_zkevm_node.star
@@ -6,9 +6,7 @@ databases_package = import_module("../../databases.star")
 def run(plan, args, genesis_artifact):
     # Start dbs.
     databases_package.run_pless(plan, suffix=args["original_suffix"])
-    db_config = databases_package.get_pless_zkevm_db_configs(
-        args["original_suffix"]
-    )
+    db_config = databases_package.get_pless_zkevm_db_configs(args["original_suffix"])
 
     # Start executor.
     executor_config_template = read_file(

--- a/src/additional_services/pless_zkevm_node.star
+++ b/src/additional_services/pless_zkevm_node.star
@@ -6,7 +6,9 @@ databases_package = import_module("../../databases.star")
 def run(plan, args, genesis_artifact):
     # Start dbs.
     databases_package.run_pless(plan, suffix=args["original_suffix"])
-    db_config = databases_package.get_pless_db_configs(args["original_suffix"])
+    zkevm_db_config = databases_package.get_pless_zkevm_db_configs(
+        args["original_suffix"]
+    )
 
     # Start executor.
     executor_config_template = read_file(

--- a/src/additional_services/pless_zkevm_node.star
+++ b/src/additional_services/pless_zkevm_node.star
@@ -5,7 +5,7 @@ databases_package = import_module("../../databases.star")
 
 def run(plan, args, genesis_artifact):
     # Start dbs.
-    databases_package.run_pless(plan, suffix=args["original_suffix"])
+    databases_package.run_pless_zkevm(plan, suffix=args["original_suffix"])
     db_config = databases_package.get_pless_zkevm_db_configs(args["original_suffix"])
 
     # Start executor.

--- a/src/additional_services/pless_zkevm_node.star
+++ b/src/additional_services/pless_zkevm_node.star
@@ -6,7 +6,7 @@ databases_package = import_module("../../databases.star")
 def run(plan, args, genesis_artifact):
     # Start dbs.
     databases_package.run_pless(plan, suffix=args["original_suffix"])
-    zkevm_db_config = databases_package.get_pless_zkevm_db_configs(
+    db_config = databases_package.get_pless_zkevm_db_configs(
         args["original_suffix"]
     )
 

--- a/zkevm_pool_manager.star
+++ b/zkevm_pool_manager.star
@@ -3,7 +3,9 @@ databases = import_module("./databases.star")
 
 
 def run_zkevm_pool_manager(plan, args):
-    db_configs = databases.get_db_configs(args["deployment_suffix"])
+    db_configs = databases.get_db_configs(
+        args["deployment_suffix"], args["sequencer_type"]
+    )
 
     zkevm_pool_manager_config_artifact = create_zkevm_pool_manager_config_artifact(
         plan, args, db_configs


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

I’ve noticed that deploying the `cdk` environment creates the various zkevm-node databases (state, pool and event) that aren’t needed. I suspect that other useless databases are being deployed.

We should first understand exactly which dbs are needed in which environment (`cdk` and `zkevm`) and then update the kurtosis implementation to reflect this.

<img width="1050" alt="Screenshot 2024-08-20 at 16 41 53" src="https://github.com/user-attachments/assets/ee886175-5320-45d1-bf40-c4f634999063">


## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
