### PR TITLE
fix: cdk node l1infotree sync configuration

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -422,6 +422,7 @@ def get_fork_id(zkevm_contracts_image):
     fork_name = "elderberry"
     if fork_id >= 12:
         fork_name = "banana"
+    # TODO: Add support for durian once released.
 
     return (fork_id, fork_name)
 

--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -4,17 +4,8 @@ L2URL="http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"
 AggLayerURL="{{.agglayer_url}}"
 
 ForkId = {{.zkevm_rollup_fork_id}}
+ContractVersions = "{{.zkevm_rollup_fork_name}}"
 IsValidiumMode = {{.is_cdk_validium}}
-
-{{if eq .zkevm_rollup_fork_id "12"}}
-ContractVersions = "banana"
-{{else if eq .zkevm_rollup_fork_id "13"}}
-# Doesn't look like this is needed at the moment, but soon perhaps?
-# ContractVersions = "durian"
-ContractVersions = "banana"
-{{else}}
-ContractVersions = "elderberry"
-{{end}}
 
 L2Coinbase =  "{{.zkevm_l2_sequencer_address}}"
 SequencerPrivateKeyPath = "{{or .zkevm_l2_sequencer_keystore_file "/etc/cdk/sequencer.keystore"}}"

--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -67,3 +67,7 @@ Outputs = ["stderr"]
 CertificateSendInterval = "1m"
 CheckSettledInterval = "5s"
 
+[L1InfoTreeSync]
+# The initial block number from which to start syncing.
+# Default: 0
+InitialBlock = {{.zkevm_rollup_manager_block_number}}


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

While deploying the stack on external L1s like Sepolia using kurtosis-cdk, some users noticed that the cdk node was syncing from genesis instead of syncing from the rollup manager deployment block. It turns out the cdk node configuration is a bit outdated. Some settings are not set, instead, we rely on default values. For example, the L1 InfoTreeSync initial block is set to zero by default which explains why the cdk node syncs from the genesis block. This PR addresses this specific issue.

- Minor: Simplify the way contract versions is set in the config.
- Next steps: update and document the cdk node configuration.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://discord.com/channels/893151281848406016/1306202853244665867/1306593102902857780
