### PR TITLE
Disable state manager in prover when stateless executor is enabled

### DIFF
--- a/templates/trusted-node/prover-config.json
+++ b/templates/trusted-node/prover-config.json
@@ -263,7 +263,11 @@
      * stateManager will use the State Manager to consolidate states
      * before writing to Database
      */ -}}
+    {{if .stateless_executor}}
+    "stateManager": false,
+    {{else}}
     "stateManager": true,
+    {{end}}
 
 {{- /*
      * useAssociativeCache to use associative cache as Database MT


### PR DESCRIPTION
## Description
This is required when using the latest prover (`8.0.0-RC8`).
