### PR TITLE
fix: change l1_seconds_per_slot from 1s -> 2s 

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -210,7 +210,7 @@ DEFAULT_L1_ARGS = {
     "l1_preset": "minimal",
     # Number of seconds per slot on the Beacon chain
     # Default: 12
-    "l1_seconds_per_slot": 1,
+    "l1_seconds_per_slot": 2,
     # The amount of ETH sent to the admin, sequence, aggregator, sequencer and other chosen addresses.
     "l1_funding_amount": "1000000ether",
     # Default: 2
@@ -621,4 +621,13 @@ def args_sanity_check(plan, deployment_stages, args, op_stack_args):
         if args.get("consensus_contract_type", "cdk-validium") != "pessimistic":
             fail(
                 "OP Stack rollup requires pessimistic consensus contract type. Change the consensus_contract_type parameter"
+            )
+
+    # OP rollup check L1 blocktime >= L2 blocktime
+    if deployment_stages.get("deploy_optimism_rollup", False):
+        if (
+            args.get("l1_seconds_per_slot", 12) < 2
+        ):  # 2 seconds is the default blocktime for Optimism L2.
+            fail(
+                "OP Stack rollup requires L1 blocktime > 1 second. Change the l1_seconds_per_slot parameter"
             )


### PR DESCRIPTION
## Description

This PR changes the `l1_seconds_per_slot` variable from `1` second to `2` seconds. This is to make sure that if the `deploy_optimism_rollup` parameter is set to `true`, it will not break the OP network even after long-running it. 

`2` seconds was chosen in particular because this is also the default blocktime for the OP network, and this is the fastest L1 blocktime that can be used without breaking anything when OP rollup is deployed. As a reference, if we do not specify the `l1_seconds_per_slot`, the current default setup will use `6` seconds, which is the default L1 blocktime for the `minimal` preset.

In cases where the OP rollup's blocktime is customized to `>2 seconds`, the L1 blocktime will also need to change to be greater or equal to it. 

---

Some [relevant discussions](https://github.com/ethereum-optimism/optimism/issues/5275) on why the L1 blocktime needs to be slower than the L2 blocktime

> it can be done, but requires protocol changes, as the current protocol assumes every L1 block is registered in the L2 chain (this helps a lot with various consistency/safety checks in the block-derivation protocol). Every such registration of L1 data into L2 requires one special top-of-block system transaction, thus requiring one L2 block per L1 block. And for the L2 chain to keep up with the L1 chain, the block-time thus has to be shorter than that of the L1 chain.