### PR TITLE
feat: add global log level parameter

### DIFF
--- a/.github/scripts/compare-default-params.sh
+++ b/.github/scripts/compare-default-params.sh
@@ -4,22 +4,26 @@
 # `kurtosis.yml` and `params.yml` where `params.yml` is the source of truth for default parameters.
 # The script outputs the differences between the specified parameters in each file compared to `params.yml`.
 
+INPUT_PARSER_PATH="../../input_parser.star"
+KURTOSIS_YML_PATH="../../kurtosis.yml"
+PARAMS_YML_PATH="../../params.yml"
+
 # Extracting default parameters from the different files.
 echo "Extracting default parameters from input_parser.star..."
-if ! sed -n '/DEFAULT_ARGS = {/,/}/ { s/DEFAULT_ARGS = //; s/}/}/; p; }' input_parser.star | yq --yaml-output >.input_parser.star; then
+if ! sed -n '/^DEFAULT_ARGS = {/,/^}/ { s/DEFAULT_ARGS = //; s/}/}/; p; }' "$INPUT_PARSER_PATH" | yq --yaml-output >.input_parser.star; then
   echo "Error: Failed to extract parameters from input_parser.star."
   exit 1
 fi
 
 echo "Extracting default parameters from kurtosis.yml..."
 # shellcheck disable=SC2016
-if ! sed -n '/```yml/,/```/ { /```yml/d; /```/d; p;}' kurtosis.yml | yq --yaml-output >.kurtosis.yml; then
+if ! sed -n '/```yml/,/```/ { /```yml/d; /```/d; p;}' "$KURTOSIS_YML_PATH" | yq --yaml-output >.kurtosis.yml; then
   echo "Error: Failed to extract parameters from kurtosis.yml."
   exit 1
 fi
 
 echo "Extracting default parameters from params.yml..."
-if ! yq --yaml-output .args params.yml >.params.yml; then
+if ! yq --yaml-output .args "$PARAMS_YML_PATH" >.params.yml; then
   echo "Error: Failed to extract parameters from params.yml."
   exit 1
 fi

--- a/.github/scripts/compare-default-params.sh
+++ b/.github/scripts/compare-default-params.sh
@@ -58,6 +58,7 @@ compare_with_source_of_truth() {
         echo "${line:2}"
       fi
     done <<<"$differences"
+    exit 1
   fi
 }
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,4 +62,5 @@ jobs:
         run: pip3 install yq
 
       - name: Compare default parameters
-        run: ./.github/scripts/compare-default-params.sh
+        working-directory: .github/scripts
+        run: ./compare-default-params.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,4 +62,5 @@ jobs:
         run: pip3 install yq
 
       - name: Compare default parameters
-        run: ./scripts/compare_default_params.sh
+        working-directory: .github/scripts
+        run: ./compare-default-params.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,5 +62,4 @@ jobs:
         run: pip3 install yq
 
       - name: Compare default parameters
-        working-directory: .github/scripts
-        run: ./compare-default-params.sh
+        run: ./.github/scripts/compare-default-params.sh

--- a/agglayer-attach-cdk-params.yml
+++ b/agglayer-attach-cdk-params.yml
@@ -25,6 +25,10 @@ args:
   # Note: It should be a string.
   deployment_suffix: "-002"
 
+  # The global log level that all components of the stack should log at.
+  # Valid values are "error", "warn", "info", "debug", and "trace".
+  global_log_level: info
+
   # The type of the sequencer to deploy.
   # Options:
   # - 'erigon': Use the new sequencer (https://github.com/0xPolygonHermez/cdk-erigon).

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -72,6 +72,7 @@ def create_agglayer_config_artifact(plan, args, contract_setup_addresses, db_con
                 # TODO: Organize those args.
                 data={
                     "deployment_suffix": args["deployment_suffix"],
+                    "global_log_level": args["global_log_level"],
                     "l1_chain_id": args["l1_chain_id"],
                     "l1_rpc_url": args["l1_rpc_url"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
@@ -103,6 +104,7 @@ def create_bridge_config_artifact(plan, args, contract_setup_addresses, db_confi
                 template=bridge_config_template,
                 data={
                     "deployment_suffix": args["deployment_suffix"],
+                    "global_log_level": args["global_log_level"],
                     "l1_rpc_url": args["l1_rpc_url"],
                     "l2_rpc_name": args["l2_rpc_name"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -162,6 +162,7 @@ def create_dac_config_artifact(plan, args, db_configs):
                 template=dac_config_template,
                 data={
                     "deployment_suffix": args["deployment_suffix"],
+                    "global_log_level": args["global_log_level"],
                     "l1_rpc_url": args["l1_rpc_url"],
                     "l1_ws_url": args["l1_ws_url"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],

--- a/input_parser.star
+++ b/input_parser.star
@@ -1,3 +1,5 @@
+constants = import_module("./src/package_io/constants.star")
+
 DEFAULT_ARGS = {
     "deployment_suffix": "-001",
     "global_log_level": "info",
@@ -73,4 +75,25 @@ DEFAULT_ARGS = {
 
 
 def parse_args(args):
+    validate_global_log_level(args["global_log_level"])
     return DEFAULT_ARGS | args
+
+
+def validate_global_log_level(global_log_level):
+    if global_log_level not in (
+        constants.GLOBAL_LOG_LEVEL.error,
+        constants.GLOBAL_LOG_LEVEL.warn,
+        constants.GLOBAL_LOG_LEVEL.info,
+        constants.GLOBAL_LOG_LEVEL.debug,
+        constants.GLOBAL_LOG_LEVEL.trace,
+    ):
+        fail(
+            "Unsupported global log level: '{}', please use '{}', '{}', '{}', '{}' or '{}'".format(
+                global_log_level,
+                constants.GLOBAL_LOG_LEVEL.error,
+                constants.GLOBAL_LOG_LEVEL.warn,
+                constants.GLOBAL_LOG_LEVEL.info,
+                constants.GLOBAL_LOG_LEVEL.debug,
+                constants.GLOBAL_LOG_LEVEL.trace,
+            )
+        )

--- a/input_parser.star
+++ b/input_parser.star
@@ -1,5 +1,6 @@
 DEFAULT_ARGS = {
     "deployment_suffix": "-001",
+    "global_log_level": "info",
     "deploy_agglayer": True,
     "sequencer_type": "erigon",
     "data_availability_mode": "cdk-validium",

--- a/input_parser.star
+++ b/input_parser.star
@@ -1,8 +1,8 @@
 DEFAULT_ARGS = {
     "deployment_suffix": "-001",
     "global_log_level": "info",
-    "deploy_agglayer": True,
     "sequencer_type": "erigon",
+    "deploy_agglayer": True,
     "data_availability_mode": "cdk-validium",
     "additional_services": [],
     "zkevm_prover_image": "hermeznetwork/zkevm-prover:v6.0.3-RC20",
@@ -12,7 +12,7 @@ DEFAULT_ARGS = {
     "zkevm_da_image": "0xpolygon/cdk-data-availability:0.0.7",
     "zkevm_contracts_image": "leovct/zkevm-contracts",
     "zkevm_agglayer_image": "ghcr.io/agglayer/agglayer-rs:main",
-    "zkevm_bridge_service_image": "hermeznetwork/zkevm-bridge-service:v0.4.2",
+    "zkevm_bridge_service_image": "hermeznetwork/zkevm-bridge-service:v0.5.0-RC9",
     "zkevm_bridge_ui_image": "leovct/zkevm-bridge-ui:multi-network",
     "zkevm_bridge_proxy_image": "haproxy:2.9.9-bookworm",
     "zkevm_sequence_sender_image": "hermeznetwork/zkevm-sequence-sender:v0.2.0-RC4",

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -59,7 +59,7 @@ description: |-
   zkevm_contracts_image: leovct/zkevm-contracts # the tag is automatically replaced by the value of /zkevm_rollup_fork_id/
 
   zkevm_agglayer_image: ghcr.io/agglayer/agglayer-rs:main
-  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.4.2
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.5.0-RC9
 
   # temporary fork https://github.com/praetoriansentry/zkevm-bridge-ui/commit/6eaa899997f70e53947d7b067ff7ae37ef1875f3
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -28,6 +28,10 @@ description: |-
   # Note: It should be a string.
   deployment_suffix: "-001"
 
+  # The global log level that all components of the stack should log at.
+  # Valid values are "error", "warn", "info", "debug", and "trace".
+  global_log_level: info
+
   sequencer_type: erigon
 
   deploy_agglayer: true

--- a/lib/zkevm_sequence_sender.star
+++ b/lib/zkevm_sequence_sender.star
@@ -11,7 +11,7 @@ def create_zkevm_sequence_sender_config(
     sequence_sender_config_artifact = plan.render_templates(
         name="zkevm-sequence-sender-config-artifact",
         config={
-            "config.toml": struct(
+            "sequence-sender-config.toml": struct(
                 data=args
                 | {
                     "zkevm_is_validium": data_availability_package.is_cdk_validium(
@@ -36,7 +36,7 @@ def create_zkevm_sequence_sender_config(
         cmd=[
             "/bin/sh",
             "-c",
-            "/app/zkevm-seqsender run --network custom --custom-network-file /etc/zkevm/genesis.json --cfg /etc/zkevm/config.toml",
+            "/app/zkevm-seqsender run --network custom --custom-network-file /etc/zkevm/genesis.json --cfg /etc/zkevm/sequence-sender-config.toml",
         ],
     )
 

--- a/params.yml
+++ b/params.yml
@@ -25,6 +25,10 @@ args:
   # Note: It should be a string.
   deployment_suffix: "-001"
 
+  # The global log level that all components of the stack should log at.
+  # Valid values are "error", "warn", "info", "debug", and "trace".
+  global_log_level: info
+
   # The type of the sequencer to deploy.
   # Options:
   # - 'erigon': Use the new sequencer (https://github.com/0xPolygonHermez/cdk-erigon).

--- a/src/additional_services/tx_spammer.star
+++ b/src/additional_services/tx_spammer.star
@@ -15,7 +15,7 @@ def run(plan, args):
                 ),
             },
             entrypoint=["bash", "-c"],
-            cmd=["chmod +x /usr/local/bin/*.sh && apply_workload.sh"],
+            cmd=["chmod +x /usr/local/bin/*.sh && spam.sh"],
             user=User(uid=0, gid=0),  # Run the container as root user.
         ),
     )

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -1,0 +1,7 @@
+GLOBAL_LOG_LEVEL = struct(
+    error="error",
+    warn="warn",
+    info="info",
+    debug="debug",
+    trace="trace",
+)

--- a/static_files/additional_services/panoptichain-config/config.yml
+++ b/static_files/additional_services/panoptichain-config/config.yml
@@ -172,4 +172,4 @@ logs:
   # - "error"
   # - "panic"
   # - "fatal"
-  verbosity: "trace"
+  verbosity: "{{.global_log_level}}"

--- a/templates/bridge-infra/agglayer-config.toml
+++ b/templates/bridge-infra/agglayer-config.toml
@@ -14,7 +14,7 @@ MaxRequestsPerIPAndSecond = 5000
 
 [Log]
 Environment = "production" # "production" or "development"
-Level = "info"
+Level = "{{.global_log_level}}"
 Outputs = ["stderr"]
 
 [EthTxManager]

--- a/templates/bridge-infra/bridge-config.toml
+++ b/templates/bridge-infra/bridge-config.toml
@@ -1,5 +1,5 @@
 [Log]
-Level = "info"
+Level = "{{.global_log_level}}"
 Environment = "production"
 Outputs = ["stderr"]
 

--- a/templates/cdk-erigon/config.yml
+++ b/templates/cdk-erigon/config.yml
@@ -20,7 +20,7 @@ private.api.addr: localhost:9092
 torrent.port: 42070
 ws: true
 externalcl: true
-log.console.verbosity: debug
+log.console.verbosity: "{{.global_log_level}}"
 
 zkevm.address-admin: "{{.zkevm_admin_address}}"
 zkevm.address-ger-manager: "{{.zkevm_global_exit_root_address}}"

--- a/templates/permissionless-node/node-config.toml
+++ b/templates/permissionless-node/node-config.toml
@@ -3,7 +3,7 @@ IsTrustedSequencer = false
 
 [Log]
 Environment = "production" # "production" or "development"
-Level = "info"
+Level = "{{.global_log_level}}"
 Outputs = ["stderr"]
 
 [State]

--- a/templates/pool-manager/pool-manager-config.toml
+++ b/templates/pool-manager/pool-manager-config.toml
@@ -1,6 +1,6 @@
 [Log]
 Environment = "development" # "production" or "development"
-Level = "info"
+Level = "{{.global_log_level}}"
 Outputs = ["stderr"]
 
 [Server]

--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -7,7 +7,7 @@ ContractVersions = "elderberry"
 
 [Log]
 Environment = "development" # "production" or "development"
-Level = "info"
+Level = "{{.global_log_level}}"
 Outputs = ["stderr"]
 
 [SequenceSender]
@@ -84,7 +84,7 @@ MaxPendingTx = 1
 		MaxConns = 200
 	[Aggregator.Log]
 		Environment = "development" # "production" or "development"
-		Level = "info"
+		Level = "{{.global_log_level}}"
 		Outputs = ["stderr"]
 	[Aggregator.StreamClient]
 		Server = "{{.sequencer_name}}{{.deployment_suffix}}:{{.zkevm_data_streamer_port}}"

--- a/templates/trusted-node/dac-config.toml
+++ b/templates/trusted-node/dac-config.toml
@@ -13,7 +13,7 @@ TrackSequencer = false
 
 [Log]
 Environment = "development" # "production" or "development"
-Level = "info"
+Level = "{{.global_log_level}}"
 Outputs = ["stderr"]
 
 [DB]

--- a/templates/trusted-node/node-config.toml
+++ b/templates/trusted-node/node-config.toml
@@ -68,7 +68,7 @@ Environment = "production"
 # log. Generally we'll switch to debug if we want to troubleshoot
 # something specifically otherwise we leave it at info
 # ------------------------------------------------------------------------------
-Level = "info"
+Level = "{{.global_log_level}}"
 
 # ------------------------------------------------------------------------------
 # Outputs define the output paths for writing logs. The default is to
@@ -1037,7 +1037,7 @@ Environment = "production"
 # log. Generally we'll switch to debug if we want to troubleshoot
 # something specifically otherwise we leave it at info
 # ------------------------------------------------------------------------------
-Level = "info"
+Level = "{{.global_log_level}}"
 
 # ==============================================================================
 #  ____  _____ ___  _   _ _____ _   _  ____ _____ ____  _____ _   _ ____  _____ ____

--- a/templates/trusted-node/sequence-sender-config.toml
+++ b/templates/trusted-node/sequence-sender-config.toml
@@ -1,6 +1,6 @@
 [Log]
 Environment = "development"
-Level = "info"
+Level = "{{.global_log_level}}"
 Outputs = ["stdout"]
 
 [SequenceSender]


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Configure `args.global_log_level` to specify the log level for all components of the CDK stack.

Valid values are `error`, `warn`, `info`, `debug` and `trace`.

Also few fixes related to default params (not related to this PR).

## Tests

- [x] Use the default `global_log_level` value => all components have log level set to `info`.

```bash
$ kurtosis service logs cdk-v1 cdk-erigon-node-001 --follow
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.820] [16/16 Finish] Finished 
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.850] Commit cycle                             in=30.608833ms
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.850] Timings (slower than 50ms)               Batches=12.133s
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.850] Tables                                   PlainState=20.0KB AccountChangeSet=12.0KB StorageChangeSet=36.0KB BlockTransaction=4.0KB TransactionLog=4.0KB FreeList=4.0KB ReclaimableSpace=4.0MB
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] RPC Daemon notified of new headers       from=104 to=107 hash=0xbd114119cec8dc4bbbcf018375aa2e28cbe5a052d8761dd8f48b383ef1e906e2 header sending=63.459µs log sending=250ns
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [1/16 L1Syncer] Starting L1 sync stage 
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [1/16 L1Syncer] Saving L1 syncer progress latestCheckedBlock=718 newVerificationsCount=0 newSequencesCount=0
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [1/16 L1Syncer] Finished L1 sync stage  
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [2/16 L1InfoTree] Starting L1 Info Tree stage 
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [2/16 L1InfoTree] Info tree updates      count=0
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [2/16 L1InfoTree] Finished L1 Info Tree stage 
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [3/16 Batches] Starting batches stage 
[cdk-erigon-node-001] [INFO] [08-21|08:29:30.851] [3/16 Batches] Reading blocks from the datastream.
```

- [x] Set `global_log_level` value to `debug` => all components have log level set to `debug`.
```bash
$ kurtosis service logs cdk-v1 cdk-erigon-node-001 --follow
[cdk-erigon-node-001] [DBUG] [08-21|07:41:09.126] [1/16 L1Syncer] DONE                     in=66µs
[cdk-erigon-node-001] [INFO] [08-21|07:41:09.126] [2/16 L1InfoTree] Starting L1 Info Tree stage 
[cdk-erigon-node-001] [DBUG] [08-21|07:41:09.126] Initial count:                           LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
[cdk-erigon-node-001] [DBUG] [08-21|07:41:09.126] Initial root:                            LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
[cdk-erigon-node-001] [INFO] [08-21|07:41:09.126] [2/16 L1InfoTree] Info tree updates      count=0
[cdk-erigon-node-001] [INFO] [08-21|07:41:09.126] [2/16 L1InfoTree] Finished L1 Info Tree stage 
[cdk-erigon-node-001] [DBUG] [08-21|07:41:09.126] [2/16 L1InfoTree] DONE                   in=113.833µs
[cdk-erigon-node-001] [INFO] [08-21|07:41:09.126] [3/16 Batches] Starting batches stage 
[cdk-erigon-node-001] [INFO] [08-21|07:41:09.126] [3/16 Batches] Reading blocks from the datastream. 
```

- [x] Wrong `global_log_level` value => kurtosis throws a descriptive error.

```bash
$ yq .args.global_log_level params.yml
"aa"

$ kurtosis run --enclave cdk-v1 --args-file params.yml .
INFO[2024-08-21T09:33:07+02:00] Creating a new enclave for Starlark to run inside... 
INFO[2024-08-21T09:33:08+02:00] Enclave 'cdk-v1' created successfully        
INFO[2024-08-21T09:33:08+02:00] Executing Starlark package at '/Users/leovct/Documents/work/infra/kurtosis-cdk' as the passed argument '.' looks like a directory 
INFO[2024-08-21T09:33:08+02:00] Compressing package 'github.com/0xPolygon/kurtosis-cdk' at '.' for upload 
INFO[2024-08-21T09:33:10+02:00] Uploading and executing package 'github.com/0xPolygon/kurtosis-cdk' 
There was an error interpreting Starlark code 
Evaluation error: fail: Unsupported global log level: 'aa', please use 'error', 'warn', 'info', 'debug' or 'trace'
	at [github.com/0xPolygon/kurtosis-cdk/main.star:34:50]: run
	at [github.com/0xPolygon/kurtosis-cdk/input_parser.star:78:30]: parse_args
	at [github.com/0xPolygon/kurtosis-cdk/input_parser.star:90:13]: validate_global_log_level
	at [0:0]: fail

Error encountered running Starlark code.

⭐ us on GitHub - https://github.com/kurtosis-tech/kurtosis
INFO[2024-08-21T09:33:11+02:00] =============================================== 
INFO[2024-08-21T09:33:11+02:00] ||          Created enclave: cdk-v1          || 
INFO[2024-08-21T09:33:11+02:00] =============================================== 
Name:            cdk-v1
UUID:            cc5b59aa0240
Status:          RUNNING
Creation Time:   Wed, 21 Aug 2024 09:33:07 CEST
Flags:           

========================================= Files Artifacts =========================================
UUID   Name

========================================== User Services ==========================================
UUID   Name   Ports   Status
```



## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://0xpolygon.slack.com/archives/C06M06XR5A4/p1724224013558149?thread_ts=1724210533.957389&cid=C06M06XR5A4