### PR TITLE
fix: docker images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -68,7 +68,7 @@ This image contains all the npm dependencies and zkevm contracts compiled for a 
 Build the `zkevm-contracts` image.
 
 ```bash
-version="v9.0.0-rc.2-pp-fork.12"
+version="v8.0.0-rc.4-fork.12"
 docker build . \
   --tag local/zkevm-contracts:$version \
   --build-arg ZKEVM_CONTRACTS_BRANCH=$version \
@@ -81,8 +81,8 @@ Check the size of the image.
 
 ```bash
 $ docker images --filter "reference=local/zkevm-contracts"
-REPOSITORY              TAG                      IMAGE ID       CREATED          SIZE
-local/zkevm-contracts   v9.0.0-rc.2-pp-fork.12   bdf8225cfa77   7 minutes ago    2.54GB
+REPOSITORY              TAG                   IMAGE ID       CREATED          SIZE
+local/zkevm-contracts   v8.0.0-rc.4-fork.12   bdf8225cfa77   7 minutes ago    2.54GB
 ```
 
 (Optional) Push image to the Docker Hub.

--- a/docker/toolbox.Dockerfile
+++ b/docker/toolbox.Dockerfile
@@ -24,5 +24,5 @@ RUN apt-get update \
   && pipx ensurepath \
   && pipx install yq \
   && curl --silent --location --proto "=https" https://foundry.paradigm.xyz | bash \
-  && /root/.foundry/bin/foundryup --version ${FOUNDRY_VERSION} \
+  && /root/.foundry/bin/foundryup --install ${FOUNDRY_VERSION} \
   && cp /root/.foundry/bin/* /usr/local/bin

--- a/docker/zkevm-contracts.Dockerfile
+++ b/docker/zkevm-contracts.Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update \
   && pipx ensurepath \
   && pipx install yq \
   && curl --silent --location --proto "=https" https://foundry.paradigm.xyz | bash \
-  && /root/.foundry/bin/foundryup --version ${FOUNDRY_VERSION} \
+  && /root/.foundry/bin/foundryup --install ${FOUNDRY_VERSION} \
   && cp /root/.foundry/bin/* /usr/local/bin
 
 USER node


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Update our docker images to follow the new `foundryup` API.

## Test

- [x] Build one of the zkevm-contracts images.
- [x] Build the toolbox image.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

Closes #431 