### PR TITLE
tests: integrate cdk bats test ci to kurtosis-cdk

### DIFF
--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -29,9 +29,6 @@ jobs:
         go-version: ${{ matrix.go-version }}
       env:
         GOARCH: ${{ matrix.goarch }}
-
-    - name: Build Docker
-      run: make build-docker
  
       # this is better to get the action in
     - name: Install kurtosis
@@ -54,7 +51,7 @@ jobs:
 
     - name: Install polycli
       run: |
-        POLYCLI_VERSION="${{ vars.POLYCLI_VERSION }}"
+        POLYCLI_VERSION="v0.1.63"
         tmp_dir=$(mktemp -d) 
         curl -L "https://github.com/0xPolygon/polygon-cli/releases/download/${POLYCLI_VERSION}/polycli_${POLYCLI_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$tmp_dir" 
         mv "$tmp_dir"/* /usr/local/bin/polycli 
@@ -75,17 +72,22 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 0xPolygon/cdk
+        path: "cdk"
         ref: "v0.4.0-beta10"
+
+    - name: Build Docker
+      run: make build-docker
+      working-directory: ${{ github.workspace }}/cdk
 
     - name: Setup Bats and bats libs
       uses: bats-core/bats-action@2.0.0
 
     - name: Test
       run: make test-e2e-${{ matrix.e2e-group }}
-      working-directory: ${{ github.workspace }}/cdk/test
+      working-directory: ./cdk/test
       env:
-        KURTOSIS_FOLDER: ./
-        # BATS_LIB_PATH: /usr/lib/
+        KURTOSIS_FOLDER: ${{ github.workspace }}
+        BATS_LIB_PATH: /usr/lib/
     
     - name: Dump enclave logs
       if: failure()

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -5,7 +5,6 @@ on:
       - '**'
   workflow_dispatch: {}
 
-
 jobs:
   test-e2e:
     strategy:
@@ -30,7 +29,6 @@ jobs:
       env:
         GOARCH: ${{ matrix.goarch }}
  
-      # this is better to get the action in
     - name: Install kurtosis
       shell: bash
       run: |
@@ -62,12 +60,6 @@ jobs:
     - name: Install foundry
       uses: foundry-rs/foundry-toolchain@v1
 
-    # - name: checkout kurtosis-cdk
-    #   uses: actions/checkout@v4
-    #   with:
-    #     repository: 0xPolygon/kurtosis-cdk
-    #     path: "kurtosis-cdk"
-    #     ref: "v0.2.19"
     - name: checkout polygon-cdk
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -1,8 +1,8 @@
 name: Test e2e
 on: 
+  pull_request:
   push:
-    branches:
-      - '**'
+    branches: [main]
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/cdk-e2e.yml
+++ b/.github/workflows/cdk-e2e.yml
@@ -1,0 +1,107 @@
+name: Test e2e
+on: 
+  push:
+    branches:
+      - '**'
+  workflow_dispatch: {}
+
+
+jobs:
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ 1.22.x ]
+        goarch: [ "amd64" ]
+        e2e-group:
+          - "fork9-validium"
+          - "fork11-rollup"
+          - "fork12-validium"
+          - "fork12-rollup"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+      env:
+        GOARCH: ${{ matrix.goarch }}
+
+    - name: Build Docker
+      run: make build-docker
+ 
+      # this is better to get the action in
+    - name: Install kurtosis
+      shell: bash
+      run: |
+        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        sudo apt update
+        sudo apt install kurtosis-cli=1.4.1
+        kurtosis version
+
+    - name: Disable kurtosis analytics
+      shell: bash
+      run: kurtosis analytics disable
+
+    - name: Install yq
+      shell: bash
+      run: |
+        pip3 install yq
+        yq --version
+
+    - name: Install polycli
+      run: |
+        POLYCLI_VERSION="${{ vars.POLYCLI_VERSION }}"
+        tmp_dir=$(mktemp -d) 
+        curl -L "https://github.com/0xPolygon/polygon-cli/releases/download/${POLYCLI_VERSION}/polycli_${POLYCLI_VERSION}_linux_amd64.tar.gz" | tar -xz -C "$tmp_dir" 
+        mv "$tmp_dir"/* /usr/local/bin/polycli 
+        rm -rf "$tmp_dir"
+        sudo chmod +x /usr/local/bin/polycli
+        /usr/local/bin/polycli version
+
+    - name: Install foundry
+      uses: foundry-rs/foundry-toolchain@v1
+
+    # - name: checkout kurtosis-cdk
+    #   uses: actions/checkout@v4
+    #   with:
+    #     repository: 0xPolygon/kurtosis-cdk
+    #     path: "kurtosis-cdk"
+    #     ref: "v0.2.19"
+    - name: checkout polygon-cdk
+      uses: actions/checkout@v4
+      with:
+        repository: 0xPolygon/cdk
+        ref: "v0.4.0-beta10"
+
+    - name: Setup Bats and bats libs
+      uses: bats-core/bats-action@2.0.0
+
+    - name: Test
+      run: make test-e2e-${{ matrix.e2e-group }}
+      working-directory: ${{ github.workspace }}/cdk/test
+      env:
+        KURTOSIS_FOLDER: ./
+        # BATS_LIB_PATH: /usr/lib/
+    
+    - name: Dump enclave logs
+      if: failure()
+      run: kurtosis dump ./dump
+
+    - name: Generate archive name
+      if: failure()
+      run: |
+        archive_name="dump_run_with_args_${{matrix.e2e-group}}_${{ github.run_id }}"
+        echo "ARCHIVE_NAME=${archive_name}" >> "$GITHUB_ENV"
+        echo "Generated archive name: ${archive_name}"
+        kurtosis service exec cdk cdk-node-001 'cat /etc/cdk/cdk-node-config.toml' > ./dump/cdk-node-config.toml
+
+    - name: Upload logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARCHIVE_NAME }}
+        path: ./dump


### PR DESCRIPTION
## Description

This PR introduces an extra github workflow `cdk-e2e.yml` which tests the e2e tests in the [cdk](https://github.com/0xPolygon/cdk/tree/main/test) repository. It includes the below matrix for testing.
```
- "fork9-validium"
- "fork11-rollup"
- "fork12-validium"
- "fork12-rollup"
```
