### PR TITLE
fix: when PR raised from fork, skip the attach-sovereign-rollup workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -648,6 +648,7 @@ jobs:
           path: ./dump
 
   attach-sovereign-rollup:
+    # This workflow depends on the existence of a valid secrets.SP1_PRIVATE_KEY, and will only run if this dependency is met.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -697,6 +698,9 @@ jobs:
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
+        if: ${{ env.agglayer_prover_sp1_key && env.agglayer_prover_sp1_key != '' }}
+        env :
+          agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
 
       - name: Send bridge transactions from L1 to OP Sovereign L2
         if: ${{ env.agglayer_prover_sp1_key || env.agglayer_prover_sp1_key != '' }}
@@ -826,12 +830,16 @@ jobs:
             agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
             
       - name: Dump enclave
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && env.agglayer_prover_sp1_key && env.agglayer_prover_sp1_key != ''}}
         run: kurtosis enclave dump ${{ env.ENCLAVE_NAME }} ./dump
+        env :
+          agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}
 
       - name: Upload enclave dump
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && env.agglayer_prover_sp1_key && env.agglayer_prover_sp1_key != ''}}
         uses: actions/upload-artifact@v4
         with:
           name: dump_attach_sovereign_${{ github.run_id }}
           path: ./dump
+        env :
+          agglayer_prover_sp1_key: ${{ secrets.SP1_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

This PR fixes failing `attach-sovereign-rollup` workflow when an external PR is raised from a fork. The steps depend on the existence of a valid `SP1_PRIVATE_KEY`, and forked repositories will not have that. This PR skips these workflows in such cases.