### PR TITLE
docker: allow to push new versions of the zkevm-contracts images

### DIFF
--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -38,19 +38,9 @@ jobs:
           fi
           echo "full_tag=$FULL_TAG" >> $GITHUB_OUTPUT
 
-      - name: Check if image already exists
-        id: check_image
-        run: |
-          if docker manifest inspect ${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.full_tag }} > /dev/null 2>&1; then
-            echo "Image already exists, skipping build."
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Image does not exist."
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
+      # We don't check if the image already exists to be able to push new versions of the images
+      # in case of a dependency breaking change (e.g. foundry).
       - name: Build image and push to the Docker Hub
-        if: ${{ steps.check_image.outputs.exists == 'false' }}
         uses: docker/build-push-action@v6
         with:
           context: docker

--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -29,9 +29,14 @@ jobs:
         id: determine_tag
         run: |
           TAG=${{ github.event.inputs.zkevm_contracts_version }}
-          if [[ $TAG == *pp ]]; then
+          if [[ $TAG == *-fork.10 ]]; then
+            # Custom rule to label fork10 tags as fork11.
+            FULL_TAG="${TAG%-fork.10}-fork.11"
+          elif [[ $TAG == *pp ]]; then
+            # Custom rule to label pp tags as fork12.
             FULL_TAG="${TAG}-fork.12"
           elif [[ $TAG != *-fork.[0-9]* ]]; then
+            # Custom rule to label undefined tags as fork13.
             FULL_TAG="${TAG}-fork.13"
           else
             FULL_TAG=$TAG


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

There was a breaking change in foundry (`forge create --broadcast`) and we updated our templates to reflect the change but unfortunately, the already built zkevm-contracts image are using an older version of `foundry`. This is quite a mess and it's breaking the CDK e2e tests. I'm pushing this PR to allow to push new versions of the zkevm-contracts image with the latest foundry versions to resolve the issues.

![Screenshot 2024-11-28 at 14 20 44](https://github.com/user-attachments/assets/dc5a7900-e183-4114-ae1b-25518b3f2622)

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
