### PR TITLE
ci: bump versions in tests

### DIFF
--- a/.github/scripts/compare-default-params.sh
+++ b/.github/scripts/compare-default-params.sh
@@ -4,8 +4,8 @@
 # `kurtosis.yml` and `params.yml` where `params.yml` is the source of truth for default parameters.
 # The script outputs the differences between the specified parameters in each file compared to `params.yml`.
 
-INPUT_PARSER_PATH="../../input_parser.star"
-PARAMS_YML_PATH="../../params.yml"
+INPUT_PARSER_PATH="input_parser.star"
+PARAMS_YML_PATH="params.yml"
 
 # Extracting default parameters from the different files.
 echo "Extracting default parameters from input_parser.star..."

--- a/.github/tests/forks/fork11.yml
+++ b/.github/tests/forks/fork11.yml
@@ -5,7 +5,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v1.2.22
   # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=fork11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
 

--- a/.github/tests/forks/fork11.yml
+++ b/.github/tests/forks/fork11.yml
@@ -5,7 +5,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v1.2.22
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
   # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=fork11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
 

--- a/.github/tests/forks/fork11.yml
+++ b/.github/tests/forks/fork11.yml
@@ -1,7 +1,12 @@
 args:
+  # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.11
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.0-RC31-fork.11
+  # https://hub.docker.com/r/hermeznetwork/zkevm-prover/tags?name=fork.11
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
 
+  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v1.2.22
+  # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=fork11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11-RC1
 
   additional_services:

--- a/.github/tests/forks/fork12.yml
+++ b/.github/tests/forks/fork12.yml
@@ -1,9 +1,12 @@
 args:
-  # This is a transitional image that includes a fix on top of version v8.0.0-rc.2-fork.12.
-  # https://github.com/0xPolygonHermez/zkevm-contracts/pull/323
-  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.3-fork.12
-  #zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.2-fork.12
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC10-fork.12
+  # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
+
+  # https://hub.docker.com/r/hermeznetwork/zkevm-prover/tags?name=v8
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
+
+  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
 
   additional_services:
     - tx_spammer

--- a/.github/tests/forks/fork12.yml
+++ b/.github/tests/forks/fork12.yml
@@ -6,7 +6,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
 
   additional_services:
     - tx_spammer

--- a/.github/tests/forks/fork12.yml
+++ b/.github/tests/forks/fork12.yml
@@ -6,7 +6,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
 
   additional_services:
     - tx_spammer

--- a/.github/tests/forks/fork9.yml
+++ b/.github/tests/forks/fork9.yml
@@ -4,6 +4,8 @@ args:
   # https://hub.docker.com/r/hermeznetwork/zkevm-prover/tags?name=v6
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
 
+  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
   # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=v0.7
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
   # https://hub.docker.com/r/0xpolygon/cdk-validium-node/tags?name=0.7

--- a/.github/tests/forks/fork9.yml
+++ b/.github/tests/forks/fork9.yml
@@ -4,8 +4,6 @@ args:
   # https://hub.docker.com/r/hermeznetwork/zkevm-prover/tags?name=v6
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
 
-  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
   # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=v0.7
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
   # https://hub.docker.com/r/0xpolygon/cdk-validium-node/tags?name=0.7

--- a/.github/tests/forks/fork9.yml
+++ b/.github/tests/forks/fork9.yml
@@ -1,8 +1,12 @@
 args:
+  # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.9
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.4
+  # https://hub.docker.com/r/hermeznetwork/zkevm-prover/tags?name=v6
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
 
+  # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=v0.7
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
+  # https://hub.docker.com/r/0xpolygon/cdk-validium-node/tags?name=0.7
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
 
   additional_services:

--- a/.github/tests/pless-zkevm-node/cardona-sepolia-testnet-pless-zkevm-node.yml
+++ b/.github/tests/pless-zkevm-node/cardona-sepolia-testnet-pless-zkevm-node.yml
@@ -16,5 +16,5 @@ args:
   # Cardona/Sepolia is using fork id 9.
   # https://sepolia.etherscan.io/address/0x32d33D5137a7cFFb54c5Bf8371172bcEc5f310ff#readProxyContract#F25
   #  rollupIDToRollupData(1) =>  forkID=9
-  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.4
+  zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.6
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,12 +120,19 @@ jobs:
       - name: Dump enclave logs
         if: failure()
         run: kurtosis dump ./dump
+      
+      - name: Generate archive name
+        run: |
+          file_name=$(basename "${{ matrix.file_name }}" ".yml")
+          archive_name="dump_run_with_args_${file_name}_${{ github.run_id }}"
+          echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
+          echo "Generated archive name: ${archive_name}"
 
       - name: Upload logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: dump_run_with_args_${{ matrix.file_name }}_${{ github.run_id }}
+          name: ${{ env.ARCHIVE_NAME }}
           path: ./dump
 
   additional_services:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,7 @@ jobs:
         run: kurtosis dump ./dump
       
       - name: Generate archive name
+        if: failure()
         run: |
           file_name=$(basename "${{ matrix.file_name }}" ".yml")
           archive_name="dump_run_with_args_${file_name}_${{ github.run_id }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,5 +62,4 @@ jobs:
         run: pip3 install yq
 
       - name: Compare default parameters
-        working-directory: .github/scripts
-        run: ./compare-default-params.sh
+        run: .github/scripts/compare-default-params.sh

--- a/input_parser.star
+++ b/input_parser.star
@@ -17,7 +17,7 @@ DEFAULT_ARGS = {
     "zkevm_bridge_ui_image": "leovct/zkevm-bridge-ui:multi-network",
     "zkevm_bridge_proxy_image": "haproxy:3.0-bookworm",
     "zkevm_sequence_sender_image": "hermeznetwork/zkevm-sequence-sender:v0.2.0-RC12",
-    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:4cf9ba7",
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:0948e33",
     "zkevm_pool_manager_image": "hermeznetwork/zkevm-pool-manager:v0.1.0",
     "zkevm_hash_db_port": 50061,
     "zkevm_executor_port": 50071,

--- a/params.yml
+++ b/params.yml
@@ -60,7 +60,7 @@ args:
   # yq .args .github/tests/forks/fork12.yml
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
 
   # FORK 11 IMAGES
   # yq .args .github/tests/forks/fork11.yml

--- a/params.yml
+++ b/params.yml
@@ -57,11 +57,13 @@ args:
   additional_services: []
 
   # FORK 12 IMAGES
+  # yq .args .github/tests/forks/fork12.yml
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
 
   # FORK 11 IMAGES
+  # yq .args .github/tests/forks/fork11.yml
   # zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   # zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
   # cdk_erigon_node_image: hermeznetwork/cdk-erigon:v1.2.22

--- a/params.yml
+++ b/params.yml
@@ -60,7 +60,7 @@ args:
   # yq .args .github/tests/forks/fork12.yml
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC12-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:4cf9ba7
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
 
   # FORK 11 IMAGES
   # yq .args .github/tests/forks/fork11.yml

--- a/params.yml
+++ b/params.yml
@@ -66,7 +66,7 @@ args:
   # yq .args .github/tests/forks/fork11.yml
   # zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   # zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.2-fork.11
-  # cdk_erigon_node_image: hermeznetwork/cdk-erigon:v1.2.22
+  # cdk_erigon_node_image: hermeznetwork/cdk-erigon:0948e33
 
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3-RC1
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- Bump to latest versions of zkevm-prover, cdk-erigon and zkevm-node in the different tests fork 9, 11 and 12.
- Fix log dump with test matrix.

![Screenshot 2024-10-03 at 15 10 27](https://github.com/user-attachments/assets/e9da3fde-0996-4aa4-8316-1060f6cdd309)

![Screenshot 2024-10-03 at 15 09 59](https://github.com/user-attachments/assets/2a0bcf43-2f6c-47a6-b470-1e1ce3c75248)



## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
