### PR TITLE
fix: use different private key to send loadtest from the tx spammer service

### DIFF
--- a/src/additional_services/tx_spammer.star
+++ b/src/additional_services/tx_spammer.star
@@ -46,14 +46,13 @@ def get_tx_spammer_config(plan, args):
                 template=spam_script_template,
                 data={
                     "rpc_url": l2_rpc_url,
-                    "private_key": args["zkevm_l2_admin_private_key"],
+                    "private_key": args["zkevm_l2_loadtest_private_key"],
                 },
             ),
             "bridge.sh": struct(
                 template=bridge_script_template,
                 data={
-                    "zkevm_l2_admin_private_key": args["zkevm_l2_admin_private_key"],
-                    "zkevm_l2_admin_address": args["zkevm_l2_admin_address"],
+                    "private_key": args["zkevm_l2_loadtest_private_key"],
                     "l1_rpc_url": args["l1_rpc_url"],
                     "l2_rpc_url": l2_rpc_url,
                     "zkevm_bridge_api_url": zkevm_bridge_api_url,

--- a/static_files/additional_services/tx-spammer-config/bridge.sh
+++ b/static_files/additional_services/tx-spammer-config/bridge.sh
@@ -9,11 +9,11 @@ cast wallet new -j | jq '.[0]' | tee .bridge.wallet.json
 eth_address="$(jq -r '.address' .bridge.wallet.json)"
 private_key="$(jq -r '.private_key' .bridge.wallet.json)"
 
-until cast send --legacy --private-key "{{.zkevm_l2_admin_private_key}}" --rpc-url "{{.l1_rpc_url}}" --value "$spammer_value" "$eth_address"; do
+until cast send --legacy --private-key "{{.private_key}}" --rpc-url "{{.l1_rpc_url}}" --value "$spammer_value" "$eth_address"; do
     echo "Attempting to fund a test account on layer 1"
 done
 
-until cast send --legacy --private-key "{{.zkevm_l2_admin_private_key}}" --rpc-url "{{.l2_rpc_url}}" --value "$spammer_value" "$eth_address"; do
+until cast send --legacy --private-key "{{.private_key}}" --rpc-url "{{.l2_rpc_url}}" --value "$spammer_value" "$eth_address"; do
     echo "Attempting to fund a test account on layer 2"
 done
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Prevent nonce issues when using the tx spammer in addition to the monitor script that already sends transactions using the admin private key.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/0xPolygon/kurtosis-cdk/actions/runs/11552813017/job/32152686869?pr=335