### PR TITLE
fix: update cdk erigon image

### DIFF
--- a/agglayer-attach-cdk-params.yml
+++ b/agglayer-attach-cdk-params.yml
@@ -72,7 +72,7 @@ args:
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_sequence_sender_image: hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.0.0-beta18
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.0.0-beta18.3
   zkevm_pool_manager_image: hermeznetwork/zkevm-pool-manager:v0.1.0-RC1
 
   # Port configuration.

--- a/input_parser.star
+++ b/input_parser.star
@@ -17,7 +17,7 @@ DEFAULT_ARGS = {
     "zkevm_bridge_ui_image": "leovct/zkevm-bridge-ui:multi-network",
     "zkevm_bridge_proxy_image": "haproxy:3.0-bookworm",
     "zkevm_sequence_sender_image": "hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12",
-    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.0.0-beta18",
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.0.0-beta18.3",
     "zkevm_pool_manager_image": "hermeznetwork/zkevm-pool-manager:v0.1.0-RC1",
     "zkevm_hash_db_port": 50061,
     "zkevm_executor_port": 50071,

--- a/params.yml
+++ b/params.yml
@@ -72,7 +72,7 @@ args:
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_sequence_sender_image: hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.0.0-beta18
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.0.0-beta18.3
   zkevm_pool_manager_image: hermeznetwork/zkevm-pool-manager:v0.1.0-RC1
 
   # Port configuration.


### PR DESCRIPTION
## Description
While testing the Access List feature in `cdk-erigon`, we encountered couple of bugs that were fixed and merged. In order to e2e test it, we need to update the `cdk-erigon` image that we use in kurtosis.

## References (if applicable)
[JIRA Ticket](https://polygon.atlassian.net/browse/CDK-477?atlOrigin=eyJpIjoiNGVjYjAyOWM1NDg1NDc2M2JjZDVhMjQ1N2UwYjBmNjEiLCJwIjoiaiJ9)
