### PR TITLE
fix: set GenBlockNumber to rollup manager block number in bridge service config

### DIFF
--- a/templates/bridge-infra/bridge-config.toml
+++ b/templates/bridge-infra/bridge-config.toml
@@ -41,7 +41,7 @@ BridgeVersion = "v1"
     MaxConns = 20
 
 [NetworkConfig]
-GenBlockNumber = 0
+GenBlockNumber = "{{.zkevm_rollup_manager_block_number}}"
 PolygonBridgeAddress = "{{.zkevm_bridge_address}}"
 PolygonZkEVMGlobalExitRootAddress = "{{.zkevm_global_exit_root_address}}"
 PolygonRollupManagerAddress = "{{.zkevm_rollup_manager_address}}"


### PR DESCRIPTION
## Description
when using a custom Sepolia chain, the data is not being stored in the database during the Deposit function on the Pessimistic Proof. That’s the reason for not working the Deposit functionality
 
