### PR TITLE
fix: Sometimes fails synchronization db for aggregator

### DIFF
--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -139,7 +139,7 @@ GetBatchWaitInterval = "10s"
         [Aggregator.Synchronizer]
                  [Aggregator.Synchronizer.SQLDB]
                         DriverName = "sqlite3"
-                        DataSourceName = "file:/tmp/aggregator_sync_db.sqlite"
+                        DataSource = "file:/data/aggregator_sync_db.sqlite"
                 [Aggregator.Synchronizer.Synchronizer]
                         SyncInterval = "10s"
                         SyncChunkSize = 1000


### PR DESCRIPTION
## Description
Sometimes synchronization db for aggregator raise errors like: 

```
FATAL	internal/synchronizer_impl.go:280	networkID: 0, error getting lastBlockSynced to resume the synchronization... Error: %!(EXTRA *fmt.wrapError=storage error: GetLastBlock: Err: no such table: block, string=
```