### PR TITLE
Keep cdk-erigon container running even when cdk-erigon is killed

### DIFF
--- a/lib/cdk_erigon.star
+++ b/lib/cdk_erigon.star
@@ -71,7 +71,7 @@ def start_node(
             # Sleep for 10 seconds in order to wait for datastream server getting ready
             # TODO: find a better way instead of waiting
             cmd=[
-                "sleep 10 && cdk-erigon --pprof=true --pprof.addr 0.0.0.0 --config /etc/cdk-erigon/config.yaml"
+                "sleep 10 && cdk-erigon --pprof=true --pprof.addr 0.0.0.0 --config /etc/cdk-erigon/config.yaml & tail -f /dev/null"
             ],
             env_vars=envs,
         ),


### PR DESCRIPTION
This will be useful when we want to manually stop the process of cdk-erigon sequencer or rpc node for debugging purpose.

