### PR TITLE
chore: increase job timeouts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
   run-with-args:
     needs: list-ymls
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -169,7 +169,7 @@ jobs:
 
   pre-deployed-gas-token:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -258,7 +258,7 @@ jobs:
 
   deploy-to-anvil-l1:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Our [nightly](https://github.com/0xPolygon/kurtosis-cdk/actions/workflows/nightly.yml) jobs have been failing due to timeouts when running bridge tests, but it works locally and on the main branch. I suspect that some of the instances used by the nightly runs are less powerful, causing timeouts.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

- https://github.com/0xPolygon/kurtosis-cdk/actions/runs/14876260869
- https://github.com/0xPolygon/kurtosis-cdk/actions/runs/14830052809
- https://github.com/0xPolygon/kurtosis-cdk/actions/runs/14818316855