### PR TITLE
ci: fix `deploy` workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,7 @@ name: Deploy
 on:
   pull_request:
   push:
-    branches:
-      - '**'
+    branches: [main]
 
 concurrency:
   group: deploy-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

The `deploy` workflow is running twice each job :)

<img width="864" alt="Screenshot 2025-02-03 at 11 30 54" src="https://github.com/user-attachments/assets/95a92d0e-407d-4430-9abf-ac6a72117c03" />

^ 51 checks 🤯

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
