### PR TITLE
ci: remove sonar cloud from pull request workflows

### DIFF
--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -3,7 +3,7 @@ name: Security Build
 on:
   push:
     branches: [main]
-  pull_request:
+  #pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Pull Requests from external forks consistently fail to pass all checks, even when the code itself is sound. This occurs due to the SonarCloud job, which requires access to the `SONAR_TOKEN` secret. For security reasons, PRs from external forks are not granted access to these secrets.

<img width="1703" alt="Screenshot 2024-09-11 at 13 23 20" src="https://github.com/user-attachments/assets/333b33bd-1d0f-4070-95b0-5a84f6938b38">

To address this issue, the SonarCloud job is now disabled for all pull requests.

Note that the SonarCloud analysis still runs when a PR is merged into the `main` branch.

## References (if applicable)

<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/0xPolygon/kurtosis-cdk/actions/runs/10810376967/job/29987498052
