### PR TITLE
chore: update op-succinct repo to agglayer version

### DIFF
--- a/.github/tests/chains/op-succinct.yml
+++ b/.github/tests/chains/op-succinct.yml
@@ -9,7 +9,7 @@ args:
   agglayer_prover_sp1_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
   agglayer_prover_primary_prover: "mock-prover"
   consensus_contract_type: pessimistic
-  op_succinct_contract_deployer_image: "jhkimqd/op-succinct-contract-deployer:v0.0.4" # https://hub.docker.com/r/jhkimqd/op-succinct-contract-deployer
+  op_succinct_contract_deployer_image: "jhkimqd/op-succinct-contract-deployer:v0.0.4-agglayer" # https://hub.docker.com/r/jhkimqd/op-succinct-contract-deployer
   op_succinct_server_image: "ghcr.io/succinctlabs/op-succinct/succinct-proposer:sha-cb18ac0" # https://github.com/succinctlabs/op-succinct/pkgs/container/op-succinct%2Fsuccinct-proposer
   op_succinct_proposer_image: "ghcr.io/succinctlabs/op-succinct/op-proposer:sha-cb18ac0" # https://github.com/succinctlabs/op-succinct/pkgs/container/op-succinct%2Fop-proposer
   # true = mock

--- a/docker/op-succinct.Dockerfile
+++ b/docker/op-succinct.Dockerfile
@@ -47,6 +47,6 @@ USER nonroot
 # STEP 2: Download op-succinct contract dependencies.
 WORKDIR /opt/op-succinct
 ARG OP_SUCCINCT_BRANCH
-RUN git clone https://github.com/succinctlabs/op-succinct.git . \
+RUN git clone https://github.com/agglayer/op-succinct.git . \
   && git checkout ${OP_SUCCINCT_BRANCH} \
   && git submodule update --init --recursive


### PR DESCRIPTION
## Description

This PR updates the `op_succinct_contract_deployer_image` to the agglayer/op-succinct repo.

```
v0.0.4-agglayer : [https://github.com/agglayer/op-succinct/tree/6f34173a2a5a37fcc382ab5236b1033c48764848⁠](https://github.com/agglayer/op-succinct/tree/6f34173a2a5a37fcc382ab5236b1033c48764848)

v0.0.4 : [https://github.com/succinctlabs/op-succinct/tree/cb18ac0e512f153e40f4f2a59a55ceaecf3c298c⁠](https://github.com/succinctlabs/op-succinct/tree/cb18ac0e512f153e40f4f2a59a55ceaecf3c298c)
```