### PR TITLE
fix: update op images with official tags

### DIFF
--- a/.github/tests/op-rollup/custom.yml
+++ b/.github/tests/op-rollup/custom.yml
@@ -6,16 +6,16 @@ optimism_package:
     - participants:
       - el_type: op-geth
         cl_type: op-node
-        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:d44bbea2407f4308f9fda20cf776bcb6dff7ff08
+        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0-rc.2
       - el_type: op-reth
         cl_type: op-node
-        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:d44bbea2407f4308f9fda20cf776bcb6dff7ff08
+        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0-rc.2
       - el_type: op-erigon
         cl_type: op-node
-        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:d44bbea2407f4308f9fda20cf776bcb6dff7ff08
+        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0-rc.2
       - el_type: op-nethermind
         cl_type: op-node
-        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:d44bbea2407f4308f9fda20cf776bcb6dff7ff08
+        cl_image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0-rc.2
 
 args:
   verbosity: debug

--- a/input_parser.star
+++ b/input_parser.star
@@ -301,11 +301,10 @@ DEFAULT_OP_STACK_ARGS = {
             "participants": [
                 {
                     "el_type": "op-geth",
-                    # https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.3
-                    # "el_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101411.3",
+                    "el_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101500.0-rc.3",
                     "cl_type": "op-node",
-                    "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:d44bbea2407f4308f9fda20cf776bcb6dff7ff08",
-                    "count": 2,  # one is a sequencer node and the other an rpc
+                    "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0-rc.2",
+                    "count": 2,
                 },
             ],
             # "batcher_params": {


### PR DESCRIPTION
## Description

Newly tagged OP-Geth and OP-Node images have been released which seems to fix deployment issues. This PR updates our images to this fixed tag.

https://us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101500.0-rc.3
https://us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.11.0-rc.2