### PR TITLE
feat: allow different chainid usage for op-succinct

### DIFF
--- a/.github/tests/chains/op-succinct.yml
+++ b/.github/tests/chains/op-succinct.yml
@@ -32,6 +32,7 @@ args:
   # The maximum number of concurrent witness generation processes to run on the `op-succinct-server`
   op_succinct_max_concurrent_witness_gen: "1"
   # Must match network_id field in network_params.network_id
+  # When changing the chain_id, the proofs.db file under /templates/op-succinct/db/{chain_id}/proofs.db must also be remapped to the new chain_id.
   zkevm_rollup_chain_id: 2151908
   # The number following the "-" should be identical to network_params.name
   deployment_suffix: "-001"
@@ -62,7 +63,9 @@ optimism_package:
       challenger_params:
         enabled: false
       network_params:
+        # This value must be equal to args["deployment_suffix"][1:]
         name: "001"
+        # This value must be equal to args["zkevm_rollup_chain_id"]
         network_id: "2151908"
         seconds_per_slot: 1
   op_contract_deployer_params:

--- a/lib/op_succinct.star
+++ b/lib/op_succinct.star
@@ -169,7 +169,8 @@ def create_op_succinct_proposer_service_config(
         image=args["op_succinct_proposer_image"],
         ports=ports,
         files={
-            "/usr/local/bin/dbdata/2151908": Directory(
+            "/usr/local/bin/dbdata/"
+            + str(args["zkevm_rollup_chain_id"]): Directory(
                 artifact_names=[
                     db_artifact,
                 ],

--- a/op_succinct.star
+++ b/op_succinct.star
@@ -49,7 +49,9 @@ def op_succinct_proposer_run(plan, args, op_succinct_env_vars):
     # echo 'CREATE TABLE `proof_requests` (`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT, `type` text NOT NULL, `start_block` integer NOT NULL, `end_block` integer NOT NULL, `status` text NOT NULL, `request_added_time` integer NOT NULL, `prover_request_id` text NULL, `proof_request_time` integer NULL, `last_updated_time` integer NOT NULL, `l1_block_number` integer NULL, `l1_block_hash` text NULL, `proof` blob NULL);'  | sqlite3 foo.db
 
     op_succinct_proposer_config_template = read_file(
-        src="./templates/op-succinct/db/2151908/proofs.db"
+        src="./templates/op-succinct/db/"
+        + str(args["zkevm_rollup_chain_id"])
+        + "/proofs.db"
     )
     op_succinct_proposer_config_artifact = plan.render_templates(
         name="op-succinct-proposer-config-artifact",

--- a/templates/sovereign-rollup/create-predeployed-sovereign-genesis.sh
+++ b/templates/sovereign-rollup/create-predeployed-sovereign-genesis.sh
@@ -11,7 +11,7 @@ git config --global --add safe.directory /opt/zkevm-contracts
 # Even with multiple op stack deployments, the rollup manager address can be retrieved from combined{{.deployment_suffix}}.json because it must be constant.
 rollup_manager_addr="$(jq -r '.polygonRollupManagerAddress' "/opt/zkevm/combined{{.deployment_suffix}}.json")"
 chainID="$(jq -r '.chainID' "/opt/zkevm/create_rollup_parameters.json")"
-rollup_id="$(cast call "$rollup_manager_addr" "chainIDToRollupID(uint64)(uint32)" "$chainID" --rpc-url http://el-1-geth-lighthouse:8545)"
+rollup_id="$(cast call "$rollup_manager_addr" "chainIDToRollupID(uint64)(uint32)" "$chainID" --rpc-url "{{.l1_rpc_url}}")"
 
 # Replace rollupManagerAddress with the extracted address
 sed -i "s|\"rollupManagerAddress\": \".*\"|\"rollupManagerAddress\":\"$rollup_manager_addr\"|" /opt/contract-deploy/create-genesis-sovereign-params.json


### PR DESCRIPTION
## Description

- Allow op-succinct networks to use different chainid by making the `proofs.db` path dynamic
- Cleanup