### PR TITLE
Option to add mitm as part of kurtosis deployment

### DIFF
--- a/aggkit.star
+++ b/aggkit.star
@@ -101,7 +101,9 @@ def create_bridge_config_artifact(
                 data={
                     "deployment_suffix": args["deployment_suffix"],
                     "global_log_level": args["global_log_level"],
-                    "l1_rpc_url": args["l1_rpc_url"],
+                    "l1_rpc_url": args["mitm_rpc_url"].get(
+                        "aggkit", args["l1_rpc_url"]
+                    ),
                     "l2_rpc_name": args["l2_rpc_name"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
                     # ports

--- a/agglayer.star
+++ b/agglayer.star
@@ -128,7 +128,9 @@ def create_agglayer_config_artifact(
                     "deployment_suffix": args["deployment_suffix"],
                     "global_log_level": args["global_log_level"],
                     "l1_chain_id": args["l1_chain_id"],
-                    "l1_rpc_url": args["l1_rpc_url"],
+                    "l1_rpc_url": args["mitm_rpc_url"].get(
+                        "agglayer", args["l1_rpc_url"]
+                    ),
                     "l1_ws_url": args["l1_ws_url"],
                     "zkevm_rollup_fork_id": args["zkevm_rollup_fork_id"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],

--- a/cdk_bridge_infra.star
+++ b/cdk_bridge_infra.star
@@ -49,7 +49,9 @@ def create_bridge_config_artifact(plan, args, contract_setup_addresses, db_confi
                 data={
                     "deployment_suffix": args["deployment_suffix"],
                     "global_log_level": args["global_log_level"],
-                    "l1_rpc_url": args["l1_rpc_url"],
+                    "l1_rpc_url": args["mitm_rpc_url"].get(
+                        "bridge", args["l1_rpc_url"]
+                    ),
                     "l2_rpc_name": args["l2_rpc_name"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
                     # ports
@@ -86,8 +88,9 @@ def create_reverse_proxy_config_artifact(plan, args):
         src="./templates/bridge-infra/haproxy.cfg"
     )
 
-    l1rpc_host = args["l1_rpc_url"].split(":")[1].replace("//", "")
-    l1rpc_port = args["l1_rpc_url"].split(":")[2]
+    l1_rpc_url = args["mitm_rpc_url"].get("bridge", args["l1_rpc_url"])
+    l1rpc_host = l1_rpc_url.split(":")[1].replace("//", "")
+    l1rpc_port = l1_rpc_url.split(":")[2]
     l2rpc_service = plan.get_service(
         name=args["l2_rpc_name"] + args["deployment_suffix"]
     )

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -114,6 +114,9 @@ def run(plan, args, contract_setup_addresses):
                         "is_cdk_validium": data_availability_package.is_cdk_validium(
                             args
                         ),
+                        "l1_rpc_url": args["mitm_rpc_url"].get(
+                            "cdk-node", args["l1_rpc_url"]
+                        ),
                     }
                     | db_configs
                     | contract_setup_addresses,
@@ -177,7 +180,7 @@ def create_dac_config_artifact(plan, args, db_configs, contract_setup_addresses)
                 data={
                     "deployment_suffix": args["deployment_suffix"],
                     "global_log_level": args["global_log_level"],
-                    "l1_rpc_url": args["l1_rpc_url"],
+                    "l1_rpc_url": args["mitm_rpc_url"].get("dac", args["l1_rpc_url"]),
                     "l1_ws_url": args["l1_ws_url"],
                     "zkevm_l2_keystore_password": args["zkevm_l2_keystore_password"],
                     # ports

--- a/docs/mitm.md
+++ b/docs/mitm.md
@@ -1,4 +1,30 @@
 # MITM tests in Kurtosis
+
+## Integrated MITM
+There are option to set MITM as the L1 endpoint for many components:
+- Agglayer
+- AggKit
+- Bridge
+- DAC
+- Erigon Sequencer
+- Eirgon RPC
+- CDK-Node
+
+To do so, you have to set to True the desired component.
+
+    "mitm_proxied_components": {
+        "agglayer": False,
+        "aggkit": False,
+        "bridge": False,
+        "dac": False,
+        "erigon-sequencer": False,
+        "erigon-rpc": False,
+        "cdk-node": False,
+    }
+
+With this, the component will send queries to MITM, and they will be forwarded to the real L1. You can modify ```/scripts/empty.py``` on the MITM service to achieve whatever you want.
+
+
 ## Reorg + Null answers
 
 Run kurtosis setting ```l1_rpc_url``` to ```http://mitm:8234```

--- a/input_parser.star
+++ b/input_parser.star
@@ -164,7 +164,7 @@ DEFAULT_ACCOUNTS = {
 
 DEFAULT_L1_ARGS = {
     # The L1 engine to use, either "geth" or "anvil".
-    "l1_engine": "anvil",
+    "l1_engine": "geth",
     # The L1 network identifier.
     "l1_chain_id": 271828,
     # This mnemonic will:
@@ -227,13 +227,13 @@ DEFAULT_L1_ARGS = {
     "erigon_datadir_archive": None,
     "anvil_state_file": None,
     "mitm_proxied_components": {
-        "agglayer": True,
+        "agglayer": False,
         "aggkit": False,
-        "bridge": True,
+        "bridge": False,
         "dac": False,
         "erigon-sequencer": False,
         "erigon-rpc": False,
-        "cdk-node": True,
+        "cdk-node": False,
     },
 }
 

--- a/input_parser.star
+++ b/input_parser.star
@@ -50,6 +50,7 @@ DEFAULT_IMAGES = {
     "zkevm_prover_image": "hermeznetwork/zkevm-prover:v8.0.0-RC14-fork.12",  # https://hub.docker.com/r/hermeznetwork/zkevm-prover/tags
     "zkevm_sequence_sender_image": "hermeznetwork/zkevm-sequence-sender:v0.2.4",  # https://hub.docker.com/r/hermeznetwork/zkevm-sequence-sender/tags
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.0.0-rc",  # https://github.com/foundry-rs/foundry/pkgs/container/foundry/versions?filters%5Bversion_type%5D=tagged
+    "mitm_image": "mitmproxy/mitmproxy:11.1.2",  # https://hub.docker.com/r/mitmproxy/mitmproxy/tags
 }
 
 DEFAULT_PORTS = {
@@ -73,6 +74,7 @@ DEFAULT_PORTS = {
     "zkevm_cdk_node_port": 5576,
     "blockscout_frontend_port": 3000,
     "anvil_port": 8545,
+    "mitm_port": 8234,
 }
 
 DEFAULT_STATIC_PORTS = {
@@ -162,7 +164,7 @@ DEFAULT_ACCOUNTS = {
 
 DEFAULT_L1_ARGS = {
     # The L1 engine to use, either "geth" or "anvil".
-    "l1_engine": "geth",
+    "l1_engine": "anvil",
     # The L1 network identifier.
     "l1_chain_id": 271828,
     # This mnemonic will:
@@ -224,6 +226,15 @@ DEFAULT_L1_ARGS = {
     "use_previously_deployed_contracts": False,
     "erigon_datadir_archive": None,
     "anvil_state_file": None,
+    "mitm_proxied_components": {
+        "agglayer": False,
+        "aggkit": False,
+        "bridge": True,
+        "dac": False,
+        "erigon-sequencer": False,
+        "erigon-rpc": False,
+        "cdk-node": False,
+    },
 }
 
 DEFAULT_L2_ARGS = {
@@ -421,6 +432,17 @@ def parse_args(plan, user_args):
                 + ":"
                 + str(DEFAULT_PORTS.get("anvil_port"))
             )
+
+    # Setting mitm for each element set to true on mitm dict
+    mitm_rpc_url = (
+        "http://mitm"
+        + args["deployment_suffix"]
+        + ":"
+        + str(DEFAULT_PORTS.get("mitm_port"))
+    )
+    args["mitm_rpc_url"] = {
+        k: mitm_rpc_url for k, v in args.get("mitm_proxied_components", {}).items() if v
+    }
 
     # Validation step.
     verbosity = args.get("verbosity", "")

--- a/input_parser.star
+++ b/input_parser.star
@@ -227,13 +227,13 @@ DEFAULT_L1_ARGS = {
     "erigon_datadir_archive": None,
     "anvil_state_file": None,
     "mitm_proxied_components": {
-        "agglayer": False,
+        "agglayer": True,
         "aggkit": False,
         "bridge": True,
         "dac": False,
         "erigon-sequencer": False,
         "erigon-rpc": False,
-        "cdk-node": False,
+        "cdk-node": True,
     },
 }
 

--- a/mitm.star
+++ b/mitm.star
@@ -1,0 +1,18 @@
+def run(plan, args):
+    plan.add_service(
+        name="mitm" + args["deployment_suffix"],
+        config=ServiceConfig(
+            image=args["mitm_image"],
+            ports={
+                "rpc": PortSpec(args["mitm_port"], application_protocol="http"),
+            },
+            cmd=[
+                "sh",
+                "-c",
+                "mitmdump --mode reverse:"
+                + args["l1_rpc_url"]
+                + " -p "
+                + str(args["mitm_port"])
+            ],
+        ),
+    )

--- a/mitm.star
+++ b/mitm.star
@@ -2,6 +2,7 @@ SRC_MITM_SCRIPT_PATH = "./scripts/mitm"
 DST_MITM_SCRIPT_PATH = "/scripts"
 DEFAULT_SCRIPT = "empty.py"
 
+
 def run(plan, args):
     mitm_script = plan.upload_files(
         name="mitm-script",

--- a/mitm.star
+++ b/mitm.star
@@ -1,4 +1,17 @@
+SRC_MITM_SCRIPT_PATH = "./scripts/mitm"
+DST_MITM_SCRIPT_PATH = "/scripts"
+DEFAULT_SCRIPT = "empty.py"
+
 def run(plan, args):
+    mitm_script = plan.upload_files(
+        name="mitm-script",
+        src=SRC_MITM_SCRIPT_PATH + "/" + DEFAULT_SCRIPT,
+        description="Uploading MITM script",
+    )
+    service_files = {
+        DST_MITM_SCRIPT_PATH: mitm_script,
+    }
+
     plan.add_service(
         name="mitm" + args["deployment_suffix"],
         config=ServiceConfig(
@@ -6,6 +19,7 @@ def run(plan, args):
             ports={
                 "rpc": PortSpec(args["mitm_port"], application_protocol="http"),
             },
+            files=service_files,
             cmd=[
                 "sh",
                 "-c",
@@ -13,6 +27,10 @@ def run(plan, args):
                 + args["l1_rpc_url"]
                 + " -p "
                 + str(args["mitm_port"])
+                + " -s "
+                + DST_MITM_SCRIPT_PATH
+                + "/"
+                + DEFAULT_SCRIPT,
             ],
         ),
     )


### PR DESCRIPTION
## Description
By setting any of these to True, mitm will be deployed and the component/s will be configured with mitm as L1 endpoint.
```
    "mitm_proxied_components": {
        "agglayer": False,
        "aggkit": False,
        "bridge": False,
        "dac": False,
        "erigon-sequencer": False,
        "erigon-rpc": False,
        "cdk-node": False,
    },

```