### PR TITLE
fix: combined.json incorrect parse

### DIFF
--- a/templates/sovereign-rollup/run-sovereign-setup-predeployed.sh
+++ b/templates/sovereign-rollup/run-sovereign-setup-predeployed.sh
@@ -159,5 +159,8 @@ jq --arg ger_proxy_addr "$ger_proxy_addr" \
     ._legacyLastPendingStateConsolidated = $_legacyLastPendingStateConsolidated |
     .lastVerifiedBatchBeforeUpgrade = $lastVerifiedBatchBeforeUpgrade |
     .rollupVerifierType = $rollupVerifierType' \
-    "/opt/zkevm/combined{{.deployment_suffix}}.json" >"/opt/zkevm/combined{{.deployment_suffix}}.json.temp" &&
-    mv "/opt/zkevm/combined{{.deployment_suffix}}.json.temp" "/opt/zkevm/combined{{.deployment_suffix}}.json"
+    "/opt/zkevm/combined.json" >"/opt/zkevm/combined.json.temp" &&
+    mv "/opt/zkevm/combined.json.temp" "/opt/zkevm/combined.json"
+
+# Copy the updated combined.json to a new file with the deployment suffix
+cp "/opt/zkevm/combined.json" "/opt/zkevm/combined{{.deployment_suffix}}.json"

--- a/templates/sovereign-rollup/run-sovereign-setup.sh
+++ b/templates/sovereign-rollup/run-sovereign-setup.sh
@@ -156,5 +156,8 @@ jq --arg ger_proxy_addr "$ger_proxy_addr" \
     ._legacyLastPendingStateConsolidated = $_legacyLastPendingStateConsolidated |
     .lastVerifiedBatchBeforeUpgrade = $lastVerifiedBatchBeforeUpgrade |
     .rollupVerifierType = $rollupVerifierType' \
-    "/opt/zkevm/combined{{.deployment_suffix}}.json" >"/opt/zkevm/combined{{.deployment_suffix}}.json.temp" &&
-    mv "/opt/zkevm/combined{{.deployment_suffix}}.json.temp" "/opt/zkevm/combined{{.deployment_suffix}}.json"
+    "/opt/zkevm/combined.json" >"/opt/zkevm/combined.json.temp" &&
+    mv "/opt/zkevm/combined.json.temp" "/opt/zkevm/combined.json"
+
+# Copy the updated combined.json to a new file with the deployment suffix
+cp "/opt/zkevm/combined.json" "/opt/zkevm/combined{{.deployment_suffix}}.json"


### PR DESCRIPTION
## Description

This PR fixes an issue when running `run-sovereign-setup.sh` where the `combined.json` does not get updated correctly.