### PR TITLE
feat: support legacy aggregator and sequence sender

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
       # Additionally, deploy cdk-erigon and zkevm-node as permissionless nodes or RPCs.
       - name: Deploy L1 chain and a first CDK L2 chain (erigon)
         run: |
+          yq -Y --in-place '.deploy_cdk_erigon_node = true' params.yml
+          yq -Y --in-place '.args.sequencer_type = "cdk"' params.yml
+          yq -Y --in-place '.args.aggregator_sequence_sender_type = "cdk"' params.yml
           yq -Y --in-place '.args.additional_services = ["pless_zkevm_node", "tx_spammer"]' params.yml
           kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false --args-file=params.yml .
 
@@ -95,6 +98,7 @@ jobs:
         run: |
           yq -Y --in-place '.deploy_cdk_erigon_node = false' params.yml
           yq -Y --in-place '.args.sequencer_type = "zkevm"' params.yml
+          yq -Y --in-place '.args.aggregator_sequence_sender_type = "zkevm"' params.yml
           yq -Y --in-place '.args.additional_services = ["pless_zkevm_node", "tx_spammer"]' params.yml
           kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false --args-file=params.yml .
 

--- a/input_parser.star
+++ b/input_parser.star
@@ -4,6 +4,7 @@ DEFAULT_ARGS = {
     "deployment_suffix": "-001",
     "global_log_level": "info",
     "sequencer_type": "erigon",
+    "aggregator_sequence_sender_type": "cdk",
     "deploy_agglayer": True,
     "data_availability_mode": "cdk-validium",
     "additional_services": [],

--- a/input_parser.star
+++ b/input_parser.star
@@ -77,6 +77,7 @@ DEFAULT_ARGS = {
 
 def parse_args(args):
     validate_global_log_level(args["global_log_level"])
+    validate_aggregator_sequence_sender_type(args["aggregator_sequence_sender_type"])
     return DEFAULT_ARGS | args
 
 
@@ -96,5 +97,19 @@ def validate_global_log_level(global_log_level):
                 constants.GLOBAL_LOG_LEVEL.info,
                 constants.GLOBAL_LOG_LEVEL.debug,
                 constants.GLOBAL_LOG_LEVEL.trace,
+            )
+        )
+
+
+def validate_aggregator_sequence_sender_type(aggregator_sequence_sender_type):
+    if aggregator_sequence_sender_type not in (
+        constants.AGGREGATOR_SEQUENCE_SENDER_TYPE.cdk,
+        constants.AGGREGATOR_SEQUENCE_SENDER_TYPE.zkevm,
+    ):
+        fail(
+            "Unsupported aggregator and sequence sender type: '{}', please use '{}' or '{}'".format(
+                aggregator_sequence_sender_type,
+                constants.AGGREGATOR_SEQUENCE_SENDER_TYPE.cdk,
+                constants.AGGREGATOR_SEQUENCE_SENDER_TYPE.zkevm,
             )
         )

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -34,6 +34,12 @@ description: |-
 
   sequencer_type: erigon
 
+  # The type of aggregator and sequence sender to deploy.
+  # Options:
+  # - 'cdk': Use the new cdk-node (https://github.com/0xPolygon/cdk).
+  # - 'zkevm': Use the legacy aggregator and sequence sender (https://github.com/0xPolygonHermez/zkevm-node).
+  aggregator_sequence_sender_type: cdk
+
   deploy_agglayer: true
 
   # The type of data availability to use.

--- a/lib/zkevm_node.star
+++ b/lib/zkevm_node.star
@@ -203,14 +203,6 @@ def create_zkevm_node_components_config(
     genesis_artifact,
     keystore_artifacts,
 ):
-    aggregator_config = create_aggregator_service_config(
-        args,
-        config_artifact,
-        genesis_artifact,
-        keystore_artifacts.sequencer,
-        keystore_artifacts.aggregator,
-        keystore_artifacts.proofsigner,
-    )
     rpc_config = create_rpc_service_config(args, config_artifact, genesis_artifact)
     eth_tx_manager_config = create_eth_tx_manager_service_config(
         args,
@@ -222,22 +214,12 @@ def create_zkevm_node_components_config(
     l2_gas_pricer_config = create_l2_gas_pricer_service_config(
         args, config_artifact, genesis_artifact
     )
-    configs = (
-        aggregator_config | rpc_config | eth_tx_manager_config | l2_gas_pricer_config
-    )
+    configs = rpc_config | eth_tx_manager_config | l2_gas_pricer_config
 
     if args["sequencer_type"] == "zkevm":
         sequencer_config = create_sequencer_service_config(
             args, config_artifact, genesis_artifact
         )
-
-        sequence_sender_config = create_sequence_sender_service_config(
-            args,
-            config_artifact,
-            genesis_artifact,
-            keystore_artifacts.sequencer,
-        )
-
-        return configs | sequencer_config | sequence_sender_config
+        return configs | sequencer_config
     else:
         return configs

--- a/params.yml
+++ b/params.yml
@@ -35,6 +35,12 @@ args:
   # - 'zkevm': Use the legacy sequencer (https://github.com/0xPolygonHermez/zkevm-node).
   sequencer_type: erigon
 
+  # The type of aggregator and sequence sender to deploy.
+  # Options:
+  # - 'cdk': Use the new cdk-node (https://github.com/0xPolygon/cdk).
+  # - 'zkevm': Use the legacy aggregator and sequence sender (https://github.com/0xPolygonHermez/zkevm-node).
+  aggregator_sequence_sender_type: cdk
+
   # Deploy agglayer.
   deploy_agglayer: true
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -5,3 +5,8 @@ GLOBAL_LOG_LEVEL = struct(
     debug="debug",
     trace="trace",
 )
+
+AGGREGATOR_SEQUENCE_SENDER_TYPE = struct(
+    cdk="cdk",
+    zkevm="zkevm",
+)


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

In #193, we introduced [cdk-node](https://github.com/0xPolygon/cdk) as the default aggregator / sequence sender component for the CDK stack. In this effort, we removed support for the legacy zkevm aggregator and sequence sender unfortunately. However, this is something we still need to test.

This PR introduces a new flag `aggregator_sequence_sender_type` to specify the type of aggregator and sequence sender to deploy. There are two options:
- `cdk`: Use the new [cdk-node](https://github.com/0xPolygon/cdk)
- `zkevm`: Use the [legacy](https://github.com/0xPolygonHermez/zkevm-node) aggregator and sequence sender

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
