### PR TITLE
feat: remove redundant proofsdb

### DIFF
--- a/lib/op_succinct.star
+++ b/lib/op_succinct.star
@@ -45,7 +45,6 @@ def create_op_succinct_contract_deployer_service_config(
 def create_op_succinct_proposer_service_config(
     args,
     op_succinct_env_vars,
-    db_artifact,
 ):
     op_succinct_name = "op-succinct-proposer" + args["deployment_suffix"]
     ports = get_op_succinct_proposer_ports(args)
@@ -88,14 +87,6 @@ def create_op_succinct_proposer_service_config(
     op_succinct_proposer_service_config = ServiceConfig(
         image=args["op_succinct_proposer_image"],
         ports=ports,
-        files={
-            "/usr/local/bin/dbdata/"
-            + str(args["zkevm_rollup_chain_id"]): Directory(
-                artifact_names=[
-                    db_artifact,
-                ],
-            ),
-        },
         env_vars=env_vars,
     )
 

--- a/op_succinct.star
+++ b/op_succinct.star
@@ -34,24 +34,10 @@ def op_succinct_proposer_run(plan, args, op_succinct_env_vars):
     # FIXME... what is this point of this.. I think we can use a script to do this and we can avoid the weird hard coded chain id
     # echo 'CREATE TABLE `proof_requests` (`id` integer NOT NULL PRIMARY KEY AUTOINCREMENT, `type` text NOT NULL, `start_block` integer NOT NULL, `end_block` integer NOT NULL, `status` text NOT NULL, `request_added_time` integer NOT NULL, `prover_request_id` text NULL, `proof_request_time` integer NULL, `last_updated_time` integer NOT NULL, `l1_block_number` integer NULL, `l1_block_hash` text NULL, `proof` blob NULL);'  | sqlite3 foo.db
 
-    op_succinct_proposer_config_template = read_file(
-        src="./templates/op-succinct/db/"
-        + str(args["zkevm_rollup_chain_id"])
-        + "/proofs.db"
-    )
-    op_succinct_proposer_config_artifact = plan.render_templates(
-        name="op-succinct-proposer-config-artifact",
-        config={
-            "proofs.db": struct(
-                template=op_succinct_proposer_config_template, data=args
-            )
-        },
-    )
-
     # Start the op-succinct-proposer component.
     op_succinct_proposer_configs = (
         op_succinct_package.create_op_succinct_proposer_service_config(
-            args, op_succinct_env_vars, op_succinct_proposer_config_artifact
+            args, op_succinct_env_vars
         )
     )
 


### PR DESCRIPTION
## Description

- Remove proofsdb which was previously needed only in the golang-proposer deployments