### PR TITLE
feat: bump eth pkg to prevent python 3.11 bug

### DIFF
--- a/ethereum.star
+++ b/ethereum.star
@@ -1,5 +1,5 @@
 ethereum_package = import_module(
-    "github.com/ethpandaops/ethereum-package/main.star@c3ecee8148068d5270d9e549d042066d2eb8aec0"  # 2025-03-10
+    "github.com/ethpandaops/ethereum-package/main.star@83830d44823767af65eda7dfe6b26c87c536c4cf"  # 2025-04-09
 )
 
 GETH_IMAGE = "ethereum/client-go:v1.14.12"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

There is a dependency error when deploying the ethereum package.

```bash
× python setup.py bdist_wheel did not run successfully.
│ exit code: 1
╰─> [6 lines of output]
    usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: setup.py --help [cmd1 cmd2 ...]
       or: setup.py --help-commands
       or: setup.py cmd --help
    
    error: invalid command 'bdist_wheel'
    [end of output]

note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed building wheel for bash
Running setup.py clean for bash
```


## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/ethpandaops/ethereum-package/commit/83830d44823767af65eda7dfe6b26c87c536c4cf