### PR TITLE
docs: define kurtosis-cdk as a dev tool meant for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Kurtosis](https://github.com/kurtosis-tech/kurtosis) package that deploys a private, portable, and modular [Polygon CDK](https://docs.polygon.technology/cdk/) devnet.
 
+> 🚨 This package is currently designed as a **development tool** for testing configurations and scenarios within the Polygon CDK stack. **It is not recommended for long-running or production environments such as testnets or mainnet**. If you need help, you can [reach out to the Polygon team](https://polygon.technology/interest-form) or [talk to an Implementation Partner (IP)](https://ecosystem.polygon.technology/spn/cdk/).
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)


### PR DESCRIPTION
We should take a stance and warn users against using kurtosis-cdk in production.

https://github.com/0xPolygon/kurtosis-cdk/issues/55#issuecomment-2058132893