### PR TITLE
Fix typos in README for Multi-PP Testing

### DIFF
--- a/docs/multi-pp-testing/README
+++ b/docs/multi-pp-testing/README
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "dont run this!"
+echo "don't run this!"
 exit 1;
 
 # # Multi Chain PP Test
@@ -51,7 +51,7 @@ cast code --rpc-url http://$(kurtosis port print pp el-1-geth-lighthouse rpc) $(
 # The third network here should use a mock verifier and should be different
 cast code --rpc-url http://$(kurtosis port print pp el-1-geth-lighthouse rpc) $(cat combined-003.json | jq -r '.verifierAddress') | sha256sum
 
-# It's also worth while probably to confirm that the vkey matches!
+# It's also worthwhile probably to confirm that the vkey matches!
 kurtosis service exec pp agglayer "agglayer vkey"
 
 # Let's make sure both rollups have the same vkey
@@ -95,7 +95,7 @@ cast balance --ether --rpc-url $l2_pp2_url $eth_address
 cast balance --ether --rpc-url $l2_fep_url $eth_address
 
 # ## Initial Funding
-# Let's fund the claim tx manager for both rollups. These address come
+# Let's fund the claim tx manager for both rollups. These addresses come
 # from the chain configurations (so either input_parser or the args
 # file). The claim tx manager will automatically perform claims on our
 # behalf for bridge assets
@@ -107,7 +107,7 @@ cast send --legacy --value 100ether --rpc-url $l2_fep_url --private-key $private
 # key for L1 bridge transfers
 cast send --value 100ether --rpc-url $l1_rpc_url --private-key $private_key $target_address
 
-# Let's mint some POL token for testing purpsoes
+# Let's mint some POL token for testing purposes
 cast send \
      --rpc-url $l1_rpc_url \
      --private-key $private_key \

--- a/docs/multi-pp-testing/README.md
+++ b/docs/multi-pp-testing/README.md
@@ -1,7 +1,7 @@
 
 ```
 #!/bin/bash
-echo "dont run this!"
+echo "don't run this!"
 exit 1;
 ```
 
@@ -72,7 +72,7 @@ The third network here should use a mock verifier and should be different
 cast code --rpc-url http://$(kurtosis port print pp el-1-geth-lighthouse rpc) $(cat combined-003.json | jq -r '.verifierAddress') | sha256sum
 ```
 
-It's also worth while probably to confirm that the vkey matches!
+It's also worthwhile probably to confirm that the vkey matches!
 
 ```
 kurtosis service exec pp agglayer "agglayer vkey"
@@ -134,7 +134,7 @@ cast balance --ether --rpc-url $l2_fep_url $eth_address
 ```
 
 ## Initial Funding
-Let's fund the claim tx manager for both rollups. These address come
+Let's fund the claim tx manager for both rollups. These addresses come
 from the chain configurations (so either input_parser or the args
 file). The claim tx manager will automatically perform claims on our
 behalf for bridge assets
@@ -152,7 +152,7 @@ key for L1 bridge transfers
 cast send --value 100ether --rpc-url $l1_rpc_url --private-key $private_key $target_address
 ```
 
-Let's mint some POL token for testing purpsoes
+Let's mint some POL token for testing purposes
 
 ```
 cast send \


### PR DESCRIPTION
This PR fixes several typos in the `docs/multi-pp-testing/README` and `docs/multi-pp-testing/README.md` files.  
The key changes include:  
- Correcting "dont" → "don't" in the Bash script.  
- Fixing "worth while" → "worthwhile" in the vkey confirmation section.  
- Updating "address" → "addresses" in the funding instructions.  
- Correcting "purpsoes" → "purposes" in the token minting section.  

