### PR TITLE
fix: L2 config for GlobalExitRootAddr

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -659,10 +659,9 @@ def set_anvil_args(plan, args, user_args):
 # Helper function to compact together checks for incompatible parameters in input_parser.star
 def args_sanity_check(plan, deployment_stages, args, user_args, op_stack_args):
     # Fix the op stack el rpc urls according to the deployment_suffix.
-    if (
-        args["op_el_rpc_url"]
-        != "http://op-el-1-op-geth-op-node" + args["deployment_suffix"] + ":8545"
-    ):
+    if args["op_el_rpc_url"] != "http://op-el-1-op-geth-op-node" + args[
+        "deployment_suffix"
+    ] + ":8545" and deployment_stages.get("deploy_op_stack", False):
         plan.print(
             "op_el_rpc_url is set to '{}', changing to 'http://op-el-1-op-geth-op-node{}:8545'".format(
                 args["op_el_rpc_url"], args["deployment_suffix"]
@@ -672,10 +671,9 @@ def args_sanity_check(plan, deployment_stages, args, user_args, op_stack_args):
             "http://op-el-1-op-geth-op-node" + args["deployment_suffix"] + ":8545"
         )
     # Fix the op stack cl rpc urls according to the deployment_suffix.
-    if (
-        args["op_cl_rpc_url"]
-        != "http://op-cl-1-op-node-op-geth" + args["deployment_suffix"] + ":8547"
-    ):
+    if args["op_cl_rpc_url"] != "http://op-cl-1-op-node-op-geth" + args[
+        "deployment_suffix"
+    ] + ":8547" and deployment_stages.get("deploy_op_stack", False):
         plan.print(
             "op_cl_rpc_url is set to '{}', changing to 'http://op-cl-1-op-node-op-geth{}:8547'".format(
                 args["op_cl_rpc_url"], args["deployment_suffix"]
@@ -686,10 +684,9 @@ def args_sanity_check(plan, deployment_stages, args, user_args, op_stack_args):
         )
     # The optimism-package network_params is a frozen hash table, and is not modifiable during runtime.
     # The check will return fail() instead of dynamically changing the network_params name.
-    if (
-        op_stack_args["optimism_package"]["chains"][0]["network_params"]["name"]
-        != args["deployment_suffix"][1:]
-    ):
+    if op_stack_args["optimism_package"]["chains"][0]["network_params"]["name"] != args[
+        "deployment_suffix"
+    ][1:] and deployment_stages.get("deploy_op_stack", False):
         fail(
             "op_stack_args network_params name is set to '{}', please change it to match deployment_suffix '{}'".format(
                 op_stack_args["optimism_package"]["chains"][0]["network_params"][

--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -41,7 +41,7 @@ genesisBlockNumber = "{{.zkevm_rollup_manager_block_number}}"
 	polygonZkEVMAddress = "{{.zkevm_rollup_address}}"
 	
 [L2Config]
-	GlobalExitRootAddr = "{{.zkevm_global_exit_root_address}}"
+	GlobalExitRootAddr = "{{.zkevm_global_exit_root_l2_address}}"
 
 [Log]
 Environment = "development" # "production" or "development"


### PR DESCRIPTION
## Description

- Fix `GlobalExitRootAddr` to point to L2 value
- Only run op `args_sanity_check()` if op deployment enabled. This should fix [aggkit ci](https://github.com/agglayer/aggkit/actions/runs/13810762478/job/38634400645?pr=292#step:10:1345)
