### PR TITLE
fix: nightly job

### DIFF
--- a/.github/tests/pless-zkevm-node/cardona-sepolia-testnet-pless-zkevm-node.yml
+++ b/.github/tests/pless-zkevm-node/cardona-sepolia-testnet-pless-zkevm-node.yml
@@ -3,6 +3,7 @@ deploy_zkevm_contracts_on_l1: false
 deploy_databases: false
 deploy_cdk_central_environment: false
 deploy_cdk_bridge_infra: false
+deploy_agglayer: false
 deploy_cdk_erigon_node: false
 
 args:


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

#262 updated the agglayer implementation and moved the `deploy_agglayer` parameter outside of the `args` struct. It should be set to `false ` in the Cardona/Sepolia permissionless zkevm-node test.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

✅ CI passes with the fix: https://github.com/leovct/kurtosis-cdk/actions/runs/10901640039
