### PR TITLE
chore: bumping versions

### DIFF
--- a/.github/tests/combinations/fork13-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork13-new-cdk-stack-cdk-validium.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v8.1.0-rc.1-fork.13
   zkevm_prover_image: hermeznetwork/zkevm-prover:v9.0.0-RC1-fork.13
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.2.0-RC3
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta1
   additional_services:
     - tx_spammer
   data_availability_mode: cdk-validium

--- a/.github/tests/combinations/fork13-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork13-new-cdk-stack-rollup.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v8.1.0-rc.1-fork.13
   zkevm_prover_image: hermeznetwork/zkevm-prover:v9.0.0-RC1-fork.13
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.2.0-RC3
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta1
   additional_services:
     - tx_spammer
   data_availability_mode: rollup

--- a/.github/tests/forks/fork13.yml
+++ b/.github/tests/forks/fork13.yml
@@ -6,7 +6,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v9.0.0-RC1-fork.13
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.2.0-RC3
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta1
 
   additional_services:
     - tx_spammer

--- a/input_parser.star
+++ b/input_parser.star
@@ -29,7 +29,7 @@ DEFAULT_DEPLOYMENT_STAGES = {
 
 DEFAULT_IMAGES = {
     "agglayer_image": "ghcr.io/agglayer/agglayer:feature-storage-adding-epoch-packing",  # https://github.com/agglayer/agglayer/pkgs/container/agglayer-rs
-    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.1.0",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.1.1",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
     "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.4.0-beta1",  # https://github.com/0xpolygon/cdk/pkgs/container/cdk
     "cdk_validium_node_image": "0xpolygon/cdk-validium-node:0.7.0-cdk",  # https://hub.docker.com/r/0xpolygon/cdk-validium-node/tags
     "zkevm_bridge_proxy_image": "haproxy:3.0-bookworm",  # https://hub.docker.com/_/haproxy/tags


### PR DESCRIPTION
## Description

Bumping to the latest versions. This is especially important for fork 12 testing because the counter limits get adjusted.