### PR TITLE
fix: op2.yml args file + cleanup

### DIFF
--- a/.github/tests/chains/op2.yml
+++ b/.github/tests/chains/op2.yml
@@ -3,13 +3,6 @@ deployment_stages:
   deploy_agglayer: false
   deploy_optimism_rollup: true
 
-optimism_package:
-  chains:
-    - network_params:
-        name: "002"
-  observability:
-    enabled: true
-
 args:
   zkevm_rollup_chain_id: 2151909
   deployment_suffix: "-002"
@@ -19,8 +12,44 @@ args:
   op_el_rpc_url: "http://op-el-1-op-geth-op-node-002:8545"
   # OP Stack CL Node URL. Will be dynamically updated by args_sanity_check().
   op_cl_rpc_url: "http://op-cl-1-op-node-op-geth-002:8547"
+  # Arbitrary key for the SP1 prover. Replace with a valid SPN key if you want to use the network provers.
+  # cast wallet private-key --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
+  sp1_prover_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
+  # Valid values are: "network-prover", "mock-prover"
+  agglayer_prover_primary_prover: "mock-prover"
+  # Valid values are: "network-prover", "mock-prover"
+  aggkit_prover_primary_prover: "mock-prover"
 
-  zkevm_l2_aggoracle_address: "0x8F43d25C7aA610A762AC59670b5FFf010a21DB5F"
-  zkevm_l2_aggoracle_private_key: "0x781a3735faba4bf257f3d97b641f66e29a3a89d74178eaeac2e44614b2e066a5"
-  zkevm_l2_sovereignadmin_address: "0x4C9fC4485ca332eAA1B0f621E6e7B5A1c336d3eE"
-  zkevm_l2_sovereignadmin_private_key: "0x719f7a806a2d34f22ed95b460e4fd2d983837e8f63980125adc809eab60151c1"
+  # zkevm_l2_aggoracle_address: "0x8F43d25C7aA610A762AC59670b5FFf010a21DB5F"
+  # zkevm_l2_aggoracle_private_key: "0x781a3735faba4bf257f3d97b641f66e29a3a89d74178eaeac2e44614b2e066a5"
+  # zkevm_l2_sovereignadmin_address: "0x4C9fC4485ca332eAA1B0f621E6e7B5A1c336d3eE"
+  # zkevm_l2_sovereignadmin_private_key: "0x719f7a806a2d34f22ed95b460e4fd2d983837e8f63980125adc809eab60151c1"
+
+
+optimism_package:
+  # We need this for pre-deployed allocs https://github.com/ethpandaops/optimism-package/compare/main...xavier-romero:optimism-package:main#diff-c479a5b20e37b19a976045939f01e8a6deb6a062a147e08b81049469d512d00cR235
+  #         "github.com/ethpandaops/optimism-package/main.star@884f4eb813884c4c8e5deead6ca4e0c54b85da90",
+  source: "github.com/xavier-romero/optimism-package/main.star@d09d841bd5528f4b29144cfc7ecba88a162427ce"
+  predeployed_contracts: true
+  chains:
+    - participants:
+        - el_type: op-geth
+          el_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth@sha256:8cad527a982e929f80fca539e612c59ccb503fc076b86ce1f4ebeefb112dee03"
+          cl_type: op-node
+          cl_image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node@sha256:207943c6ca92a203e5c2f7908769023c76d2304060c8d8c4cfbd469b7fbaaf0d"
+          count: 1
+      batcher_params:
+        image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher@sha256:a017bf0a1dbe88e770eb6979354a148534b36e58ea7bc2fd7ae01f5e90eb9ed3"
+      proposer_params:
+        image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer@sha256:1c6e0c0ac79b561652af1bd5df30f0fcca1490c3989ea0a15e7e18d823e96825"
+      network_params:
+        name: "002"
+        network_id: "2151909"
+        seconds_per_slot: 1
+  op_contract_deployer_params:
+    # image: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.0.12"
+    image: "xavierromero/op-deployer:20250314"
+    l1_artifacts_locator: "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz"
+    l2_artifacts_locator: "https://storage.googleapis.com/oplabs-contract-artifacts/artifacts-v1-fffcbb0ebf7f83311791534a41e65ef90df47797f9ca8f86941452f597f7128c.tar.gz"
+  observability:
+    enabled: true

--- a/cdk_central_environment.star
+++ b/cdk_central_environment.star
@@ -156,17 +156,11 @@ def get_keystores_artifacts(plan, args):
         service_name="contracts" + args["deployment_suffix"],
         src="/opt/zkevm/dac.keystore",
     )
-    claimsponsor_keystore_artifact = plan.store_service_files(
-        name="claimsponsor-keystore",
-        service_name="contracts" + args["deployment_suffix"],
-        src="/opt/zkevm/claimsponsor.keystore",
-    )
     return struct(
         sequencer=sequencer_keystore_artifact,
         aggregator=aggregator_keystore_artifact,
         proofsigner=proofsigner_keystore_artifact,
         dac=dac_keystore_artifact,
-        claimsponsor=claimsponsor_keystore_artifact,
     )
 
 

--- a/input_parser.star
+++ b/input_parser.star
@@ -142,7 +142,7 @@ DEFAULT_STATIC_PORTS = {
 
 # Addresses and private keys of the different components.
 # They have been generated using the following command:
-# polycli wallet inspect --mnemonic 'lab code glass agree maid neutral vessel horror deny frequent favorite soft gate galaxy proof vintage once figure diary virtual scissors marble shrug drop' --addresses 14 | tee keys.txt | jq -r '.Addresses[] | [.ETHAddress, .HexPrivateKey] | @tsv' | awk 'BEGIN{split("sequencer,aggregator,claimtxmanager,timelock,admin,loadtest,agglayer,dac,proofsigner,l1testing,claimsponsor,aggoracle,sovereignadmin",roles,",")} {print "# " roles[NR] "\n\"zkevm_l2_" roles[NR] "_address\": \"" $1 "\","; print "\"zkevm_l2_" roles[NR] "_private_key\": \"0x" $2 "\",\n"}'
+# polycli wallet inspect --mnemonic 'lab code glass agree maid neutral vessel horror deny frequent favorite soft gate galaxy proof vintage once figure diary virtual scissors marble shrug drop' --addresses 12 | tee keys.txt | jq -r '.Addresses[] | [.ETHAddress, .HexPrivateKey] | @tsv' | awk 'BEGIN{split("sequencer,aggregator,claimtxmanager,timelock,admin,loadtest,agglayer,dac,proofsigner,l1testing,aggoracle,sovereignadmin",roles,",")} {print "# " roles[NR] "\n\"zkevm_l2_" roles[NR] "_address\": \"" $1 "\","; print "\"zkevm_l2_" roles[NR] "_private_key\": \"0x" $2 "\",\n"}'
 DEFAULT_ACCOUNTS = {
     # sequencer
     "zkevm_l2_sequencer_address": "0x5b06837A43bdC3dD9F114558DAf4B26ed49842Ed",
@@ -174,14 +174,11 @@ DEFAULT_ACCOUNTS = {
     # l1testing
     "zkevm_l2_l1testing_address": "0xfa291C5f54E4669aF59c6cE1447Dc0b3371EF046",
     "zkevm_l2_l1testing_private_key": "0x1324200455e437cd9d9dc4aa61c702f06fb5bc495dc8ad94ae1504107a216b59",
-    # claimsponsor
-    "zkevm_l2_claimsponsor_address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-    "zkevm_l2_claimsponsor_private_key": "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     # AggKit Addresses
-    "zkevm_l2_aggoracle_address": "0xc653eCD4AC5153a3700Fb13442Bcf00A691cca16",
-    "zkevm_l2_aggoracle_private_key": "0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0",
-    "zkevm_l2_sovereignadmin_address": "0x635243A11B41072264Df6c9186e3f473402F94e9",
-    "zkevm_l2_sovereignadmin_private_key": "0x986b325f6f855236b0b04582a19fe0301eeecb343d0f660c61805299dbf250eb",
+    "zkevm_l2_aggoracle_address": "0x0b68058E5b2592b1f472AdFe106305295A332A7C",
+    "zkevm_l2_aggoracle_private_key": "0x6d1d3ef5765cf34176d42276edd7a479ed5dc8dbf35182dfdb12e8aafe0a4919",
+    "zkevm_l2_sovereignadmin_address": "0xc653eCD4AC5153a3700Fb13442Bcf00A691cca16",
+    "zkevm_l2_sovereignadmin_private_key": "0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0",
 }
 
 DEFAULT_L1_ARGS = {

--- a/input_parser.star
+++ b/input_parser.star
@@ -174,9 +174,10 @@ DEFAULT_ACCOUNTS = {
     # l1testing
     "zkevm_l2_l1testing_address": "0xfa291C5f54E4669aF59c6cE1447Dc0b3371EF046",
     "zkevm_l2_l1testing_private_key": "0x1324200455e437cd9d9dc4aa61c702f06fb5bc495dc8ad94ae1504107a216b59",
-    # AggKit Addresses
+    # aggoracle
     "zkevm_l2_aggoracle_address": "0x0b68058E5b2592b1f472AdFe106305295A332A7C",
     "zkevm_l2_aggoracle_private_key": "0x6d1d3ef5765cf34176d42276edd7a479ed5dc8dbf35182dfdb12e8aafe0a4919",
+    # sovereignadmin
     "zkevm_l2_sovereignadmin_address": "0xc653eCD4AC5153a3700Fb13442Bcf00A691cca16",
     "zkevm_l2_sovereignadmin_private_key": "0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0",
 }

--- a/input_parser.star
+++ b/input_parser.star
@@ -174,6 +174,9 @@ DEFAULT_ACCOUNTS = {
     # l1testing
     "zkevm_l2_l1testing_address": "0xfa291C5f54E4669aF59c6cE1447Dc0b3371EF046",
     "zkevm_l2_l1testing_private_key": "0x1324200455e437cd9d9dc4aa61c702f06fb5bc495dc8ad94ae1504107a216b59",
+    # claimsponsor
+    "zkevm_l2_claimsponsor_address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+    "zkevm_l2_claimsponsor_private_key": "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     # AggKit Addresses
     "zkevm_l2_aggoracle_address": "0xc653eCD4AC5153a3700Fb13442Bcf00A691cca16",
     "zkevm_l2_aggoracle_private_key": "0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0",

--- a/input_parser.star
+++ b/input_parser.star
@@ -174,9 +174,6 @@ DEFAULT_ACCOUNTS = {
     # l1testing
     "zkevm_l2_l1testing_address": "0xfa291C5f54E4669aF59c6cE1447Dc0b3371EF046",
     "zkevm_l2_l1testing_private_key": "0x1324200455e437cd9d9dc4aa61c702f06fb5bc495dc8ad94ae1504107a216b59",
-    # claimsponsor
-    "zkevm_l2_claimsponsor_address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-    "zkevm_l2_claimsponsor_private_key": "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     # AggKit Addresses
     "zkevm_l2_aggoracle_address": "0xc653eCD4AC5153a3700Fb13442Bcf00A691cca16",
     "zkevm_l2_aggoracle_private_key": "0xa574853f4757bfdcbb59b03635324463750b27e16df897f3d00dc6bef2997ae0",

--- a/lib/cdk_node.star
+++ b/lib/cdk_node.star
@@ -22,7 +22,6 @@ def create_cdk_node_service_config(
                     genesis_artifact,
                     keystore_artifact.aggregator,
                     keystore_artifact.sequencer,
-                    keystore_artifact.claimsponsor,
                 ],
             ),
             "/data": Directory(

--- a/templates/contract-deploy/create-keystores.sh
+++ b/templates/contract-deploy/create-keystores.sh
@@ -23,6 +23,5 @@ create_geth_keystore "claimtxmanager.keystore"  "{{.zkevm_l2_claimtxmanager_priv
 create_geth_keystore "agglayer.keystore"        "{{.zkevm_l2_agglayer_private_key}}"        "{{.zkevm_l2_keystore_password}}"
 create_geth_keystore "dac.keystore"             "{{.zkevm_l2_dac_private_key}}"             "{{.zkevm_l2_keystore_password}}"
 create_geth_keystore "proofsigner.keystore"     "{{.zkevm_l2_proofsigner_private_key}}"     "{{.zkevm_l2_keystore_password}}"
-create_geth_keystore "claimsponsor.keystore"    "{{.zkevm_l2_claimsponsor_private_key}}"    "{{.zkevm_l2_keystore_password}}"
 create_geth_keystore "aggoracle.keystore"       "{{.zkevm_l2_aggoracle_private_key}}"       "{{.zkevm_l2_keystore_password}}"
 create_geth_keystore "sovereignadmin.keystore"  "{{.zkevm_l2_sovereignadmin_private_key}}"  "{{.zkevm_l2_keystore_password}}"

--- a/templates/sovereign-rollup/create-predeployed-sovereign-genesis.sh
+++ b/templates/sovereign-rollup/create-predeployed-sovereign-genesis.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 pushd /opt/zkevm-contracts || exit 1
 
@@ -9,7 +10,8 @@ git config --global --add safe.directory /opt/zkevm-contracts
 # So a manual extraction of polygonRollupManagerAddress is done here.
 # Even with multiple op stack deployments, the rollup manager address can be retrieved from combined{{.deployment_suffix}}.json because it must be constant.
 rollup_manager_addr="$(jq -r '.polygonRollupManagerAddress' "/opt/zkevm/combined{{.deployment_suffix}}.json")"
-rollup_id=$(jq -r '.rollupID' /opt/zkevm/create_rollup_output.json)
+chainID="$(jq -r '.chainID' "/opt/zkevm/create_rollup_parameters.json")"
+rollup_id="$(cast call $rollup_manager_addr "chainIDToRollupID(uint64)(uint32)" $chainID --rpc-url http://el-1-geth-lighthouse:8545)"
 
 # Replace rollupManagerAddress with the extracted address
 sed -i "s|\"rollupManagerAddress\": \".*\"|\"rollupManagerAddress\":\"$rollup_manager_addr\"|" /opt/contract-deploy/create-genesis-sovereign-params.json
@@ -21,6 +23,10 @@ cp /opt/contract-deploy/create-genesis-sovereign-params.json /opt/zkevm-contract
 # 2025-04-03 it's not clear which of these should be used at this point
 # cp /opt/contract-deploy/sovereign-genesis.json /opt/zkevm-contracts/tools/createSovereignGenesis/genesis-base.json
 cp /opt/zkevm-contracts/deployment/v2/genesis.json /opt/zkevm-contracts/tools/createSovereignGenesis/genesis-base.json
+
+# Remove all existing output files if they exist
+find /opt/zkevm-contracts/tools/createSovereignGenesis/ -maxdepth 1 -type f -name 'genesis-rollupID*' -exec rm {} +
+find /opt/zkevm-contracts/tools/createSovereignGenesis/ -maxdepth 1 -type f -name 'output-rollupID*' -exec rm {} +
 
 # Run the script
 npx hardhat run ./tools/createSovereignGenesis/create-sovereign-genesis.ts --network localhost

--- a/templates/sovereign-rollup/create-predeployed-sovereign-genesis.sh
+++ b/templates/sovereign-rollup/create-predeployed-sovereign-genesis.sh
@@ -11,7 +11,7 @@ git config --global --add safe.directory /opt/zkevm-contracts
 # Even with multiple op stack deployments, the rollup manager address can be retrieved from combined{{.deployment_suffix}}.json because it must be constant.
 rollup_manager_addr="$(jq -r '.polygonRollupManagerAddress' "/opt/zkevm/combined{{.deployment_suffix}}.json")"
 chainID="$(jq -r '.chainID' "/opt/zkevm/create_rollup_parameters.json")"
-rollup_id="$(cast call $rollup_manager_addr "chainIDToRollupID(uint64)(uint32)" $chainID --rpc-url http://el-1-geth-lighthouse:8545)"
+rollup_id="$(cast call "$rollup_manager_addr" "chainIDToRollupID(uint64)(uint32)" "$chainID" --rpc-url http://el-1-geth-lighthouse:8545)"
 
 # Replace rollupManagerAddress with the extracted address
 sed -i "s|\"rollupManagerAddress\": \".*\"|\"rollupManagerAddress\":\"$rollup_manager_addr\"|" /opt/contract-deploy/create-genesis-sovereign-params.json

--- a/templates/sovereign-rollup/run-initialize-rollup.sh
+++ b/templates/sovereign-rollup/run-initialize-rollup.sh
@@ -253,5 +253,9 @@ check_deployed_contracts() {
 check_deployed_contracts "$l1_contract_addresses" "{{.l1_rpc_url}}"
 check_deployed_contracts "$l2_contract_addresses" "{{.op_el_rpc_url}}"
 
+# Only set the aggchainVkey for the first rollup. Adding multiple aggchainVkeys of the same value will revert with "0x22a1bdc4" or "AggchainVKeyAlreadyExists()".
+rollupID=$(cast call $rollup_manager_addr "chainIDToRollupID(uint64)(uint32)" "{{.zkevm_rollup_chain_id}}" --rpc-url "{{.l1_rpc_url}}")
+if [[ $rollupID == "1" ]]; then
 # FIXME - Temporary work around to make sure the default aggkey is configured
 cast send --rpc-url "{{.l1_rpc_url}}" --private-key "{{.zkevm_l2_admin_private_key}}" "$(jq -r '.aggLayerGatewayAddress' /opt/zkevm/combined.json)" "addDefaultAggchainVKey(bytes4,bytes32)" "{{.pp_vkey_selector}}" "{{.aggchain_vkey_hash}}" 
+fi

--- a/templates/sovereign-rollup/run-initialize-rollup.sh
+++ b/templates/sovereign-rollup/run-initialize-rollup.sh
@@ -254,7 +254,7 @@ check_deployed_contracts "$l1_contract_addresses" "{{.l1_rpc_url}}"
 check_deployed_contracts "$l2_contract_addresses" "{{.op_el_rpc_url}}"
 
 # Only set the aggchainVkey for the first rollup. Adding multiple aggchainVkeys of the same value will revert with "0x22a1bdc4" or "AggchainVKeyAlreadyExists()".
-rollupID=$(cast call $rollup_manager_addr "chainIDToRollupID(uint64)(uint32)" "{{.zkevm_rollup_chain_id}}" --rpc-url "{{.l1_rpc_url}}")
+rollupID=$(cast call "$rollup_manager_addr" "chainIDToRollupID(uint64)(uint32)" "{{.zkevm_rollup_chain_id}}" --rpc-url "{{.l1_rpc_url}}")
 if [[ $rollupID == "1" ]]; then
 # FIXME - Temporary work around to make sure the default aggkey is configured
 cast send --rpc-url "{{.l1_rpc_url}}" --private-key "{{.zkevm_l2_admin_private_key}}" "$(jq -r '.aggLayerGatewayAddress' /opt/zkevm/combined.json)" "addDefaultAggchainVKey(bytes4,bytes32)" "{{.pp_vkey_selector}}" "{{.aggchain_vkey_hash}}" 


### PR DESCRIPTION
## Description

- Fix the `op2.yml` args file to allow attaching second op-geth network to the existing enclave with something like `kurtosis run --enclave=aggkit --args-file=./.github/tests/chains/op2.yml .` 
- Remove `zkevm_l2_claimsponsor_address` which was originally intended to be used as a separate address for the aggkit bridge. But having both `zkevm_l2_claimtxmanager_address` and `zkevm_l2_claimsponsor_address` could be confusing.
- Fix an issue on the `create-predeployed-sovereign-genesis.sh` script where the output that would be copied to create the allocs would be the incorrect default (example) output