### PR TITLE
feat: fund claim tx manager even if deploy l2 contracts is false

### DIFF
--- a/deploy_l2_contracts.star
+++ b/deploy_l2_contracts.star
@@ -1,7 +1,7 @@
 service_package = import_module("./lib/service.star")
 
 
-def run(plan, args):
+def run(plan, args, deploy_l2_contracts):
     l2_rpc_url = service_package.get_l2_rpc_url(plan, args)
 
     # When funding accounts and deploying the contracts on l2, the
@@ -17,9 +17,10 @@ def run(plan, args):
             command=[
                 "/bin/sh",
                 "-c",
-                "export l2_rpc_url={0} && chmod +x {1} && {1}".format(
+                "export l2_rpc_url={0} && chmod +x {1} && {1} {2}".format(
                     l2_rpc_url.http,
                     "/opt/contract-deploy/run-l2-contract-setup.sh",
+                    str(deploy_l2_contracts).strip().lower(),
                 ),
             ]
         ),

--- a/main.star
+++ b/main.star
@@ -170,11 +170,9 @@ def run(plan, args={}):
         plan.print("Skipping the deployment of cdk/bridge infrastructure")
 
     # Deploy contracts on L2.
-    if deployment_stages.get("deploy_l2_contracts", False):
-        plan.print("Deploying contracts on L2")
-        import_module(deploy_l2_contracts_package).run(plan, args)
-    else:
-        plan.print("Skipping the deployment of contracts on L2")
+    plan.print("Deploying contracts on L2")
+    deploy_l2_contracts = deployment_stages.get("deploy_l2_contracts", False)
+    import_module(deploy_l2_contracts_package).run(plan, args, deploy_l2_contracts)
 
     # Deploy an OP Stack rollup.
     if deployment_stages.get("deploy_optimism_rollup", False):

--- a/main.star
+++ b/main.star
@@ -154,6 +154,11 @@ def run(plan, args={}):
         import_module(cdk_central_environment_package).run(
             plan, central_environment_args, contract_setup_addresses
         )
+
+        # Deploy contracts on L2.
+        plan.print("Deploying contracts on L2")
+        deploy_l2_contracts = deployment_stages.get("deploy_l2_contracts", False)
+        import_module(deploy_l2_contracts_package).run(plan, args, deploy_l2_contracts)
     else:
         plan.print("Skipping the deployment of cdk central/trusted environment")
 
@@ -168,11 +173,6 @@ def run(plan, args={}):
         )
     else:
         plan.print("Skipping the deployment of cdk/bridge infrastructure")
-
-    # Deploy contracts on L2.
-    plan.print("Deploying contracts on L2")
-    deploy_l2_contracts = deployment_stages.get("deploy_l2_contracts", False)
-    import_module(deploy_l2_contracts_package).run(plan, args, deploy_l2_contracts)
 
     # Deploy an OP Stack rollup.
     if deployment_stages.get("deploy_optimism_rollup", False):

--- a/src/package_io/ports.star
+++ b/src/package_io/ports.star
@@ -15,7 +15,7 @@ def get_public_ports(port_config, start_port_name, args):
     for index, (key, port) in enumerate(sorted_port_config.items()):
         new_port = PortSpec(
             number=start_port + index,
-            # Some ports don't define a transport protocol which makes this specific intruction fail.
+            # Some ports don't define a transport protocol which makes this specific instruction fail.
             # Solutions:
             #   1. We don't care about transport protocol in the case of public ports.
             #   2. We make it mandatory to define transport protocols in PortSpec.

--- a/templates/contract-deploy/run-l2-contract-setup.sh
+++ b/templates/contract-deploy/run-l2-contract-setup.sh
@@ -67,6 +67,11 @@ account_nonce="$(cast nonce --rpc-url "$l2_rpc_url" "$eth_address")"
 echo_ts "Funding bridge autoclaimer account on l2"
 fund_account_on_l2 "{{.zkevm_l2_claimtxmanager_address}}"
 
+# Only fund the claim tx manager address if l2 contracts are not being deployed.
+if [[ "$1" != "true" ]]; then
+    exit 1
+fi
+
 echo_ts "Funding accounts on l2"
 for (( i = 0; i < "{{.l2_accounts_to_fund}}"; i++ )); do
     address=$(cast wallet address --mnemonic "{{.l1_preallocated_mnemonic}}" --mnemonic-index "$i")

--- a/templates/contract-deploy/run-l2-contract-setup.sh
+++ b/templates/contract-deploy/run-l2-contract-setup.sh
@@ -69,7 +69,7 @@ fund_account_on_l2 "{{.zkevm_l2_claimtxmanager_address}}"
 
 # Only fund the claim tx manager address if l2 contracts are not being deployed.
 if [[ "$1" != "true" ]]; then
-    exit 1
+    exit
 fi
 
 echo_ts "Funding accounts on l2"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->
Not funding the claimtxmanager account causes some problems. We run the `deploy_l2_contracts` by default, but only fund the claimtxmanager and skip everything else if it's `false`.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
