### PR TITLE
feat: pre-deployed erc20 gas token

### DIFF
--- a/.github/tests/additional-services.yml
+++ b/.github/tests/additional-services.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   additional_services:
     - arpeggio
     # - blockscout # blockscout experiences Out of Memory (OOM) termination when deployed inside github runners.

--- a/.github/tests/attach-second-cdk.yml
+++ b/.github/tests/attach-second-cdk.yml
@@ -3,6 +3,7 @@ deployment_stages:
   deploy_agglayer: false
 
 args:
+  verbosity: debug
   deployment_suffix: "-002"
   zkevm_rollup_chain_id: 20202
   zkevm_rollup_id: 2

--- a/.github/tests/combinations/fork11-legacy-zkevm-stack-rollup.yml
+++ b/.github/tests/combinations/fork11-legacy-zkevm-stack-rollup.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork11-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork11-new-cdk-stack-cdk-validium.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork11-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork11-new-cdk-stack-rollup.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
   zkevm_prover_image: hermeznetwork/zkevm-prover:v7.0.4-fork.11
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork12-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork12-new-cdk-stack-cdk-validium.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC14-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork12-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork12-new-cdk-stack-rollup.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC14-fork.12
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork13-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork13-new-cdk-stack-cdk-validium.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v8.1.0-rc.1-fork.13
   zkevm_prover_image: hermeznetwork/zkevm-prover:v9.0.0-RC2-fork.13
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork13-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork13-new-cdk-stack-rollup.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v8.1.0-rc.1-fork.13
   zkevm_prover_image: hermeznetwork/zkevm-prover:v9.0.0-RC2-fork.13
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta10

--- a/.github/tests/combinations/fork9-legacy-zkevm-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork9-legacy-zkevm-stack-cdk-validium.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2

--- a/.github/tests/combinations/fork9-legacy-zkevm-stack-rollup.yml
+++ b/.github/tests/combinations/fork9-legacy-zkevm-stack-rollup.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2

--- a/.github/tests/combinations/fork9-new-cdk-stack-cdk-validium.yml
+++ b/.github/tests/combinations/fork9-new-cdk-stack-cdk-validium.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2

--- a/.github/tests/combinations/fork9-new-cdk-stack-rollup.yml
+++ b/.github/tests/combinations/fork9-new-cdk-stack-rollup.yml
@@ -1,4 +1,5 @@
 args:
+  verbosity: debug
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
   zkevm_prover_image: hermeznetwork/zkevm-prover:v6.0.8
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.1.2

--- a/.github/tests/external-l1/deploy-cdk-to-local-l1.yml
+++ b/.github/tests/external-l1/deploy-cdk-to-local-l1.yml
@@ -1,0 +1,6 @@
+deployment_stages:
+  # Disable local L1.
+  deploy_l1: false
+
+args:
+  verbosity: debug

--- a/.github/tests/external-l1/deploy-cdk-to-sepolia.yml
+++ b/.github/tests/external-l1/deploy-cdk-to-sepolia.yml
@@ -3,6 +3,8 @@ deployment_stages:
   deploy_l1: false
 
 args:
+  verbosity: debug
+
   ## L1 Config
   l1_chain_id: 11155111
   # TODO: Create another mnemonic seed phrase for running the contract deployment on L1.

--- a/.github/tests/external-l1/deploy-local-l1.yml
+++ b/.github/tests/external-l1/deploy-local-l1.yml
@@ -7,3 +7,6 @@ deployment_stages:
   deploy_agglayer: false
   deploy_cdk_erigon_node: false
   deploy_l2_contracts: false
+
+args:
+  verbosity: debug

--- a/.github/tests/fork12-pessimistic.yml
+++ b/.github/tests/fork12-pessimistic.yml
@@ -9,6 +9,5 @@ args:
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
-  zkevm_use_gas_token_contract: false
   #agglayer_prover_sp1_key: 
   enable_normalcy: true

--- a/.github/tests/forks/fork11.yml
+++ b/.github/tests/forks/fork11.yml
@@ -1,4 +1,6 @@
 args:
+  verbosity: debug
+
   # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.11
   zkevm_contracts_image: leovct/zkevm-contracts:v7.0.0-rc.2-fork.11
 

--- a/.github/tests/forks/fork12.yml
+++ b/.github/tests/forks/fork12.yml
@@ -1,4 +1,6 @@
 args:
+  verbosity: debug
+
   # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.12
   zkevm_contracts_image: leovct/zkevm-contracts:v8.0.0-rc.4-fork.12
 

--- a/.github/tests/forks/fork13.yml
+++ b/.github/tests/forks/fork13.yml
@@ -1,4 +1,6 @@
 args:
+  verbosity: debug
+
   # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.12
   zkevm_contracts_image: leovct/zkevm-contracts:v8.1.0-rc.1-fork.13
 

--- a/.github/tests/forks/fork9.yml
+++ b/.github/tests/forks/fork9.yml
@@ -1,4 +1,6 @@
 args:
+  verbosity: debug
+
   # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags?name=fork.9
   zkevm_contracts_image: leovct/zkevm-contracts:v6.0.0-rc.1-fork.9
 

--- a/.github/tests/gas-token.yml
+++ b/.github/tests/gas-token.yml
@@ -1,2 +1,0 @@
-args:
-  zkevm_use_gas_token_contract: true

--- a/.github/tests/gas-token/auto.yml
+++ b/.github/tests/gas-token/auto.yml
@@ -1,0 +1,2 @@
+args:
+  gas_token_enabled: true

--- a/.github/tests/gas-token/auto.yml
+++ b/.github/tests/gas-token/auto.yml
@@ -1,2 +1,3 @@
 args:
+  verbosity: debug
   gas_token_enabled: true

--- a/.github/tests/gas-token/pre-deployed.yml
+++ b/.github/tests/gas-token/pre-deployed.yml
@@ -1,3 +1,4 @@
 args:
+  verbosity: debug
   gas_token_enabled: true
   gas_token_address: "0xCHANGEME"

--- a/.github/tests/gas-token/pre-deployed.yml
+++ b/.github/tests/gas-token/pre-deployed.yml
@@ -1,3 +1,3 @@
 args:
   gas_token_enabled: true
-  gas_token_address: ""
+  gas_token_address: "0xCHANGEME"

--- a/.github/tests/gas-token/pre-deployed.yml
+++ b/.github/tests/gas-token/pre-deployed.yml
@@ -1,0 +1,3 @@
+args:
+  gas_token_enabled: true
+  gas_token_address: ""

--- a/.github/tests/pless-zkevm-node/cardona-sepolia-testnet-pless-zkevm-node.yml
+++ b/.github/tests/pless-zkevm-node/cardona-sepolia-testnet-pless-zkevm-node.yml
@@ -9,6 +9,7 @@ deployment_stages:
   deploy_l2_contracts: false
 
 args:
+  verbosity: debug
   additional_services:
     - pless_zkevm_node
   l1_rpc_url: CHANGE_ME

--- a/.github/tests/static-ports/custom-static-ports-cdk-erigon-sequencer-ds.yml
+++ b/.github/tests/static-ports/custom-static-ports-cdk-erigon-sequencer-ds.yml
@@ -1,6 +1,7 @@
 # Only expose the datastream port of the cdk-erigon sequencer to a static public port.
 # All the other ports will be allocated dynamically using Kurtosis.
 args:
+  verbosity: debug
   use_dynamic_ports: false
   static_ports:
     cdk_erigon_sequencer_start_port: 61700

--- a/.github/tests/static-ports/custom-static-ports.yml
+++ b/.github/tests/static-ports/custom-static-ports.yml
@@ -2,6 +2,7 @@
 # - L1 services will be exposed on the range 60000-60999.
 # - L2 services on the range 61000-61999.
 args:
+  verbosity: debug
   use_dynamic_ports: false
   static_ports:
     # L1 public ports (60000-60999).

--- a/.github/tests/static-ports/default-static-ports.yml
+++ b/.github/tests/static-ports/default-static-ports.yml
@@ -2,4 +2,5 @@
 # - L1 services will be exposed on the range 50000-50999.
 # - L2 services on the range 51000-51999.
 args:
+  verbosity: debug
   use_dynamic_ports: false

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -1,101 +1,101 @@
-name: Test e2e
-on: 
-  pull_request:
-  push:
-    branches: [main]
-  workflow_dispatch: {}
+# name: Test e2e
+# on: 
+#   pull_request:
+#   push:
+#     branches: [main]
+#   workflow_dispatch: {}
 
-jobs:
-  test-e2e:
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [ 1.22.x ]
-        goarch: [ "amd64" ]
-        e2e-group:
-          - "fork9-validium"
-          - "fork11-rollup"
-          - "fork12-validium"
-          - "fork12-rollup"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+# jobs:
+#   test-e2e:
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         go-version: [ 1.22.x ]
+#         goarch: [ "amd64" ]
+#         e2e-group:
+#           - "fork9-validium"
+#           - "fork11-rollup"
+#           - "fork12-validium"
+#           - "fork12-rollup"
+#     runs-on: ubuntu-latest
+#     steps:
+#     - name: Checkout code
+#       uses: actions/checkout@v4
 
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-      env:
-        GOARCH: ${{ matrix.goarch }}
+#     - name: Install Go
+#       uses: actions/setup-go@v5
+#       with:
+#         go-version: ${{ matrix.go-version }}
+#       env:
+#         GOARCH: ${{ matrix.goarch }}
  
-    - name: Install kurtosis
-      shell: bash
-      run: |
-        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-        sudo apt update
-        sudo apt install kurtosis-cli=1.4.1
-        kurtosis version
+#     - name: Install kurtosis
+#       shell: bash
+#       run: |
+#         echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+#         sudo apt update
+#         sudo apt install kurtosis-cli=1.4.1
+#         kurtosis version
 
-    - name: Disable kurtosis analytics
-      shell: bash
-      run: kurtosis analytics disable
+#     - name: Disable kurtosis analytics
+#       shell: bash
+#       run: kurtosis analytics disable
 
-    - name: Install yq
-      shell: bash
-      run: |
-        pip3 install yq
-        yq --version
+#     - name: Install yq
+#       shell: bash
+#       run: |
+#         pip3 install yq
+#         yq --version
 
-    - name: Install polycli
-      run: |
-        POLYCLI_VERSION="v0.1.63"
-        tmp_dir=$(mktemp -d) 
-        curl -L "https://github.com/0xPolygon/polygon-cli/releases/download/${POLYCLI_VERSION}/polycli_${POLYCLI_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$tmp_dir" 
-        mv "$tmp_dir"/* /usr/local/bin/polycli 
-        rm -rf "$tmp_dir"
-        sudo chmod +x /usr/local/bin/polycli
-        /usr/local/bin/polycli version
+#     - name: Install polycli
+#       run: |
+#         POLYCLI_VERSION="v0.1.63"
+#         tmp_dir=$(mktemp -d) 
+#         curl -L "https://github.com/0xPolygon/polygon-cli/releases/download/${POLYCLI_VERSION}/polycli_${POLYCLI_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$tmp_dir" 
+#         mv "$tmp_dir"/* /usr/local/bin/polycli 
+#         rm -rf "$tmp_dir"
+#         sudo chmod +x /usr/local/bin/polycli
+#         /usr/local/bin/polycli version
 
-    - name: Install foundry
-      uses: foundry-rs/foundry-toolchain@v1
+#     - name: Install foundry
+#       uses: foundry-rs/foundry-toolchain@v1
 
-    - name: checkout polygon-cdk
-      uses: actions/checkout@v4
-      with:
-        repository: 0xPolygon/cdk
-        path: "cdk"
-        ref: "v0.4.0-beta10"
+#     - name: checkout polygon-cdk
+#       uses: actions/checkout@v4
+#       with:
+#         repository: 0xPolygon/cdk
+#         path: "cdk"
+#         ref: "v0.4.0-beta10"
 
-    - name: Build Docker
-      run: make build-docker
-      working-directory: ${{ github.workspace }}/cdk
+#     - name: Build Docker
+#       run: make build-docker
+#       working-directory: ${{ github.workspace }}/cdk
 
-    - name: Setup Bats and bats libs
-      uses: bats-core/bats-action@2.0.0
+#     - name: Setup Bats and bats libs
+#       uses: bats-core/bats-action@2.0.0
 
-    - name: Test
-      run: make test-e2e-${{ matrix.e2e-group }}
-      working-directory: ./cdk/test
-      env:
-        KURTOSIS_FOLDER: ${{ github.workspace }}
-        BATS_LIB_PATH: /usr/lib/
+#     - name: Test
+#       run: make test-e2e-${{ matrix.e2e-group }}
+#       working-directory: ./cdk/test
+#       env:
+#         KURTOSIS_FOLDER: ${{ github.workspace }}
+#         BATS_LIB_PATH: /usr/lib/
     
-    - name: Dump enclave logs
-      if: failure()
-      run: kurtosis dump ./dump
+#     - name: Dump enclave logs
+#       if: failure()
+#       run: kurtosis dump ./dump
 
-    - name: Generate archive name
-      if: failure()
-      run: |
-        archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
-        echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
-        echo "Generated archive name: ${archive_name}"
-        kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
+#     - name: Generate archive name
+#       if: failure()
+#       run: |
+#         archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
+#         echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
+#         echo "Generated archive name: ${archive_name}"
+#         kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
 
-    - name: Upload logs
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.ARCHIVE_NAME }}
-        path: ./dump
+#     - name: Upload logs
+#       if: failure()
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: ${{ env.ARCHIVE_NAME }}
+#         path: ./dump

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,8 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Run Starlark
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false . '{"args": {"verbosity": "debug"}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -121,7 +122,8 @@ jobs:
         run: ./combine-ymls.sh
 
       - name: Run Starlark
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=${{ matrix.file_name }} --show-enclave-inspect=false .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=${{ matrix.file_name }} --show-enclave-inspect=false . '{"args": {"verbosity": "debug"}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -215,7 +217,8 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Deploy L1 chain
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml . '{"args": {"verbosity": "debug"}}'
       
       - name: Deploy gas token on L1
         run: |
@@ -250,7 +253,7 @@ jobs:
             --enclave=${{ env.ENCLAVE_NAME }} \
             --args-file=./.github/tests/gas-token/pre-deployed.yml \
             . \
-            '{"deployment_stages": {"deploy_l1": false}}'
+            '{"deployment_stages": {"deploy_l1": false}, "args": {"verbosity": "debug"}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -295,7 +298,8 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Run Starlark
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/additional-services.yml --show-enclave-inspect=false .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/additional-services.yml --show-enclave-inspect=false . '{"args": {"verbosity": "debug"}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -398,10 +402,12 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Deploy L1 chain and a first CDK L2 chain (cdk-erigon sequencer + cdk stack)
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"args": {"verbosity": "debug"}}'
 
       - name: Attach a second CDK L2 chain (cdk-erigon sequencer + cdk stack)
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-second-cdk.yml .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-second-cdk.yml . '{"args": {"verbosity": "debug"}}'
 
       - name: Update the agglayer config
         run: |
@@ -467,11 +473,12 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Deploy L1 chain
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml .
+        run: |
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml . '{"args": {"verbosity": "debug"}}'
 
       - name: Deploy to local L1 chain
         run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"deployment_stages": {"deploy_l1": false}}'
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"deployment_stages": {"deploy_l1": false}, "args": {"verbosity": "debug"}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,12 @@ jobs:
       - id: set-matrix
         # List all yml files in the .github/tests directory, as well as test combinations, except for the additional-services.yml file.
         run: |
-          files=$(ls -R ./.github/tests/combinations/*.yml ./.github/tests/static-ports/custom-static-ports.yml ./.github/tests/static-ports/default-static-ports.yml | grep -v 'additional-services.yml')
+          files=$(ls -R \
+            ./.github/tests/combinations/*.yml \
+            ./.github/tests/gas-token/auto.yml \
+            ./.github/tests/static-ports/custom-static-ports.yml \
+            ./.github/tests/static-ports/default-static-ports.yml \
+            | grep -v 'additional-services.yml')
           matrix=$(echo "$files" | jq -R -s -c 'split("\n")[:-1]')
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,6 +193,86 @@ jobs:
           name: ${{ env.ARCHIVE_NAME }}
           path: ./dump
 
+  pre-deployed-gas-token:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        # This step will only execute if the necessary secrets are available, preventing failures
+        # on pull requests from forked repositories.
+        if: ${{ env.DOCKERHUB_USERNAME && env.DOCKERHUB_TOKEN }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Kurtosis CDK tools
+        uses: ./.github/actions/setup-kurtosis-cdk
+
+      - name: Deploy L1 chain
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml .
+      
+      - name: Deploy gas token on L1
+        run: |
+          zkevm_contracts_version="v8.0.0-rc.4-fork.12"
+          echo "Cloning zkevm-contracts $zkevm_contracts_version..."
+          git clone https://github.com/0xPolygonHermez/zkevm-contracts
+          pushd zkevm-contracts
+          git checkout $zkevm_contracts_version
+          npm install @openzeppelin/contracts@4.8.2
+          printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
+
+          echo "Deploying gas token to L1..."
+          l1_rpc_url=$(kurtosis port print ${{ env.ENCLAVE_NAME }} el-1-geth-lighthouse rpc)
+          gas_token_address=$(forge create \
+            --json \
+            --rpc-url $l1_rpc_url \
+            --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete" \
+            contracts/mocks/ERC20PermitMock.sol:ERC20PermitMock \
+            --constructor-args  "CDK Gas Token" "CDK" "0xE34aaF64b29273B7D567FCFc40544c014EEe9970" "1000000000000000000000000" \
+            | jq --raw-output '.deployedTo')
+          if [[ -z "$gas_token_address" ]]; then
+            echo "Unable to deploy gas token"
+            exit 1
+          fi
+          echo "Gas token contract deployed at $gas_token_address on L1"
+          popd
+          yq -Y --in-place ".args.gas_token_address = \"$gas_token_address\"" ./.github/tests/gas-token/pre-deployed.yml
+
+      - name: Deploy the rest of the stack
+        run: |
+          kurtosis run \
+            --enclave=${{ env.ENCLAVE_NAME }} \
+            --args-file=./.github/tests/gas-token/pre-deployed.yml \
+            . \
+            '{"deployment_stages": {"deploy_l1": false}}'
+
+      - name: Inspect enclave
+        run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+
+      - name: Monitor verified batches
+        working-directory: .github/scripts
+        run: |
+          ./monitor-verified-batches.sh \
+            --enclave ${{ env.ENCLAVE_NAME }} \
+            --rpc-url "$(kurtosis port print ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-001 rpc)"
+
+      - name: Dump enclave
+        if: ${{ !cancelled() }}
+        run: kurtosis enclave dump ${{ env.ENCLAVE_NAME }} ./dump
+
+      - name: Upload enclave dump
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dump_pre_deployed_gas_token${{ github.run_id }}
+          path: ./dump
+
   additional-services:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,11 +246,8 @@ jobs:
 
       - name: Deploy the rest of the stack
         run: |
-          kurtosis run \
-            --enclave=${{ env.ENCLAVE_NAME }} \
-            --args-file=./.github/tests/gas-token/pre-deployed.yml \
-            . \
-            '{"deployment_stages": {"deploy_l1": false}}'
+          yq -Y --in-place ".deployment_stages.deploy_l1 = false" ./.github/tests/gas-token/pre-deployed.yml
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/gas-token/pre-deployed.yml .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -471,7 +468,7 @@ jobs:
 
       - name: Deploy to local L1 chain
         run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"deployment_stages": {"deploy_l1": false}}'
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-cdk-to-local-l1.yml .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,7 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Run Starlark
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -122,8 +121,7 @@ jobs:
         run: ./combine-ymls.sh
 
       - name: Run Starlark
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=${{ matrix.file_name }} --show-enclave-inspect=false . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=${{ matrix.file_name }} --show-enclave-inspect=false .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -217,8 +215,7 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Deploy L1 chain
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml .
       
       - name: Deploy gas token on L1
         run: |
@@ -253,7 +250,7 @@ jobs:
             --enclave=${{ env.ENCLAVE_NAME }} \
             --args-file=./.github/tests/gas-token/pre-deployed.yml \
             . \
-            '{"deployment_stages": {"deploy_l1": false}, "args": {"verbosity": "debug"}}'
+            '{"deployment_stages": {"deploy_l1": false}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -298,8 +295,7 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Run Starlark
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/additional-services.yml --show-enclave-inspect=false . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/additional-services.yml --show-enclave-inspect=false .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -402,12 +398,10 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Deploy L1 chain and a first CDK L2 chain (cdk-erigon sequencer + cdk stack)
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} .
 
       - name: Attach a second CDK L2 chain (cdk-erigon sequencer + cdk stack)
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-second-cdk.yml . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-second-cdk.yml .
 
       - name: Update the agglayer config
         run: |
@@ -473,12 +467,11 @@ jobs:
         uses: ./.github/actions/setup-kurtosis-cdk
 
       - name: Deploy L1 chain
-        run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml . '{"args": {"verbosity": "debug"}}'
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/external-l1/deploy-local-l1.yml .
 
       - name: Deploy to local L1 chain
         run: |
-          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"deployment_stages": {"deploy_l1": false}, "args": {"verbosity": "debug"}}'
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} . '{"deployment_stages": {"deploy_l1": false}}'
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/docs/upgrade-pp/README.org
+++ b/docs/upgrade-pp/README.org
@@ -305,7 +305,6 @@ args:
   consensus_contract_type: pessimistic
   sequencer_type: erigon
   erigon_strict_mode: false
-  zkevm_use_gas_token_contract: false
   enable_normalcy: true
 #+end_src
 

--- a/input_parser.star
+++ b/input_parser.star
@@ -238,8 +238,12 @@ DEFAULT_ROLLUP_ARGS = {
     # This flag will enable a stateless executor to verify the execution of the batches.
     # Set to true to run erigon as the sequencer.
     "erigon_strict_mode": True,
-    # Set to true to automatically deploy an ERC20 contract on L1 to be used as the gas token on the rollup.
-    "zkevm_use_gas_token_contract": False,
+    # Set to true to use an L1 ERC20 contract as the gas token on the rollup.
+    # The address of the gas token will be determined by the value of `gas_token_address`.
+    "gas_token_enabled": False,
+    # The address of the L1 ERC20 contract that will be used as the gas token on the rollup.
+    # If the address is empty, a contract will be deployed automatically.
+    "gas_token_address": "",
     # Set to true to use Kurtosis dynamic ports (default) and set to false to use static ports.
     # You can either use the default static ports defined in this file or specify your custom static
     # ports.

--- a/input_parser.star
+++ b/input_parser.star
@@ -334,7 +334,7 @@ def parse_args(plan, args):
     global_log_level = args.get("global_log_level", "")
     validate_log_level("global log level", global_log_level)
 
-    gas_token_enabled = args.get("gas_token_enabled", false)
+    gas_token_enabled = args.get("gas_token_enabled", False)
     gas_token_address = args.get("gas_token_address", "")
     if not gas_token_enabled and gas_token_address != "":
         fail(

--- a/input_parser.star
+++ b/input_parser.star
@@ -334,6 +334,15 @@ def parse_args(plan, args):
     global_log_level = args.get("global_log_level", "")
     validate_log_level("global log level", global_log_level)
 
+    gas_token_enabled = args.get("gas_token_enabled", false)
+    gas_token_address = args.get("gas_token_address", "")
+    if not gas_token_enabled and gas_token_address != "":
+        fail(
+            "Gas token address set to '{}' but gas token is not enabled".format(
+                gas_token_address
+            )
+        )
+
     # Determine fork id from the zkevm contracts image tag.
     zkevm_contracts_image = args.get("zkevm_contracts_image", "")
     (fork_id, fork_name) = get_fork_id(zkevm_contracts_image)

--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -109,7 +109,10 @@ echo_ts "Setting up local zkevm-contracts repo for deployment"
 pushd /opt/zkevm-contracts || exit 1
 cp /opt/contract-deploy/deploy_parameters.json /opt/zkevm-contracts/deployment/v2/deploy_parameters.json
 cp /opt/contract-deploy/create_rollup_parameters.json /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
+# Set up the hardhat environment.
 sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
+# Set up a foundry project in case we do a gas token or dac deployment.
+printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
 
 # Deploy gas token
 # TODO in the future this should be configurable. I.e. we should be able to specify a token address that has already been deployed
@@ -117,7 +120,6 @@ sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
 
 # {{if eq .gas_token_address ""}}
 echo_ts "Deploying gas token to L1"
-printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
 forge create \
     --json \
     --rpc-url "{{.l1_rpc_url}}" \

--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -115,10 +115,8 @@ sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
 # TODO in the future this should be configurable. I.e. we should be able to specify a token address that has already been deployed
 # {{if .gas_token_enabled}}
 # {{if eq .gas_token_address ""}}
-echo_ts "Using L1 pre-deployed gas token: {{ .gas_token_address }}"
-# {{else}}
-printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
 echo_ts "Deploying gas token to L1"
+printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
 forge create \
     --json \
     --rpc-url "{{.l1_rpc_url}}" \
@@ -126,6 +124,8 @@ forge create \
     contracts/mocks/ERC20PermitMock.sol:ERC20PermitMock \
     --constructor-args  "CDK Gas Token" "CDK" "{{.zkevm_l2_admin_address}}" "1000000000000000000000000" \
     > gasToken-erc20.json
+# {{else}}
+echo_ts "Using L1 pre-deployed gas token: {{ .gas_token_address }}"
 # {{end}}
 jq \
     --slurpfile c gasToken-erc20.json \

--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -124,12 +124,17 @@ forge create \
     contracts/mocks/ERC20PermitMock.sol:ERC20PermitMock \
     --constructor-args  "CDK Gas Token" "CDK" "{{.zkevm_l2_admin_address}}" "1000000000000000000000000" \
     > gasToken-erc20.json
+jq \
+    --slurpfile c gasToken-erc20.json \
+    '.gasTokenAddress = $c[0].deployedTo' \
+    /opt/contract-deploy/create_rollup_parameters.json \
+    > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 # {{else}}
 echo_ts "Using L1 pre-deployed gas token: {{ .gas_token_address }}"
 # {{end}}
 jq \
-    --slurpfile c gasToken-erc20.json \
-    '.gasTokenAddress = $c[0].deployedTo' \
+    --arg c "{{ .gas_token_address }}" \
+    '.gasTokenAddress = $c' \
     /opt/contract-deploy/create_rollup_parameters.json \
     > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 # {{end}}

--- a/templates/contract-deploy/run-contract-setup.sh
+++ b/templates/contract-deploy/run-contract-setup.sh
@@ -114,6 +114,7 @@ sed -i 's#http://127.0.0.1:8545#{{.l1_rpc_url}}#' hardhat.config.ts
 # Deploy gas token
 # TODO in the future this should be configurable. I.e. we should be able to specify a token address that has already been deployed
 # {{if .gas_token_enabled}}
+
 # {{if eq .gas_token_address ""}}
 echo_ts "Deploying gas token to L1"
 printf "[profile.default]\nsrc = 'contracts'\nout = 'out'\nlibs = ['node_modules']\n" > foundry.toml
@@ -131,12 +132,13 @@ jq \
     > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
 # {{else}}
 echo_ts "Using L1 pre-deployed gas token: {{ .gas_token_address }}"
-# {{end}}
 jq \
     --arg c "{{ .gas_token_address }}" \
     '.gasTokenAddress = $c' \
     /opt/contract-deploy/create_rollup_parameters.json \
     > /opt/zkevm-contracts/deployment/v2/create_rollup_parameters.json
+# {{end}}
+
 # {{end}}
 
 is_first_rollup=0 # an indicator if this deployment is doing the first setup of the agglayer etc


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Allow to use a pre-deployed ERC20 gas token.

Now we support three different configurations related to the gas token:

1. Don't use a gas token (default behaviour)

```yaml
args:
  gas_token_enabled: false
```

2. Use a gas token but automatically deploy the contract on L1.

```yaml
args:
  gas_token_enabled: true
```

3. Use a gas token and use the provided contract address.

```yaml
args:
  gas_token_enabled: true
  gas_token_address: "0xCONTRACT_ADDRESS"

```

## Tests

The following tests should be added to the CI:

- [x] Use a gas token but automatically deploy the contract on L1.
- [x] Use a gas token and use the provided contract address.

> 🚨 Unfortunately, it broke all the cdk tests related to gas token... I [fixed](https://github.com/leovct/cdk/tree/chore/kurtosis-cdk-bump-gas-token) the tests on my fork and will push an upstream PR once this PR gets merged.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
