### PR TITLE
fix: bump ethereum-package to `v4.4.0`

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/ethpandaops/ethereum-package/main.star@4.3.0"
+    "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
 )
 
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The CL of the ethereum-package does not start because of an error. It looks like the `lighthouse` custom image used by the ethereum-package has been updated and thus it breaks previous versions of the package that rely on an old flag.

```bash
== SERVICE 'cl-1-lighthouse-geth' LOGS ===================================
  error: unexpected argument '--http-allow-sync-stalled' found
  
    tip: a similar argument exists: '--http-allow-origin'
  
  Usage: lighthouse beacon_node --execution-endpoint <EXECUTION-ENDPOINT> --debug-level <LEVEL> --datadir <DIR> --disable-enr-auto-update --enr-address <ADDRESS>... --enr-udp-port <PORT> --enr-tcp-port <PORT> --listen-address [<ADDRESS>...] --port <PORT> --http-address <ADDRESS> --http-port <PORT> --http-allow-origin <ORIGIN> <--http|--gui|--staking>
  
  For more information, try '--help'.
  
  == FINISHED SERVICE 'cl-1-lighthouse-geth' LOGS ===================================
```

This PR addresses this issue by bumping the ethereum-package version to `v4.4.0` which includes the fix.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
