### PR TITLE
chore: bump cdk-erigon for <= fork12

### DIFF
--- a/.github/tests/combinations/fork11-legacy-zkevm-stack-rollup.yml
+++ b/.github/tests/combinations/fork11-legacy-zkevm-stack-rollup.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11
   additional_services:
     - tx_spammer

--- a/.github/tests/combinations/fork11-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork11-new-cdk-stack-cdk-validium.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11
   additional_services:
     - tx_spammer

--- a/.github/tests/combinations/fork11-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork11-new-cdk-stack-rollup.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11
   additional_services:
     - tx_spammer

--- a/.github/tests/combinations/fork12-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork12-new-cdk-stack-cdk-validium.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC14-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   additional_services:
     - tx_spammer
   data_availability_mode: cdk-validium

--- a/.github/tests/combinations/fork12-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork12-new-cdk-stack-rollup.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC14-fork.12
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   additional_services:
     - tx_spammer
   data_availability_mode: rollup

--- a/.github/tests/combinations/fork9-legacy-zkevm-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork9-legacy-zkevm-stack-cdk-validium.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   additional_services:

--- a/.github/tests/combinations/fork9-legacy-zkevm-stack-rollup.yml
+++ b/.github/tests/combinations/fork9-legacy-zkevm-stack-rollup.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   additional_services:

--- a/.github/tests/combinations/fork9-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork9-new-cdk-stack-cdk-validium.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   additional_services:

--- a/.github/tests/combinations/fork9-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork9-new-cdk-stack-rollup.yml
@@ -1,7 +1,7 @@
 args:
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3
   cdk_validium_node_image: 0xpolygon/cdk-validium-node:0.7.0-cdk
   additional_services:

--- a/.github/tests/forks/fork11.yml
+++ b/.github/tests/forks/fork11.yml
@@ -6,7 +6,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
 
   # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=fork11
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.0-fork11

--- a/.github/tests/forks/fork12.yml
+++ b/.github/tests/forks/fork12.yml
@@ -6,7 +6,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC14-fork.12
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
 
   additional_services:
     - tx_spammer

--- a/.github/tests/forks/fork9.yml
+++ b/.github/tests/forks/fork9.yml
@@ -6,7 +6,7 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
 
   # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.1
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2
 
   # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags?name=v0.7
   zkevm_node_image: hermeznetwork/zkevm-node:v0.7.3


### PR DESCRIPTION
Bump to the latest version