### PR TITLE
fix: issue where we were missing bridge l2 address

### DIFF
--- a/src/additional_services/bridge_spammer.star
+++ b/src/additional_services/bridge_spammer.star
@@ -22,10 +22,8 @@ def run(plan, args, contract_setup_addresses):
                     "l1_rpc_url": args["l1_rpc_url"],
                     "l1_chain_id": args["l1_chain_id"],
                     "zkevm_rollup_chain_id": args["zkevm_rollup_chain_id"],
-                    "zkevm_bridge_address": contract_setup_addresses[
-                        "zkevm_bridge_address"
-                    ],
-                },
+                }
+                | contract_setup_addresses,
             ),
         },
     )


### PR DESCRIPTION
## Description
The bridge spammer was sending transactions on l2 to the wrong address. It looks like the service file was only passing one of the addresses.