### PR TITLE
Enabling L2 Deployment for CI Tests Only

### DIFF
--- a/.github/tests/combinations/fork11-legacy-zkevm-stack-rollup.yml
+++ b/.github/tests/combinations/fork11-legacy-zkevm-stack-rollup.yml
@@ -7,6 +7,7 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: rollup
   sequencer_type: zkevm
 deployment_stages:

--- a/.github/tests/combinations/fork11-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork11-new-cdk-stack-cdk-validium.yml
@@ -7,5 +7,6 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: cdk-validium
   sequencer_type: erigon

--- a/.github/tests/combinations/fork11-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork11-new-cdk-stack-rollup.yml
@@ -7,5 +7,6 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: rollup
   sequencer_type: erigon

--- a/.github/tests/combinations/fork12-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork12-new-cdk-stack-cdk-validium.yml
@@ -6,5 +6,6 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: cdk-validium
   sequencer_type: erigon

--- a/.github/tests/combinations/fork12-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork12-new-cdk-stack-rollup.yml
@@ -6,5 +6,6 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: rollup
   sequencer_type: erigon

--- a/.github/tests/combinations/fork13-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork13-new-cdk-stack-cdk-validium.yml
@@ -6,5 +6,6 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: cdk-validium
   sequencer_type: erigon

--- a/.github/tests/combinations/fork13-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork13-new-cdk-stack-rollup.yml
@@ -6,5 +6,6 @@ args:
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
   additional_services:
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: rollup
   sequencer_type: erigon

--- a/.github/tests/combinations/fork9-legacy-zkevm-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork9-legacy-zkevm-stack-cdk-validium.yml
@@ -9,6 +9,7 @@ args:
   additional_services:
     - pless_zkevm_node
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: cdk-validium
   sequencer_type: zkevm
 deployment_stages:

--- a/.github/tests/combinations/fork9-legacy-zkevm-stack-rollup.yml
+++ b/.github/tests/combinations/fork9-legacy-zkevm-stack-rollup.yml
@@ -9,6 +9,7 @@ args:
   additional_services:
     - pless_zkevm_node
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: rollup
   sequencer_type: zkevm
 deployment_stages:

--- a/.github/tests/combinations/fork9-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork9-new-cdk-stack-cdk-validium.yml
@@ -9,5 +9,6 @@ args:
   additional_services:
     - pless_zkevm_node
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: cdk-validium
   sequencer_type: erigon

--- a/.github/tests/combinations/fork9-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork9-new-cdk-stack-rollup.yml
@@ -9,5 +9,6 @@ args:
   additional_services:
     - pless_zkevm_node
     - tx_spammer
+  deploy_l2_contracts: true
   consensus_contract_type: rollup
   sequencer_type: erigon

--- a/.github/tests/forks/fork11.yml
+++ b/.github/tests/forks/fork11.yml
@@ -19,3 +19,5 @@ args:
 
   additional_services:
     - tx_spammer
+
+  deploy_l2_contracts: true

--- a/.github/tests/forks/fork12.yml
+++ b/.github/tests/forks/fork12.yml
@@ -16,3 +16,5 @@ args:
 
   additional_services:
     - tx_spammer
+
+  deploy_l2_contracts: true

--- a/.github/tests/forks/fork13.yml
+++ b/.github/tests/forks/fork13.yml
@@ -16,3 +16,5 @@ args:
 
   additional_services:
     - tx_spammer
+
+  deploy_l2_contracts: true

--- a/.github/tests/forks/fork9.yml
+++ b/.github/tests/forks/fork9.yml
@@ -23,3 +23,5 @@ args:
   additional_services:
     - pless_zkevm_node
     - tx_spammer
+
+  deploy_l2_contracts: true

--- a/input_parser.star
+++ b/input_parser.star
@@ -25,13 +25,13 @@ DEFAULT_DEPLOYMENT_STAGES = {
     # TODO: Remove this parameter to incorporate cdk-erigon inside the central environment.
     "deploy_cdk_erigon_node": True,
     # Deploy contracts on L2 (as well as fund accounts).
-    "deploy_l2_contracts": True,
+    "deploy_l2_contracts": False,
 }
 
 DEFAULT_IMAGES = {
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.2.0-rc.5",  # https://github.com/agglayer/agglayer/pkgs/container/agglayer-rs
     "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.1.2",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
-    "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.4.0-beta4",  # https://github.com/0xpolygon/cdk/pkgs/container/cdk
+    "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.4.0-beta5",  # https://github.com/0xpolygon/cdk/pkgs/container/cdk
     "cdk_validium_node_image": "0xpolygon/cdk-validium-node:0.7.0-cdk",  # https://hub.docker.com/r/0xpolygon/cdk-validium-node/tags
     "zkevm_bridge_proxy_image": "haproxy:3.0-bookworm",  # https://hub.docker.com/_/haproxy/tags
     "zkevm_bridge_service_image": "hermeznetwork/zkevm-bridge-service:v0.6.0-RC1",  # https://hub.docker.com/r/hermeznetwork/zkevm-bridge-service/tags

--- a/templates/contract-deploy/deploy_parameters.json
+++ b/templates/contract-deploy/deploy_parameters.json
@@ -5,7 +5,7 @@
     "initialZkEVMDeployerOwner": "{{.zkevm_l2_admin_address}}",
     "maxFeePerGas": "",
     "maxPriorityFeePerGas": "",
-    "minDelayTimelock": 3600,
+    "minDelayTimelock": 60,
     "multiplierGas": "",
     "pendingStateTimeout": 604799,
     "polTokenAddress":"",


### PR DESCRIPTION
## Description
There are three small changes here:
1. I'm disabling the l2 deployment process by default. This should speed things up slightly. But I'm keeping it in place for CI since it can help detect errors
2. I changing the default timelock delay to better support upgrade testing
3. I'm bumping to the latest cdk version.
