### PR TITLE
test: add attaching a third PP network into the CI

### DIFF
--- a/.github/tests/attach-third-cdk.yml
+++ b/.github/tests/attach-third-cdk.yml
@@ -1,0 +1,67 @@
+deployment_stages:
+  deploy_l1: false
+  deploy_agglayer: false
+
+args:
+  deployment_suffix: "-003"
+  zkevm_rollup_chain_id: 30303
+  zkevm_rollup_id: 3
+
+  # polycli wallet inspect --mnemonic 'holiday crunch rule artefact cinnamon suit uphold evil shrimp topic core abstract' --addresses 11 | tee keys.txt | jq -r '.Addresses[] | [.ETHAddress, .HexPrivateKey] | @tsv' | awk 'BEGIN{split("sequencer,aggregator,claimtxmanager,timelock,admin,loadtest,agglayer,dac,proofsigner,l1testing,claimsponsor",roles,",")} {print "# " roles[NR] "\nzkevm_l2_" roles[NR] "_address: " $1 ""; print "zkevm_l2_" roles[NR] "_private_key: 0x" $2 "\n"}'
+
+  # sequencer
+  zkevm_l2_sequencer_address: "0x0d59BC8C02A089D48d9Cd465b74Cb6E23dEB950D"
+  zkevm_l2_sequencer_private_key: "0xf6385a27e7710349617340c6f9310e88f0aad10d01646a9bb204177431babcd8"
+
+  # aggregator
+  zkevm_l2_aggregator_address: "0x2D20D9081fb403E856355F2cddd1C4863D0109cb"
+  zkevm_l2_aggregator_private_key: "0x2cb77c2cca48d3fee64c14d73564fd6e90676a4f6da6545681e10c8b9b22fce2"
+
+  # claimtxmanager
+  zkevm_l2_claimtxmanager_address: "0x1359D1eAf25aADaA04304Ee7EFC5b94C43e0e1D5"
+  zkevm_l2_claimtxmanager_private_key: "0xb0244fcbf83d7aaa2d51dc78a55233058af31797a974d25f724de041f3484418"
+
+  # timelock
+  zkevm_l2_timelock_address: "0x7803E33388C695E7cbd85eD55f4abe6455E9ce2e"
+  zkevm_l2_timelock_private_key: "0xe12e739b58489a2c2f49c472169ba20eb89d039e71f04d5342ab645dc3fb6540"
+
+  # admin
+  # zkevm_l2_admin_address: "0x5666Cc6B46ad32b469D9Aec7C1eE6d02f7312759"
+  # zkevm_l2_admin_private_key: "0xd2ee309113fc97bed6030201fea0d1234d6b4acbc47b9a4fe12a8fa5270052aa"
+
+  # loadtest
+  zkevm_l2_loadtest_address: "0x5198d92d278Fd36e5745C308F728d256198A0e3d"
+  zkevm_l2_loadtest_private_key: "0xcc594c53eca19f9e56200cadf60c94757b0bdee1fc4bc73552ba879d51fd82b3"
+
+  # agglayer
+  zkevm_l2_agglayer_address: "0x9b5A1f2bC7bb48419d9f6407CFcA454F87884072"
+  zkevm_l2_agglayer_private_key: "0x7b1164f53f633e940089031a3c265c308d2bcf4756bc8dcf9046bf00e21ec3b1"
+
+  # dac
+  zkevm_l2_dac_address: "0xA9875E9B9FE3BD46da758ba69a5d4B9dFCA6F133"
+  zkevm_l2_dac_private_key: "0x5d1a923f60e2423932f782dab9510e1c2fd64b0f29b0893978864191ecdd6f4f"
+
+  # proofsigner
+  zkevm_l2_proofsigner_address: "0x3AA075513578d86dC63f9344cD9489b948d7686a"
+  zkevm_l2_proofsigner_private_key: "0xfd402dcc8c7fc7ce0df59fe12f33da7ac2ed760a619188ff16974fde16f9b00e"
+
+  # l1testing
+  zkevm_l2_l1testing_address: "0x943413d3b2E1B6aF09a758c35b6F5d23a4d6d262"
+  zkevm_l2_l1testing_private_key: "0x27d8ab2d65296d0da072b172ca9ca874583f9930adb6ac3222fd9494ae7c7f0d"
+
+  # claimsponsor
+  zkevm_l2_claimsponsor_address: "0xeA06890A8A547aDd71f98A6845542eb3B63C2862"
+  zkevm_l2_claimsponsor_private_key: "0xb97112e36cfcde131faa110430eed6593b75406e5d6991d8db3ed0f492a73b6f"
+
+  agglayer_image: ghcr.io/agglayer/agglayer:0.2.0-rc.5
+  cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0-beta4
+  cdk_node_image: nulyjkdhthz/cdk:6d775da5dad55990f534e0190a89613ae64f5ccf
+  zkevm_bridge_proxy_image: haproxy:3.0-bookworm
+  zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC1
+  zkevm_contracts_image: nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12
+  additional_services: []
+  consensus_contract_type: pessimistic
+  sequencer_type: erigon
+  erigon_strict_mode: false
+  zkevm_use_gas_token_contract: false
+  enable_normalcy: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -322,6 +322,11 @@ jobs:
       - name: Attach a third PP CDK L2 chain (cdk-erigon sequencer + cdk PP stack)
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-third-cdk.yml .
 
+      - name: Restart the Erigon RPC of the PP network
+        run: |
+          kurtosis service stop ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-003
+          kurtosis service start ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-003
+
       - name: Update the agglayer config
         run: |
           # Download the agglayer config file.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,8 @@ name: Deploy
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - '**'
 
 concurrency:
   group: deploy-${{ github.event.pull_request.number || github.ref }}
@@ -291,7 +292,7 @@ jobs:
           name: dump_additional_services_${{ github.run_id }}
           path: ./dump
 
-  attach-second-cdk:
+  attach-additional-cdks:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -315,8 +316,11 @@ jobs:
       - name: Deploy L1 chain and a first CDK L2 chain (cdk-erigon sequencer + cdk stack)
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} .
 
-      - name: Attach a second CDK L2 chain (cdk-erigon sequencer + cdk stack)
+      - name: Attach a second FEP CDK L2 chain (cdk-erigon sequencer + cdk FEP stack)
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-second-cdk.yml .
+
+      - name: Attach a third PP CDK L2 chain (cdk-erigon sequencer + cdk PP stack)
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/tests/attach-third-cdk.yml .
 
       - name: Update the agglayer config
         run: |
@@ -325,6 +329,8 @@ jobs:
           cd agglayer-config-artifact
           # Update the config by adding the rpc and proof signer of the second chain.
           tomlq -Y --toml-output --in-place '."full-node-rpcs" += {"2": "http://cdk-erigon-rpc-002:8123"}' agglayer-config.toml
+          # Update the config by adding the rpc and proof signer of the third chain.
+          tomlq -Y --toml-output --in-place '."full-node-rpcs" += {"3": "http://cdk-erigon-rpc-003:8123"}' agglayer-config.toml
           # Replace the agglayer config.
           agglayer_container_id="$(docker ps --filter name=agglayer --format json | jq -r -s '. | map(select(.Names | startswith("agglayer--"))) | .[].ID')"
           docker cp agglayer-config.toml "$agglayer_container_id:/etc/zkevm/agglayer-config.toml"
@@ -348,6 +354,13 @@ jobs:
           ./monitor-verified-batches.sh \
             --enclave ${{ env.ENCLAVE_NAME }} \
             --rpc-url "$(kurtosis port print ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-002 rpc)"
+
+      - name: Monitor verified batches of the third PP L2 chain (CDK Erigon Permissionless RPC)
+        working-directory: .github/scripts
+        run: |
+          ./monitor-verified-batches.sh \
+            --enclave ${{ env.ENCLAVE_NAME }} \
+            --rpc-url "$(kurtosis port print ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-003 rpc)"
 
       - name: Dump enclave
         if: ${{ !cancelled() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -361,11 +361,23 @@ jobs:
             --rpc-url "$(kurtosis port print ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-002 rpc)"
 
       - name: Monitor verified batches of the third PP L2 chain (CDK Erigon Permissionless RPC)
-        working-directory: .github/scripts
         run: |
-          ./monitor-verified-batches.sh \
-            --enclave ${{ env.ENCLAVE_NAME }} \
-            --rpc-url "$(kurtosis port print ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-003 rpc)"
+          echo "Sending a transaction to the PP network Erigon RPC..."
+          cast send \
+            --legacy \
+            --timeout 30 \
+            --rpc-url "$(kurtosis port print ${{ env.ENCLAVE_NAME }} cdk-erigon-rpc-003 rpc)" \
+            --private-key "0x12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625" \
+            --gas-limit 100000 \
+            --create 0x6001617000526160006110005ff05b6109c45a111560245761600061100080833c600e565b50
+          ret_code=$?
+          if [[ $ret_code -eq 0 ]]; then
+              echo "[$(date '+%Y-%m-%d %H:%M:%S')] ✅ Exiting... Transaction successfuly sent!"
+              exit 0
+          else
+              echo "[$(date '+%Y-%m-%d %H:%M:%S')] ❌ Exiting... Transaction failed!"
+              exit 1
+          fi
 
       - name: Dump enclave
         if: ${{ !cancelled() }}

--- a/input_parser.star
+++ b/input_parser.star
@@ -30,13 +30,13 @@ DEFAULT_DEPLOYMENT_STAGES = {
 
 DEFAULT_IMAGES = {
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.2.0-rc.12",  # https://github.com/agglayer/agglayer/pkgs/container/agglayer-rs
-    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.1.2",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.60.0-beta8",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
     "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.4.0-beta10",  # https://github.com/0xpolygon/cdk/pkgs/container/cdk
     "cdk_validium_node_image": "0xpolygon/cdk-validium-node:0.7.0-cdk",  # https://hub.docker.com/r/0xpolygon/cdk-validium-node/tags
     "zkevm_bridge_proxy_image": "haproxy:3.0-bookworm",  # https://hub.docker.com/_/haproxy/tags
     "zkevm_bridge_service_image": "hermeznetwork/zkevm-bridge-service:v0.6.0-RC1",  # https://hub.docker.com/r/hermeznetwork/zkevm-bridge-service/tags
     "zkevm_bridge_ui_image": "leovct/zkevm-bridge-ui:multi-network",  # https://hub.docker.com/r/leovct/zkevm-bridge-ui/tags
-    "zkevm_contracts_image": "leovct/zkevm-contracts:v8.0.0-rc.4-fork.12",  # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags
+    "zkevm_contracts_image": "nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12",  # https://hub.docker.com/repository/docker/leovct/zkevm-contracts/tags
     "zkevm_da_image": "0xpolygon/cdk-data-availability:0.0.10",  # https://hub.docker.com/r/0xpolygon/cdk-data-availability/tags
     "zkevm_node_image": "hermeznetwork/zkevm-node:v0.7.3",  # https://hub.docker.com/r/hermeznetwork/zkevm-node/tags
     "zkevm_pool_manager_image": "hermeznetwork/zkevm-pool-manager:v0.1.2",  # https://hub.docker.com/r/hermeznetwork/zkevm-pool-manager/tags


### PR DESCRIPTION
## Description
This PR adds another step to attach a third PP network in addition to the existing steps, and does a minimal check by sending a simple transfer in that network. The test [CI](https://github.com/jhkimqd/kurtosis-cdk/actions/runs/11966433403/job/33362053157) seems to be passing.

This is however dependent on using the PP CDK Erigon and Contract images, so it may be better to hold until the latest images are applied on the `main` branch first:
```
"cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.60.0-beta8",
...
"zkevm_contracts_image": "nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12",
```