### PR TITLE
chore: pin prometheus image version

### DIFF
--- a/.github/tests/fork12-pessimistic.yml
+++ b/.github/tests/fork12-pessimistic.yml
@@ -3,7 +3,7 @@ args:
   cdk_erigon_node_image: hermeznetwork/cdk-erigon:v2.60.0
   zkevm_bridge_service_image: hermeznetwork/zkevm-bridge-service:v0.6.0-RC2
   zkevm_bridge_ui_image: leovct/zkevm-bridge-ui:multi-network
-  zkevm_contracts_image: nulyjkdhthz/zkevm-contracts:v9.0.0-rc.3-pp-fork.12
+  zkevm_contracts_image: leovct/zkevm-contracts:v9.0.0-rc.3-pp-fork.12-patch.1
   additional_services: []
   consensus_contract_type: pessimistic
   sequencer_type: erigon

--- a/src/additional_services/prometheus.star
+++ b/src/additional_services/prometheus.star
@@ -2,11 +2,23 @@ prometheus_package = import_module(
     "github.com/kurtosis-tech/prometheus-package/main.star"
 )
 
+PROMETHEUS_IMAGE = "prom/prometheus:v3.0.1"
+
 
 def run(plan, args):
     metrics_jobs = get_metrics_jobs(plan)
     prometheus_package.run(
-        plan, metrics_jobs, name="prometheus" + args["deployment_suffix"]
+        plan,
+        metrics_jobs,
+        name="prometheus" + args["deployment_suffix"],
+        min_cpu=10,
+        max_cpu=1000,
+        min_memory=128,
+        max_memory=2048,
+        node_selectors=None,
+        storage_tsdb_retention_time="1d",
+        storage_tsdb_retention_size="512MB",
+        image=PROMETHEUS_IMAGE,
     )
 
 


### PR DESCRIPTION
Make sure a new Prometheus image doesn't break our package in any way.

Minor: fix an issue with the cdk node fork12 pp test:

![Screenshot 2024-12-02 at 17 45 20](https://github.com/user-attachments/assets/d6d14adf-55ea-418d-a9db-f93c89428475)
