### PR TITLE
feat: bump to zkevm-contracts@fork12.rc4

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,7 @@ This image contains all the npm dependencies and zkevm contracts compiled for a 
 Build the `zkevm-contracts` image.
 
 ```bash
-version="v8.0.0-rc.3-fork.12"
+version="v8.0.0-rc.4-fork.12"
 docker build . \
   --tag local/zkevm-contracts:$version \
   --build-arg ZKEVM_CONTRACTS_BRANCH=$version \
@@ -57,8 +57,8 @@ docker build . \
 
 ```bash
 $ docker images --filter "reference=local/zkevm-contracts"
-REPOSITORY               TAG                    IMAGE ID       CREATED          SIZE
-local/zkevm-contracts    v8.0.0-rc.3-fork.12    25217fcaa683   28 seconds ago   2.53GB
+REPOSITORY               TAG                    IMAGE ID       CREATED              SIZE
+leovct/zkevm-contracts   v8.0.0-rc.4-fork.12   ba0a5d31a69d   About a minute ago   2.53GB
 ```
 
 From now on, the [leovct/zkevm-contracts](https://hub.docker.com/repository/docker/leovct/zkevm-contracts/general) image tags will follow the same tags as [0xPolygonHermez/zkevm-contracts](https://github.com/0xPolygonHermez/zkevm-contracts).
@@ -72,6 +72,7 @@ From now on, the [leovct/zkevm-contracts](https://hub.docker.com/repository/dock
 | 12-RC1 | [v8.0.0-rc.1-fork.12](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v8.0.0-rc.1-fork.12) | [leovct/zkevm-contracts:v8.0.0-rc.1-fork.12](https://hub.docker.com/layers/leovct/zkevm-contracts/v8.0.0-rc.1-fork.12/images/sha256-2197c0b502b93e77bee36a4b87e318a49c6b97bb74b0aca8a13767ef0e684607?context=repo) |
 | 12-RC2 | [v8.0.0-rc.2-fork.12](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v8.0.0-rc.2-fork.12) | [leovct/zkevm-contracts:v8.0.0-rc.2-fork.12](https://hub.docker.com/layers/leovct/zkevm-contracts/v8.0.0-rc.2-fork.12/images/sha256-5d835411ff43efb1008eeede0d25db79f6cb563e86d76b33274bcaebc8f9f7d0?context=repo) |
 | 12-RC3 | [v8.0.0-rc.3-fork.12](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v8.0.0-rc.3-fork.12) | [leovct/zkevm-contracts:v8.0.0-rc.3-fork.12](https://hub.docker.com/layers/leovct/zkevm-contracts/v8.0.0-rc.3-fork.12/images/sha256-f3e9a34651403f246572823249b5f698b4e5d311478f87a84cbfa11c2d091705?context=repo) |
+| 12-RC4 | [v8.0.0-rc.4-fork.12](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v8.0.0-rc.4-fork.12) | [leovct/zkevm-contracts:v8.0.0-rc.4-fork.12](https://hub.docker.com/layers/leovct/zkevm-contracts/v8.0.0-rc.4-fork.12/images/sha256-544b2db63c608b851aa1fd9c4d4e28c63f4253e295a487c4140a6392799f336e?context=repo) |
 
 The following tags are now deprecated:
 

--- a/input_parser.star
+++ b/input_parser.star
@@ -6,7 +6,7 @@ DEFAULT_ARGS = {
     "sequencer_type": "erigon",
     "data_availability_mode": "cdk-validium",
     "additional_services": [],
-    "zkevm_contracts_image": "leovct/zkevm-contracts:v8.0.0-rc.3-fork.12",
+    "zkevm_contracts_image": "leovct/zkevm-contracts:v8.0.0-rc.4-fork.12",
     "zkevm_prover_image": "hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12",
     "zkevm_node_image": "hermeznetwork/zkevm-node:v0.7.3-RC1",
     "cdk_validium_node_image": "0xpolygon/cdk-validium-node:0.7.0-cdk",

--- a/params.yml
+++ b/params.yml
@@ -59,7 +59,7 @@ args:
   # Docker images and repositories used to spin up services.
   # This is a transitional image that includes a fix on top of version v8.0.0-rc.2-fork.12.
   # https://github.com/0xPolygonHermez/zkevm-contracts/pull/323
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.3-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   #zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.2-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Build a new version of the zkevm contracts image. It contains a patch to automatically initialize the `polygonZkEVMGlobalExitRoot` smart contract during deployment.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://github.com/0xPolygonHermez/zkevm-contracts/pull/335
- https://0xpolygon.slack.com/archives/C03QFGTLQCF/p1726843565242389