### PR TITLE
feat: add helper function for sanity checking parameters

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -27,6 +27,8 @@ DEFAULT_DEPLOYMENT_STAGES = {
     # TODO: Remove this parameter to incorporate cdk-erigon inside the central environment.
     "deploy_cdk_erigon_node": True,
     # Deploy Optimism rollup.
+    # Setting to True will deploy the Aggkit components and Sovereign contracts as well.
+    # Requires consensus_contract_type to be "pessimistic".
     "deploy_optimism_rollup": False,
     # Deploy contracts on L2 (as well as fund accounts).
     "deploy_l2_contracts": False,
@@ -459,6 +461,12 @@ def parse_args(plan, user_args):
 
     # Determine OP stack args.
     op_stack_args = get_op_stack_args(plan, args, op_stack_args)
+    # deploy_optimistic_rollup and consensus_contract_type check
+    if deployment_stages.get("deploy_optimism_rollup", False):
+        if args.get("consensus_contract_type", "cdk-validium") != "pessimistic":
+            fail(
+                "OP Stack rollup requires pessimistic consensus contract type. Change the consensus_contract_type parameter"
+            )
 
     # When using assertoor to test L1 scenarios, l1_preset should be mainnet for deposits and withdrawls to work.
     if "assertoor" in args["l1_additional_services"]:

--- a/main.star
+++ b/main.star
@@ -38,10 +38,6 @@ def run(plan, args={}):
     if verbosity == constants.LOG_LEVEL.debug or verbosity == constants.LOG_LEVEL.trace:
         plan.print("Deploying CDK stack with the following configuration: " + str(args))
 
-    # Sanity check for conflicting parameters.
-    plan.print("Checking for incompatible parameters...")
-    sanity_check(plan, deployment_stages, args, op_stack_args)
-
     # Deploy a local L1.
     if deployment_stages.get("deploy_l1", False):
         plan.print("Deploying a local L1")
@@ -282,14 +278,3 @@ def deploy_additional_service(plan, name, package, args, contract_setup_addresse
     else:
         import_module(package).run(plan, service_args, contract_setup_addresses)
     plan.print("Successfully launched %s" % name)
-
-
-# Helper function to check for parameter combinations that will result in errors within individual services even though the deployment may succeed.
-def sanity_check(plan, deployment_stages, args, op_stack_args):
-    # deploy_optimistic_rollup and consensus_contract_type check
-    if deployment_stages.get("deploy_optimism_rollup", False):
-        if args.get("consensus_contract_type", "cdk-validium") != "pessimistic":
-            plan.print(
-                "OP Stack rollup requires pessimistic consensus contract type, halting further deployment..."
-            )
-            return fail("Incompatible parameters")


### PR DESCRIPTION
## Description

There are some combinations of parameters within `input_parser.star` which can result in a successful deployment after running `kurtosis run .`, but may cause some services to fail after the deployment. An example of this would be:
```
"deploy_optimism_rollup": True,
...
"consensus_contract_type": "cdk-validium",
```
When running Kurtosis CDK with these parameters, the deployment will succeed, but the aggkit component will return an error, because the process of creating and attaching sovereign rollups and deploying sovereign contracts assumes a pessimistic consensus contract is supported.

![image](https://github.com/user-attachments/assets/5aa3e4a7-1bda-4823-8433-bd09ba6b01c5)

This PR adds a helper function `sanity_check()` to check for these type of incompatible parameters at the start of the deployment and exits the deployment with `fail()` if such cases are caught. A separate helper function was created with this in mind, because adding checks in the middle of the deployment would require the user to wait much longer than needed only to find out the deployment wouldn't work. In case more incompatible cases are found, it could be added to the `sanity_check()` function to detect them early in the deployment.

![image](https://github.com/user-attachments/assets/3f5b84a1-7bd2-4646-83e7-0b9c3966544f)