### PR TITLE
revert: zkevm-bridge-ui image changes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -30,7 +30,6 @@ Kurtosis CDK's zkevm bridge UI images are [hosted](https://hub.docker.com/reposi
 
 | zkEVM Bridge UI Tag / Commit | Image |
 | ---------------------------- | ----- |
-| [develop@0006445](https://github.com/0xPolygonHermez/zkevm-bridge-ui/commit/0006445e1cace5c4d737523fca44af7f7261e041) + [patch files](./zkevm-bridge-ui/) | `leovct/zkevm-bridge-ui:multi-network-2` |
 | [develop@0006445](https://github.com/0xPolygonHermez/zkevm-bridge-ui/commit/0006445e1cace5c4d737523fca44af7f7261e041) | `leovct/zkevm-bridge-ui:multi-network` |
 
 ## Custom Docker Images

--- a/docker/zkevm-bridge-ui/deploy.sh.diff
+++ b/docker/zkevm-bridge-ui/deploy.sh.diff
@@ -1,32 +1,13 @@
 diff --git a/scripts/deploy.sh b/scripts/deploy.sh
-index 22e5b09..b751cbd 100644
+index 22e5b09..00da634 100644
 --- a/scripts/deploy.sh
 +++ b/scripts/deploy.sh
 @@ -21,6 +21,9 @@ echo "VITE_POLYGON_ZK_EVM_NETWORK_ID=$POLYGON_ZK_EVM_NETWORK_ID" >> $ENV_FILENAM
  # BRIDGE API env vars
  echo "VITE_BRIDGE_API_URL=$BRIDGE_API_URL" >> $ENV_FILENAME
- 
+
 +# Support for relative URLS
 +echo "VITE_RESOLVE_RELATIVE_URLS=$RESOLVE_RELATIVE_URLS" >> $ENV_FILENAME
 +
  # FIAT EXCHANGE RATES API env vars
  echo "VITE_ENABLE_FIAT_EXCHANGE_RATES=$ENABLE_FIAT_EXCHANGE_RATES" >> $ENV_FILENAME
- 
-@@ -91,17 +94,5 @@ fi
- echo "Generated .env file:"
- echo "$(cat /app/.env)"
- 
--# Build app
--cd /app && npm run build
--
--# Copy nginx config
--cp /app/deployment/nginx.conf /etc/nginx/conf.d/default.conf
--
--# Copy app dist
--cp -r /app/dist/. /usr/share/nginx/html
--
--# Delete source code
--rm -rf /app
--
- # Run nginx
- nginx -g 'daemon off;'

--- a/docker/zkevm-bridge-ui/zkevm-bridge-ui.Dockerfile
+++ b/docker/zkevm-bridge-ui/zkevm-bridge-ui.Dockerfile
@@ -1,30 +1,35 @@
 FROM alpine:3.20 AS builder
-
 # STEP 1: Clone zkevm-bridge-ui repository.
 ARG ZKEVM_BRIDGE_UI_TAG
 WORKDIR /opt/zkevm-bridge-ui
 # WARNING (DL3018): Pin versions in apk add.
 # hadolint ignore=DL3018
-RUN apk add --no-cache git nodejs npm patch \
+RUN apk add --no-cache git patch \
   && rm -rf /var/cache/apk/* \
   && git clone --branch ${ZKEVM_BRIDGE_UI_TAG} https://github.com/0xPolygonHermez/zkevm-bridge-ui .
 
-# STEP 2: Apply patches and build the app.
+# STEP 2: Apply patches.
 COPY deploy.sh.diff env.ts.diff ./
 RUN patch -p1 -i deploy.sh.diff \
-  && patch -p1 -i env.ts.diff \
-  && npm install \
-  && npm run build
+  && patch -p1 -i env.ts.diff
 
 
-# STEP 3: Serve the app using nginx.
+# STEP 3: Build zkevm-bridge-ui image using the official Dockerfile.
 FROM nginx:alpine
 LABEL author="devtools@polygon.technology"
 LABEL description="Enhanced zkevm-bridge-ui image with relative URLs support enabled"
 
-COPY --from=builder /opt/zkevm-bridge-ui/dist /usr/share/nginx/html
-COPY --from=builder /opt/zkevm-bridge-ui/deployment/nginx.conf /etc/nginx/conf.d/default.conf
+# WARNING (DL3018): Pin versions in apk add.
+# hadolint ignore=DL3018
+RUN apk add --no-cache nodejs npm \
+  && rm -rf /var/cache/apk/*
 
 WORKDIR /app
+COPY --from=builder /opt/zkevm-bridge-ui/package.json /opt/zkevm-bridge-ui/package-lock.json ./
 COPY --from=builder /opt/zkevm-bridge-ui/scripts ./scripts
+COPY --from=builder /opt/zkevm-bridge-ui/abis ./abis
+RUN npm install
+COPY --from=builder /opt/zkevm-bridge-ui/ .
+
+WORKDIR /
 ENTRYPOINT ["/bin/sh", "/app/scripts/deploy.sh"]


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Revert most of the zkevm-bridge-ui changes made in #333.

We tried to speed up the zkevm-bridge-ui startup process by building the app directly in the `Dockerfile`. Unfortunately, this solution doesn't work because [Vite replaces environment variables at build time and not run time](https://github.com/vitejs/vite/issues/10059). This explains why the bridge UI complains about environment variables being not defined.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- Related to #363
 