### PR TITLE
fix: disable erpc

### DIFF
--- a/.github/tests/additional-services.yml
+++ b/.github/tests/additional-services.yml
@@ -3,7 +3,7 @@ args:
     - arpeggio
     # - blockscout # blockscout experiences Out of Memory (OOM) termination when deployed inside github runners.
     - blutgang
-    - erpc
+    # - erpc # erpc images are not available anymore (https://github.com/erpc/erpc/issues/75).
     - prometheus_grafana
     - tx_spammer
     # - pless_zkevm_node # zkevm-node doesn't support fork12.


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

`erpc` image are unavailable for now. Issue has been reported in their repository.

```bash
$ docker run --rm -it ghcr.io/erpc/erpc:0.0.24 /bin/bash                                                                                                                    
Unable to find image 'ghcr.io/erpc/erpc:0.0.24' locally
0.0.24: Pulling from erpc/erpc
docker: manifest unknown.
See 'docker run --help'.
```


For now, we'll just remove the deployment of erpc from the additional services to prevent the CI failling. 

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://github.com/0xPolygon/kurtosis-cdk/actions/runs/11436776463/job/31815831702?pr=312
