### PR TITLE
feat: deploy without exposing secrets stored in `args`

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -265,6 +265,10 @@ DEFAULT_ARGS = (
         # Suffix appended to service names.
         # Note: It should be a string.
         "deployment_suffix": "-001",
+        # Verbosity of the `kurtosis run` output.
+        # Valid values are "error", "warn", "info", "debug", and "trace".
+        # By default, the verbosity is set to "info". It won't log the value of the args.
+        "verbosity": "info",
         # The global log level that all components of the stack should log at.
         # Valid values are "error", "warn", "info", "debug", and "trace".
         "global_log_level": "info",
@@ -312,8 +316,11 @@ def parse_args(plan, args):
     args = DEFAULT_ARGS | args.get("args", {})
 
     # Validation step.
+    verbosity = args.get("verbosity", "")
+    validate_log_level("verbosity", verbosity)
+
     global_log_level = args.get("global_log_level", "")
-    validate_global_log_level(global_log_level)
+    validate_log_level("global log level", global_log_level)
 
     # Determine fork id from the zkevm contracts image tag.
     zkevm_contracts_image = args.get("zkevm_contracts_image", "")
@@ -363,22 +370,23 @@ def parse_args(plan, args):
     return (sorted_deployment_stages, sorted_args)
 
 
-def validate_global_log_level(global_log_level):
-    if global_log_level not in (
-        constants.GLOBAL_LOG_LEVEL.error,
-        constants.GLOBAL_LOG_LEVEL.warn,
-        constants.GLOBAL_LOG_LEVEL.info,
-        constants.GLOBAL_LOG_LEVEL.debug,
-        constants.GLOBAL_LOG_LEVEL.trace,
+def validate_log_level(name, log_level):
+    if log_level not in (
+        constants.LOG_LEVEL.error,
+        constants.LOG_LEVEL.warn,
+        constants.LOG_LEVEL.info,
+        constants.LOG_LEVEL.debug,
+        constants.LOG_LEVEL.trace,
     ):
         fail(
-            "Unsupported global log level: '{}', please use '{}', '{}', '{}', '{}' or '{}'".format(
-                global_log_level,
-                constants.GLOBAL_LOG_LEVEL.error,
-                constants.GLOBAL_LOG_LEVEL.warn,
-                constants.GLOBAL_LOG_LEVEL.info,
-                constants.GLOBAL_LOG_LEVEL.debug,
-                constants.GLOBAL_LOG_LEVEL.trace,
+            "Unsupported {}: '{}', please use '{}', '{}', '{}', '{}' or '{}'".format(
+                name,
+                log_level,
+                constants.LOG_LEVEL.error,
+                constants.LOG_LEVEL.warn,
+                constants.LOG_LEVEL.info,
+                constants.LOG_LEVEL.debug,
+                constants.LOG_LEVEL.trace,
             )
         )
 

--- a/main.star
+++ b/main.star
@@ -67,7 +67,7 @@ def run(plan, args={}):
     # Get the genesis file.
     genesis_artifact = ""
     if deployment_stages.get("deploy_cdk_central_environment", False):
-        plan.print("Getting genesis file...")
+        plan.print("Getting genesis file")
         genesis_artifact = plan.store_service_files(
             name="genesis",
             service_name="contracts" + args["deployment_suffix"],

--- a/main.star
+++ b/main.star
@@ -29,7 +29,8 @@ def run(plan, args={}):
     # Parse args.
     (deployment_stages, args) = input_parser.parse_args(plan, args)
     plan.print("Deploying the following components: " + str(deployment_stages))
-    plan.print("Deploying CDK stack with the following configuration: " + str(args))
+    if verbosity == constants.LOG_LEVEL.debug or verbosity == constants.LOG_LEVEL.trace:
+        plan.print("Deploying CDK stack with the following configuration: " + str(args))
 
     # Deploy a local L1.
     if deployment_stages.get("deploy_l1", False):

--- a/main.star
+++ b/main.star
@@ -29,6 +29,7 @@ def run(plan, args={}):
     # Parse args.
     (deployment_stages, args) = input_parser.parse_args(plan, args)
     plan.print("Deploying the following components: " + str(deployment_stages))
+    verbosity = args.get("verbosity", "")
     if verbosity == constants.LOG_LEVEL.debug or verbosity == constants.LOG_LEVEL.trace:
         plan.print("Deploying CDK stack with the following configuration: " + str(args))
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -1,4 +1,4 @@
-GLOBAL_LOG_LEVEL = struct(
+LOG_LEVEL = struct(
     error="error",
     warn="warn",
     info="info",


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The goal of this PR is to be able to deploy an enclave without exposing secrets stored in `args`.

The `args` struct should not be logged by default. It should only be logged if the `verbosity` flag is set to `debug` or `trace`, by default it is set to `info`.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

Before

![Screenshot 2024-11-12 at 15 32 06](https://github.com/user-attachments/assets/d2b906a0-d834-4fce-b819-e233861bf4ec)

After

![Screenshot 2024-11-12 at 15 39 09](https://github.com/user-attachments/assets/c81e6fa2-bc13-433b-9999-9f9f34efbd67)
