### PR TITLE
Add -y flag to kurtosis install gha

### DIFF
--- a/.github/actions/setup-kurtosis-cdk/action.yml
+++ b/.github/actions/setup-kurtosis-cdk/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
         sudo apt update
-        sudo apt install kurtosis-cli=${{ inputs.kurtosis-version }}
+        sudo apt install -y kurtosis-cli=${{ inputs.kurtosis-version }}
         kurtosis version
 
     - name: Disable kurtosis analytics


### PR DESCRIPTION
## Description
Add flag -y to kursosis install command.
Trying to run action on custom docker image which already has kurtosis latest version installed fails because this flag is missing.
![image](https://github.com/user-attachments/assets/c7d0e4c6-0c98-4945-b254-dcd93f1aedfd)
