### PR TITLE
chore: version bump on op-succinct with important bug fix

### DIFF
--- a/.github/tests/chains/op-succinct.yml
+++ b/.github/tests/chains/op-succinct.yml
@@ -4,20 +4,19 @@ deployment_stages:
   deploy_op_succinct: true
 
 args:
-  # Fix agglayer image to v0.2.x
-  # https://github.com/agglayer/agglayer/pkgs/container/agglayer/353418839
-  agglayer_image: "ghcr.io/agglayer/agglayer@sha256:5715855f2cc6834bd84a99a33937915164648547d21bfb55198948b0ae4e0fad"
   # Arbitrary key for the SP1 prover. This will not work if op_succinct_mock is set to false. Replace with a valid SPN key if you want to use the network provers.
   # cast wallet private-key --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
   agglayer_prover_sp1_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
   agglayer_prover_primary_prover: "mock-prover"
   consensus_contract_type: pessimistic
-  op_succinct_contract_deployer_image: "jhkimqd/op-succinct-contract-deployer:v0.0.4-agglayer" # https://hub.docker.com/r/jhkimqd/op-succinct-contract-deployer
-  op_succinct_server_image: "ghcr.io/succinctlabs/op-succinct/succinct-proposer:sha-cb18ac0" # https://github.com/succinctlabs/op-succinct/pkgs/container/op-succinct%2Fsuccinct-proposer
-  op_succinct_proposer_image: "ghcr.io/succinctlabs/op-succinct/op-proposer:sha-cb18ac0" # https://github.com/succinctlabs/op-succinct/pkgs/container/op-succinct%2Fop-proposer
+  op_succinct_contract_deployer_image: "jhkimqd/op-succinct-contract-deployer:v0.0.5-agglayer" # https://hub.docker.com/r/jhkimqd/op-succinct-contract-deployer
+  op_succinct_server_image: "jhkimqd/op-succinct-server:v0.0.5-agglayer" # https://github.com/succinctlabs/op-succinct/pkgs/container/op-succinct%2Fsuccinct-proposer
+  op_succinct_proposer_image: "jhkimqd/op-succinct-proposer:v0.0.5-agglayer" # https://github.com/succinctlabs/op-succinct/pkgs/container/op-succinct%2Fop-proposer
   # true = mock
   # false = network
-  op_succinct_mock: true
+  op_succinct_mock: false
+  # Enable the integration with the Agglayer
+  op_succinct_agglayer: true
   # The maximum number of blocks to include in each span proof. For chains with high throughput, you need to decrease this value.
   op_succinct_proposer_span_proof: "50"
   # The minimum interval in L2 blocks at which checkpoints must be submitted. An aggregation proof can be posted for any range larger than this interval.

--- a/lib/op_succinct.star
+++ b/lib/op_succinct.star
@@ -90,6 +90,7 @@ def create_op_succinct_proposer_service_config(
             "VERIFIER_ADDRESS": op_succinct_env_vars["verifier_address"],
             "L2OO_ADDRESS": op_succinct_env_vars["l2oo_address"],
             "OP_SUCCINCT_MOCK": op_succinct_env_vars["op_succinct_mock"],
+            "OP_SUCCINCT_AGGLAYER": op_succinct_env_vars["op_succinct_agglayer"],
             "NETWORK_PRIVATE_KEY": args["agglayer_prover_sp1_key"],
             "MAX_BLOCK_RANGE_PER_SPAN_PROOF": args["op_succinct_proposer_span_proof"],
             "MAX_CONCURRENT_PROOF_REQUESTS": args[

--- a/lib/service.star
+++ b/lib/service.star
@@ -109,6 +109,7 @@ def get_op_succinct_env_vars(plan, args):
         "verifier_address": "fromjson | .VERIFIER_ADDRESS",
         "l2oo_address": "fromjson | .L2OO_ADDRESS",
         "op_succinct_mock": "fromjson | .OP_SUCCINCT_MOCK",
+        "op_succinct_agglayer": "fromjson | .OP_SUCCINCT_AGGLAYER",
         "l1_preallocated_mnemonic": "fromjson | .PRIVATE_KEY",
     }
 

--- a/templates/op-succinct/deploy-op-succinct-contracts.sh
+++ b/templates/op-succinct/deploy-op-succinct-contracts.sh
@@ -32,6 +32,9 @@ L2OO_ADDRESS=""
 # false = network
 OP_SUCCINCT_MOCK="{{.op_succinct_mock}}"
 
+# Enable the integration with the Agglayer
+OP_SUCCINCT_AGGLAYER="{{.op_succinct_agglayer}}"
+
 # The RPC endpoint for the Succinct Prover Network
 NETWORK_RPC_URL="{{.agglayer_prover_network_url}}"
 EOF


### PR DESCRIPTION
## Description

- This bumps the op-succint version to match https://github.com/agglayer/op-succinct/commit/f3f35308d5ae320cb7526c17d7378707a6c2e082
- The new images fix the error logs in the op-succinct-proposer