### PR TITLE
ci: bump kurtosis version to `1.4.1`

### DIFF
--- a/.github/actions/setup-kurtosis-cdk/action.yml
+++ b/.github/actions/setup-kurtosis-cdk/action.yml
@@ -6,7 +6,7 @@ inputs:
   kurtosis-version:
     description: The version of kurtosis
     required: false
-    default: '1.0.0' # https://github.com/kurtosis-tech/kurtosis/releases
+    default: '1.4.1' # https://github.com/kurtosis-tech/kurtosis/releases
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Bump from `1.0.0` to `1.4.1`.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://github.com/kurtosis-tech/kurtosis/releases/tag/v1.4.1