### PR TITLE
ci: re-enable arpeggio deployment in additional service test

### DIFF
--- a/.github/tests/additional-services.yml
+++ b/.github/tests/additional-services.yml
@@ -1,8 +1,6 @@
 args:
   additional_services:
-    # TODO Find out why the arpeggio service doesn't work properly
-    # For reference: https://github.com/0xPolygon/kurtosis-cdk/pull/302
-    #- arpeggio
+    - arpeggio
     - blockscout
     - blutgang
     - erpc

--- a/.github/tests/additional-services.yml
+++ b/.github/tests/additional-services.yml
@@ -1,9 +1,11 @@
 args:
   additional_services:
     - arpeggio
-    - blockscout
+    # We don't deploy blockscout in CI anymore because it requires too much memory to run.
+    # - blockscout
     - blutgang
     - erpc
     - prometheus_grafana
     - tx_spammer
-    #- pless_zkevm_node # zkevm-node doesn't support fork12
+    # zkevm-node doesn't support fork 12 for now.
+    # - pless_zkevm_node

--- a/.github/tests/additional-services.yml
+++ b/.github/tests/additional-services.yml
@@ -1,7 +1,9 @@
 args:
   additional_services:
+    # TODO Find out why the arpeggio service doesn't work properly
+    # For reference: https://github.com/0xPolygon/kurtosis-cdk/pull/302
     #- arpeggio
-    #- blockscout # TODO: Find out why the blockcout backend doesn't start: https://github.com/xavier-romero/kurtosis-blockscout/issues/7
+    - blockscout
     - blutgang
     - erpc
     - prometheus_grafana


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- Blockscout takes too much memory to run in CI so we'll disable it for now.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
