### PR TITLE
fix: gas token check

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -766,15 +766,15 @@ def args_sanity_check(plan, deployment_stages, args, user_args, op_stack_args):
             )
         )
 
-    # Gas token enabled and gas token address check
-    if (
-        args.get("gas_token_enabled", False)
-        and args.get("gas_token_address", "0x0000000000000000000000000000000000000000")
-        != "0x0000000000000000000000000000000000000000"
+    # Gas token check
+    gas_token_address = args.get("gas_token_address", "")
+    if args.get("gas_token_enabled", False) and (
+        gas_token_address == ""
+        or gas_token_address == "0x0000000000000000000000000000000000000000"
     ):
         fail(
-            "Gas token address set to '{}' but gas token is not enabled".format(
-                args.get("gas_token_address", "")
+            "Gas token is enabled, but the gas token address is either empty or set to the zero address: '{}'.".format(
+                gas_token_address
             )
         )
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -14,3 +14,6 @@ SEQUENCER_TYPE = struct(
 TOOLBOX_IMAGE = "leovct/toolbox:0.0.8"
 
 L1_ENGINES = ("geth", "anvil")
+
+# Standard zero address in Ethereum.
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

When running the `pre-deployed-gas-token` test, it fails because of the following error:

```bash
Evaluation error: fail: Gas token address set to '0xb4B46bdAA835F8E4b4d8e208B6559cD267851051' but gas token is not enabled
```

This is because the check implemented in the sanity check module is wrong.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- Failing job: https://github.com/0xPolygon/kurtosis-cdk/actions/runs/14587822421/job/40916421933
- Successful job: https://github.com/leovct/kurtosis-cdk/actions/runs/14590317089/job/40923866110
