### PR TITLE
chore: speed up ethereum-pkg deployment by using the default mnemonic

### DIFF
--- a/docs/deterministic-deployment-proxy.md
+++ b/docs/deterministic-deployment-proxy.md
@@ -38,19 +38,19 @@ proxy deployer address which should be `0x4e59b44847b379578588920ca78fbf26c0b495
 
 ### Deploy Contracts on L1
 
-The accounts using the `code code code code code code code code code code code quality`
+The accounts using the `giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete`
 mnemonic are pre-funded on L1, so you can use those accounts to for the contract
 deployments.
 
 ```bash
-polycli wallet inspect --mnemonic "code code code code code code code code code code code quality" | jq -r ".Addresses[0].HexPrivateKey"
+polycli wallet inspect --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete" | jq -r ".Addresses[0].HexPrivateKey"
 ```
 
 ```bash
 cast send \
     --legacy \
     --rpc-url "http://$(kurtosis port print cdk el-1-geth-lighthouse rpc)" \
-    --private-key "0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa" \
+    --private-key "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31" \
     "0x4e59b44847b379578588920ca78fbf26c0b4956c" \
     "$salt$bytecode"
 ```

--- a/docs/native-token/native-token.md
+++ b/docs/native-token/native-token.md
@@ -53,7 +53,7 @@ It depicts several scenarios, such as bridging an ERC20 token from mainnet to an
     export gta=$(kurtosis service exec cdk-v1 contracts-001 "cat /opt/zkevm/create_rollup_parameters.json" | tail -n +2 | jq -r .gasTokenAddress)
     export l1_rpc_url=$(kurtosis port print cdk-v1 el-1-geth-lighthouse rpc)
     cast send \
-    --mnemonic "code code code code code code code code code code code quality" \
+    --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete" \
     --rpc-url "$l1_rpc_url" \
     "$gta" \
     "mint(address,uint256)" \

--- a/input_parser.star
+++ b/input_parser.star
@@ -94,7 +94,7 @@ DEFAULT_ACCOUNTS = {
     # proofsigner
     "zkevm_l2_proofsigner_address": "0x7569cc70950726784c8D3bB256F48e43259Cb445",
     "zkevm_l2_proofsigner_private_key": "0x77254a70a02223acebf84b6ed8afddff9d3203e31ad219b2bf900f4780cf9b51",
-    # l1testing address from the same mnemonic as abvoe - renamed variable for clarity.
+    # l1testing
     "l1_deposit_account": "0xfa291C5f54E4669aF59c6cE1447Dc0b3371EF046",
     "l1_deposit_account_private_key": "0x1324200455e437cd9d9dc4aa61c702f06fb5bc495dc8ad94ae1504107a216b59",
 }

--- a/input_parser.star
+++ b/input_parser.star
@@ -106,7 +106,7 @@ DEFAULT_L1_ARGS = {
     # a) be used to create keystores for all the types of validators that we have, and
     # b) be used to generate a CL genesis.ssz that has the children validator keys already
     # preregistered as validators
-    "l1_preallocated_mnemonic": "code code code code code code code code code code code quality",
+    "l1_preallocated_mnemonic": "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete",
     # The L1 HTTP RPC endpoint.
     "l1_rpc_url": "http://el-1-geth-lighthouse:8545",
     # The L1 WS RPC endpoint.


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

By using the same mnemonic as the ethereum package, we avoid deriving 22 addresses and private keys.

The key derivation process used in the Ethereum package cannot be easily accelerated, as it involves creating an array from the output of a command (a string). This task is not trivial, which is why they opted for this method. Yes, it is a little inefficient, but at least it works in a Starlark environment.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://github.com/ethpandaops/ethereum-package/blob/main/main.star#L93-L99
- https://github.com/ethpandaops/ethereum-package/blob/main/src/package_io/constants.star#L99

