### PR TITLE
chore: bumping to latest version of cdk-erigon

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -17,7 +17,7 @@ DEFAULT_ARGS = {
     "zkevm_bridge_ui_image": "leovct/zkevm-bridge-ui:multi-network",
     "zkevm_bridge_proxy_image": "haproxy:3.0-bookworm",
     "zkevm_sequence_sender_image": "hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12",
-    "cdk_erigon_node_image": "jerrycgh/cdk-erigon:c69caf5bf62b2ad9c907184ad257ed2aef5c4bfc",
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:4cf9ba7",
     "zkevm_pool_manager_image": "hermeznetwork/zkevm-pool-manager:v0.1.0-RC1",
     "zkevm_hash_db_port": 50061,
     "zkevm_executor_port": 50071,

--- a/params.yml
+++ b/params.yml
@@ -73,7 +73,7 @@ args:
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
   zkevm_bridge_proxy_image: haproxy:3.0-bookworm
   zkevm_sequence_sender_image: hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12
-  cdk_erigon_node_image: jerrycgh/cdk-erigon:c69caf5bf62b2ad9c907184ad257ed2aef5c4bfc
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
   zkevm_pool_manager_image: hermeznetwork/zkevm-pool-manager:v0.1.0-RC1
 
   # Port configuration.


### PR DESCRIPTION
## Description

This is a small change to move away from the @cffls branded erigon images to the official builds from the CI. The change shouldn't impact anything else.