### PR TITLE
docs: update deploy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,15 @@ Check the [tests](.github/tests/) folder for sample configuration files.
 kurtosis run --enclave cdk --args-file params.yml .
 ```
 
-5. Deploy with a configuration file and specify on-the-fly custom arguments.
+5. Do not deploy with a configuration file and specify on-the-fly custom arguments.
 
-Note: In this specific case, on-the-fly custom arguments take precedence over defaults and config file arguments.
+🚨 Avoid using this method, as Kurtosis is unable to merge parameters from two different sources (the parameters file and on-the-fly arguments).
+
+The parameters file will not be used, and only the on-the-fly arguments will be considered.
 
 ```bash
 kurtosis run --enclave cdk --args-file params.yml . '{"args": {"agglayer_image": "ghcr.io/agglayer/agglayer:latest"}}'
+# similar to: kurtosis run --enclave cdk . '{"args": {"agglayer_image": "ghcr.io/agglayer/agglayer:latest"}}'
 ```
 
 </details>


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

After playing a little with kurtosis-cdk and the different ways to specify args, I noticed a weird behaviour when combining params file and on-the-fly args.

![Screenshot 2024-11-27 at 12 10 10](https://github.com/user-attachments/assets/11074708-1b6c-4b05-a6b2-9115a33b9b84)

It was not properly documented so this PR fixes that.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://github.com/0xPolygon/leovct/blob/main/debug/kurtosis-cdk/params/params.md
