### PR TITLE
ci: zkevm contracts docker image builder

### DIFF
--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -1,0 +1,64 @@
+---
+# Workflow for automatically building and deploying docker images for kurtosis-cdk.
+name: Docker Image Builder
+
+on:
+  workflow_dispatch:
+    inputs:
+      zkevm_contracts_version:
+        description: The ZkEVM contracts version tag to build (e.g., v8.1.0-rc.1-fork.13 or a commit hash)
+        required: true
+
+env:
+  IMAGE_NAME: leovct/zkevm-contracts
+  POLYCLI_VERSION: main
+
+jobs:
+  zkevm-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:      
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.IMAGE_BUILDER_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.IMAGE_BUILDER_DOCKERHUB_TOKEN }}
+
+      - name: Determine full tag
+        id: determine_tag
+        run: |
+          TAG=${{ github.event.inputs.zkevm_contracts_version }}
+          if [[ $TAG == *pp ]]; then
+            FULL_TAG="${TAG}-fork.12"
+          elif [[ $TAG != *-fork.[0-9]* ]]; then
+            FULL_TAG="${TAG}-fork.13"
+          else
+            FULL_TAG=$TAG
+          fi
+          echo "full_tag=$FULL_TAG" >> $GITHUB_OUTPUT
+
+      - name: Check if image already exists
+        id: check_image
+        run: |
+          if docker manifest inspect ${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.full_tag }} > /dev/null 2>&1; then
+            echo "Image already exists, skipping build."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Image does not exist."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build image and push to the Docker Hub
+        if: ${{ steps.check_image.outputs.exists == 'false' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: kurtosis-cdk/docker
+          file: kurtosis-cdk/docker/zkevm-contracts.Dockerfile
+          build-args: |
+            ZKEVM_CONTRACTS_BRANCH=${{ github.event.inputs.zkevm_contracts_version }}
+            POLYCLI_VERSION=${{ env.POLYCLI_VERSION }}
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.full_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -53,8 +53,8 @@ jobs:
         if: ${{ steps.check_image.outputs.exists == 'false' }}
         uses: docker/build-push-action@v6
         with:
-          context: kurtosis-cdk/docker
-          file: kurtosis-cdk/docker/zkevm-contracts.Dockerfile
+          context: docker
+          file: docker/zkevm-contracts.Dockerfile
           build-args: |
             ZKEVM_CONTRACTS_BRANCH=${{ github.event.inputs.zkevm_contracts_version }}
             POLYCLI_VERSION=${{ env.POLYCLI_VERSION }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,7 @@ pushd /tmp/kurtosis-cdk/docker
 
 This image contains all the npm dependencies and zkevm contracts compiled for a specific fork id.
 
-> Automate the build process using this CI [workflow](https://github.com/leovct/zkevm-contracts/actions/workflows/custom-docker-build.yaml). Images will be automatically [pushed](https://hub.docker.com/repository/docker/leovct/zkevm-contracts/general) to the Docker Hub.
+> Automate the build process using this CI [workflow](https://github.com/0xPolygon/kurtosis-cdk/actions/workflows/docker-image-builder.yml). Images will be automatically [pushed](https://hub.docker.com/repository/docker/leovct/zkevm-contracts/general) to the Docker Hub.
 
 Build the `zkevm-contracts` image.
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- Move the automated docker build workflow from my zkevm-contracts fork to the kurtosis-cdk repository.
- Update the `docker` docs.

## Test

The tests have been performed on my [fork](https://github.com/leovct/kurtosis-cdk) of the kurtosis-cdk repository. They required the creation of two new secrets, `IMAGE_BUILDER_DOCKERHUB_USERNAME` and `IMAGE_BUILDER_DOCKERHUB_TOKEN`.

1. Build and push images that already exist on the Docker Hub.

The workflow should skip the build and push part.

- [x] [v8.1.0-rc.1-fork.13](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v8.1.0-rc.1-fork.13): https://github.com/leovct/kurtosis-cdk/actions/runs/11703871078/job/32595118786
- [x] [v9.0.0-rc.2-pp](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v9.0.0-rc.2-pp): https://github.com/leovct/kurtosis-cdk/actions/runs/11704008932

2. Build and push images that don't exist on the Docker Hub.

The workflow should push the images to the Docker Hub.

- [x] [v9.0.0-rc.3-pp](https://github.com/0xPolygonHermez/zkevm-contracts/releases/tag/v9.0.0-rc.3-pp): https://github.com/leovct/kurtosis-cdk/actions/runs/11704067376 and new [image](https://hub.docker.com/layers/leovct/zkevm-contracts/v9.0.0-rc.3-pp-fork.12/images/sha256-e57df065c050ade86d81d708155545685150a18b03030835385303dce59a34bd?context=explore) pushed to the docker hub
- [x] [4912f4b](https://github.com/0xPolygonHermez/zkevm-contracts/commit/4912f4b673015209b3dbe1dd0702a9ffec5c9261): https://github.com/leovct/kurtosis-cdk/actions/runs/11704070098 (the image has been deleted from the docker hub)

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- Follow up of #351.
- https://polygon.enterprise.slack.com/lists/T8VPLGV4Z/F07AWFULS49?record_id=Rec07V48FFZDF
