### PR TITLE
fix: cdk-erigon proc-runner artifact names

### DIFF
--- a/lib/cdk_erigon.star
+++ b/lib/cdk_erigon.star
@@ -49,6 +49,7 @@ def _start_service(
     # Leaving the name out for now. This might cause some idempotency
     # issues, but we're not currently relying on that for now.‡
     proc_runner_file_artifact = plan.upload_files(
+        name="cdk-erigon-" + type + "-proc-runner" + args["deployment_suffix"],
         src="../templates/proc-runner.sh",
     )
     plan_files["/usr/local/share/proc-runner"] = proc_runner_file_artifact


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The cdk-erigon's proc-runner file artifacts lack a specified name.

<img width="1792" alt="Screenshot 2024-11-25 at 11 00 09" src="https://github.com/user-attachments/assets/4b0af891-c69f-44c3-b439-668d5a3a89b3">


## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

x
