### PR TITLE
Create keystores with cast instead polycli

### DIFF
--- a/templates/contract-deploy/create-keystores.sh
+++ b/templates/contract-deploy/create-keystores.sh
@@ -11,7 +11,7 @@ create_geth_keystore() {
     temp_dir="/tmp/$keystore_name"
     output_dir="/opt/zkevm"
     mkdir -p "$temp_dir"
-    cast wallet import -k "$temp_dir" --private-key "$private_key" --unsafe-password "$password" "$keystore_name"
+    cast wallet import --keystore-dir "$temp_dir" --private-key "$private_key" --unsafe-password "$password" "$keystore_name"
     jq < "$temp_dir/$keystore_name" > "$output_dir/$keystore_name"
     chmod a+r "$output_dir/$keystore_name"
     rm -rf "$temp_dir"

--- a/templates/contract-deploy/create-keystores.sh
+++ b/templates/contract-deploy/create-keystores.sh
@@ -11,10 +11,8 @@ create_geth_keystore() {
     temp_dir="/tmp/$keystore_name"
     output_dir="/opt/zkevm"
     mkdir -p "$temp_dir"
-    polycli parseethwallet --hexkey "$private_key" --password "$password" --keystore "$temp_dir"
-    mv "$temp_dir"/UTC* "$output_dir/$keystore_name"
-    jq < "$output_dir/$keystore_name" > "$output_dir/$keystore_name.new"
-    mv "$output_dir/$keystore_name.new" "$output_dir/$keystore_name"
+    cast wallet import -k "$temp_dir" --private-key "$private_key" --unsafe-password "$password" "$keystore_name"
+    jq < "$temp_dir/$keystore_name" > "$output_dir/$keystore_name"
     chmod a+r "$output_dir/$keystore_name"
     rm -rf "$temp_dir"
 }


### PR DESCRIPTION
## Description
Featureless PR that just speed ups keystore creation by using cast instead polycli.
The whole kurtosis deployment (default - no params) takes 3:45-3:49 instead 4-4:02, because create-keystores.sh takes ~12-13s using polycli and less than a second with cast.
