### PR TITLE
chore: pin foundry version in ci and docker images

### DIFF
--- a/.github/actions/setup-kurtosis-cdk/action.yml
+++ b/.github/actions/setup-kurtosis-cdk/action.yml
@@ -6,7 +6,11 @@ inputs:
   kurtosis-version:
     description: The version of kurtosis
     required: false
-    default: '1.4.1' # https://github.com/kurtosis-tech/kurtosis/releases
+    default: 1.4.2 # Should be aligned with .github/workflows/lint.yml
+  foundry-version:
+    description: The version of foundry
+    required: false
+    default: nightly-c63aba816b76f9bad103b1275cc662a063919403 # https://github.com/foundry-rs/foundry/releases/tag/nightly-c63aba816b76f9bad103b1275cc662a063919403
 
 runs:
   using: "composite"
@@ -38,3 +42,5 @@ runs:
 
     - name: Install foundry
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: ${{ inputs.foundry-version }}

--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -11,7 +11,8 @@ on:
 
 env:
   IMAGE_NAME: leovct/zkevm-contracts
-  POLYCLI_VERSION: main
+  POLYCLI_VERSION: v0.1.64 # https://github.com/0xPolygon/polygon-cli/releases/tag/v0.1.64
+  FOUNDRY_VERSION: nightly-c63aba816b76f9bad103b1275cc662a063919403 # https://github.com/foundry-rs/foundry/releases/tag/nightly-c63aba816b76f9bad103b1275cc662a063919403
 
 jobs:
   zkevm-contracts:
@@ -63,6 +64,7 @@ jobs:
           build-args: |
             ZKEVM_CONTRACTS_BRANCH=${{ github.event.inputs.zkevm_contracts_version }}
             POLYCLI_VERSION=${{ env.POLYCLI_VERSION }}
+            FOUNDRY_VERSION=${{ env.FOUNDRY_VERSION }}
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.full_tag }}
           cache-from: type=gha

--- a/.github/workflows/docker-image-builder.yml
+++ b/.github/workflows/docker-image-builder.yml
@@ -29,9 +29,14 @@ jobs:
         id: determine_tag
         run: |
           TAG=${{ github.event.inputs.zkevm_contracts_version }}
-          if [[ $TAG == *pp ]]; then
+          if [[ $TAG == *-fork.10 ]]; then
+            # Custom rule to label fork10 tags as fork11.
+            FULL_TAG="${TAG%-fork.10}-fork.11"
+          elif [[ $TAG == *pp ]]; then
+            # Custom rule to label pp tags as fork12.
             FULL_TAG="${TAG}-fork.12"
           elif [[ $TAG != *-fork.[0-9]* ]]; then
+            # Custom rule to label undefined tags as fork13.
             FULL_TAG="${TAG}-fork.13"
           else
             FULL_TAG=$TAG

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KURTOSIS_VERSION: 0.90.1
+  KURTOSIS_VERSION: 1.4.2 # Should be aligned with .github/actions/setup-kurtosis-cdk/action.yml
 
 jobs:
   lint:

--- a/docker/README.md
+++ b/docker/README.md
@@ -132,6 +132,7 @@ Build the `toolbox` image.
 docker build . \
   --tag local/toolbox:local \
   --build-arg POLYCLI_VERSION=main \
+  --build-arg FOUNDRY_VERSION=nightly \
   --file toolbox.Dockerfile
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -81,6 +81,7 @@ docker build . \
   --tag local/zkevm-contracts:$version \
   --build-arg ZKEVM_CONTRACTS_BRANCH=$version \
   --build-arg POLYCLI_VERSION=main \
+  --build-arg FOUNDRY_VERSION=nightly \
   --file zkevm-contracts.Dockerfile
 ```
 

--- a/docker/toolbox.Dockerfile
+++ b/docker/toolbox.Dockerfile
@@ -6,6 +6,7 @@ RUN git clone --branch ${POLYCLI_VERSION} https://github.com/maticnetwork/polygo
 
 
 FROM ubuntu:24.04
+ARG FOUNDRY_VERSION
 LABEL author="devtools@polygon.technology"
 LABEL description="Blockchain toolbox"
 
@@ -23,5 +24,5 @@ RUN apt-get update \
   && pipx ensurepath \
   && pipx install yq \
   && curl --silent --location --proto "=https" https://foundry.paradigm.xyz | bash \
-  && /root/.foundry/bin/foundryup \
+  && /root/.foundry/bin/foundryup --version ${FOUNDRY_VERSION} \
   && cp /root/.foundry/bin/* /usr/local/bin

--- a/docker/zkevm-contracts.Dockerfile
+++ b/docker/zkevm-contracts.Dockerfile
@@ -19,6 +19,7 @@ RUN git clone https://github.com/0xPolygonHermez/zkevm-contracts . \
   && npx hardhat compile
 
 # STEP 2: Install tools.
+ARG FOUNDRY_VERSION
 COPY --from=polycli-builder /opt/polygon-cli/out/polycli /usr/bin/polycli
 WORKDIR /opt
 # WARNING (DL3008): Pin versions in apt get install.
@@ -32,7 +33,7 @@ RUN apt-get update \
   && pipx ensurepath \
   && pipx install yq \
   && curl --silent --location --proto "=https" https://foundry.paradigm.xyz | bash \
-  && /root/.foundry/bin/foundryup \
+  && /root/.foundry/bin/foundryup --version ${FOUNDRY_VERSION} \
   && cp /root/.foundry/bin/* /usr/local/bin
 
 USER node

--- a/docs/edit-contracts.md
+++ b/docs/edit-contracts.md
@@ -164,6 +164,7 @@ docker build . \
  --tag local/zkevm-contracts:v6.0.0-rc.1-fork.9 \
  --build-arg ZKEVM_CONTRACTS_BRANCH=v6.0.0-rc.1-fork.9 \
  --build-arg POLYCLI_VERSION=main \
+--build-arg FOUNDRY_VERSION=nightly \
  --file zkevm-contracts.Dockerfile
 ```
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -11,4 +11,4 @@ SEQUENCER_TYPE = struct(
     ZKEVM="zkevm",
 )
 
-TX_SPAMMER_IMG = "leovct/toolbox:0.0.5"
+TX_SPAMMER_IMG = "leovct/toolbox:0.0.7"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Prevent a foundry breaking change from breaking our package.

- All the `zkevm-contracts` images have been rebuilt using the latest foundry nightly version.
- A new `toolbox` image tag has been released: `0.0.7` containing the latest foundry nightly version also.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://0xpolygon.slack.com/archives/C02JAJVVAH1/p1732787538017799