### PR TITLE
fix: Remove redundant copy step for `create_rollup_parameters.json`

### DIFF
--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -105,6 +105,10 @@ pushd /opt/zkevm-contracts || exit 1
 # setup a foundry toml in case we do a gas token or dac deployment
 printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
 
+cp /opt/contract-deploy/deploy_parameters.json /opt/zkevm-contracts/deployment/v2/deploy_parameters.json
+cp /opt/contract-deploy/create_rollup_parameters.json /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
+sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
+
 # Deploy gas token
 # TODO in the future this should be configurable. I.e. we should be able to specify a token address that has already been deployed
 # {{if .zkevm_use_gas_token_contract}}
@@ -119,9 +123,6 @@ forge create \
 # In this case, we'll configure the create rollup parameters to have a gas token
 jq --slurpfile c gasToken-erc20.json '.gasTokenAddress = $c[0].deployedTo' /opt/contract-deploy/create_rollup_parameters.json > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 # {{end}}
-
-cp /opt/contract-deploy/deploy_parameters.json /opt/zkevm-contracts/deployment/v2/deploy_parameters.json
-sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
 
 is_first_rollup=0 # an indicator if this deployment is doing the first setup of the agglayer etc
 if [[ ! -e /opt/zkevm/combined.json ]]; then

--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -121,7 +121,6 @@ jq --slurpfile c gasToken-erc20.json '.gasTokenAddress = $c[0].deployedTo' /opt/
 # {{end}}
 
 cp /opt/contract-deploy/deploy_parameters.json /opt/zkevm-contracts/deployment/v2/deploy_parameters.json
-cp /opt/contract-deploy/create_rollup_parameters.json /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
 
 is_first_rollup=0 # an indicator if this deployment is doing the first setup of the agglayer etc


### PR DESCRIPTION
## Description
This PR fixes the issue with `gasTokenAddress` not being populated in the `create_rollup_parameters.json`. It is due to the misplace of copying the `create_rollup_parameters.json` file contents with outdated values. The issue was introduced through #266.