### PR TITLE
fix: ci

### DIFF
--- a/.github/tests/additional-services.yml
+++ b/.github/tests/additional-services.yml
@@ -1,7 +1,7 @@
 args:
   additional_services:
     - arpeggio
-    - blockscout
+    #- blockscout # TODO: Find out why the blockcout backend doesn't start: https://github.com/xavier-romero/kurtosis-blockscout/issues/7
     - blutgang
     - erpc
     - prometheus_grafana


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

After an [update](https://github.com/0xPolygon/kurtosis-cdk/pull/296) of some of the CDK components version, the additional services job fails because the blockscout backend doesn't start.

<img width="1326" alt="Screenshot 2024-10-05 at 11 43 45" src="https://github.com/user-attachments/assets/0eebf5fc-62c4-46e7-8330-96e974679138">

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- Failing job: https://github.com/0xPolygon/kurtosis-cdk/actions/runs/11192146602/job/31115940722#step:4:1295
- I already opened an [issue](https://github.com/xavier-romero/kurtosis-blockscout/issues/7) to track this problem in the [xavier-romero/kurtosis-blockscout](https://github.com/xavier-romero/kurtosis-blockscout) repository.