### PR TITLE
fix: tag ethereum-package image versions

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -2,6 +2,9 @@ ethereum_package = import_module(
     "github.com/ethpandaops/ethereum-package/main.star@4.4.0"
 )
 
+GETH_IMAGE = "ethereum/client-go:v1.14.12"
+LIGHTHOUSE_IMAGE = "sigp/lighthouse:v6.0.0"
+
 
 def run(plan, args):
     port_publisher = generate_port_publisher_config(args)
@@ -11,7 +14,9 @@ def run(plan, args):
             "participants": [
                 {
                     "el_type": "geth",
+                    "el_image": GETH_IMAGE,
                     "cl_type": "lighthouse",
+                    "cl_image": LIGHTHOUSE_IMAGE,
                     "el_extra_params": ["--gcmode archive"],
                     "cl_extra_params": [
                         # Disable optimistic finalized sync. This will force Lighthouse to
@@ -26,6 +31,8 @@ def run(plan, args):
                         # required for staking.
                         "--disable-backfill-rate-limiting",
                     ],
+                    "vc_type": "lighthouse",
+                    "vc_image": LIGHTHOUSE_IMAGE,
                     "count": args["l1_participants_count"],
                 }
             ],


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Follow up of #409 which fixes the issue with the upstream ethereum-package but does not prevent us from potential breaking changes in the EL/CL images in the future. This PR pins the versions of the ethereum-package images.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

#409 