### PR TITLE
feat: update images and vkeys

### DIFF
--- a/.github/tests/chains/op-succinct-real-prover.yml
+++ b/.github/tests/chains/op-succinct-real-prover.yml
@@ -12,8 +12,8 @@ args:
   # Valid values are: "network-prover", "mock-prover"
   aggkit_prover_primary_prover: "network-prover"
   consensus_contract_type: fep
-  pp_vkey_hash: "0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7"
-  aggchain_vkey_hash: "0x2e1061045949ba9e43324bfa58dc554b43f51b45538a62e91c83cf8e0c5d3617"
+  pp_vkey_hash: "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be"
+  aggchain_vkey_hash: "0x6b649aca1ba2be1e509a1cce39f7f0a1601bfcf90f0a27104970669c22df59d5"
   # aggkit_prover_image: "ghcr.io/agglayer/aggkit-prover:feat-rust-proposer"
   # false = network
   # Using the network provers will use the real SP1 verifier contract which is also deployed together in the Kurtosis devnet.

--- a/.github/tests/chains/op-succinct.yml
+++ b/.github/tests/chains/op-succinct.yml
@@ -12,8 +12,8 @@ args:
   aggkit_prover_primary_prover: "mock-prover"
   sp1_prover_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
   consensus_contract_type: fep
-  pp_vkey_hash: "0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7"
-  aggchain_vkey_hash: "0x2e1061045949ba9e43324bfa58dc554b43f51b45538a62e91c83cf8e0c5d3617"
+  pp_vkey_hash: "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be"
+  aggchain_vkey_hash: "0x6b649aca1ba2be1e509a1cce39f7f0a1601bfcf90f0a27104970669c22df59d5"
   # aggkit_prover_image: "ghcr.io/agglayer/aggkit-prover:feat-rust-proposer"
   # true = mock
   # false = network

--- a/.github/tests/chains/op2.yml
+++ b/.github/tests/chains/op2.yml
@@ -8,8 +8,8 @@ args:
   deployment_suffix: "-002"
   zkevm_rollup_id: 2
   consensus_contract_type: pessimistic
-  pp_vkey_hash: "0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7"
-  aggchain_vkey_hash: "0x1f3df68a258f9d6748b291dd35faf80065af7cc11ef8b5fc6db2a4d958ea62d2"
+  pp_vkey_hash: "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be"
+  aggchain_vkey_hash: "0x6b649aca1ba2be1e509a1cce39f7f0a1601bfcf90f0a27104970669c22df59d5"
   # OP Stack EL RPC URL. Will be dynamically updated by args_sanity_check().
   op_el_rpc_url: "http://op-el-1-op-geth-op-node-002:8545"
   # OP Stack CL Node URL. Will be dynamically updated by args_sanity_check().

--- a/.github/tests/combinations/fork12-cdk-erigon-sovereign.yml
+++ b/.github/tests/combinations/fork12-cdk-erigon-sovereign.yml
@@ -6,7 +6,7 @@ args:
   zkevm_contracts_image: leovct/zkevm-contracts:v10.1.0-rc.3-devtools-fork.12
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   consensus_contract_type: pessimistic
-  pp_vkey_hash: '0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7'
+  pp_vkey_hash: '0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be'
   sp1_prover_key: ''
   agglayer_prover_primary_prover: mock-prover
   erigon_strict_mode: false

--- a/.github/tests/consensus/sovereign.yml
+++ b/.github/tests/consensus/sovereign.yml
@@ -2,7 +2,7 @@
 args:
   consensus_contract_type: pessimistic
 
-  pp_vkey_hash: "0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7"
+  pp_vkey_hash: "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be"
   sp1_prover_key: ""
   agglayer_prover_primary_prover: mock-prover # network-prover (using SP1 network)
 

--- a/.github/tests/nightly/op-rollup/op-default.yml
+++ b/.github/tests/nightly/op-rollup/op-default.yml
@@ -5,7 +5,7 @@ args:
   verbosity: debug
   consensus_contract_type: pessimistic
   zkevm_rollup_chain_id: 2151908
-  pp_vkey_hash: "0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7"
+  pp_vkey_hash: "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be"
   aggchain_vkey_hash: "0x2e1061045949ba9e43324bfa58dc554b43f51b45538a62e91c83cf8e0c5d3617"
   # Arbitrary key for the SP1 prover. Replace with a valid SPN key if you want to use the network provers.
   # cast wallet private-key --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"

--- a/.github/tests/nightly/op-rollup/op-default.yml
+++ b/.github/tests/nightly/op-rollup/op-default.yml
@@ -6,7 +6,7 @@ args:
   consensus_contract_type: pessimistic
   zkevm_rollup_chain_id: 2151908
   pp_vkey_hash: "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be"
-  aggchain_vkey_hash: "0x2e1061045949ba9e43324bfa58dc554b43f51b45538a62e91c83cf8e0c5d3617"
+  aggchain_vkey_hash: "0x6b649aca1ba2be1e509a1cce39f7f0a1601bfcf90f0a27104970669c22df59d5"
   # Arbitrary key for the SP1 prover. Replace with a valid SPN key if you want to use the network provers.
   # cast wallet private-key --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
   sp1_prover_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"

--- a/input_parser.star
+++ b/input_parser.star
@@ -39,7 +39,7 @@ DEFAULT_DEPLOYMENT_STAGES = {
 }
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "aggkit:local",  # https://github.com/agglayer/aggkit/pkgs/container/aggkit
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta2",  # https://github.com/agglayer/aggkit/pkgs/container/aggkit
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.0-rc.20",  # https://github.com/agglayer/agglayer/pkgs/container/agglayer
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:0.1.0-rc.27",  # https://github.com/agglayer/provers/pkgs/container/aggkit-prover
     "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.19",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags

--- a/input_parser.star
+++ b/input_parser.star
@@ -39,9 +39,9 @@ DEFAULT_DEPLOYMENT_STAGES = {
 }
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.3.0-beta2",  # https://github.com/agglayer/aggkit/pkgs/container/aggkit
-    "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.0-rc.16",  # https://github.com/agglayer/agglayer/pkgs/container/agglayer
-    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:0.1.0-rc.22",  # https://github.com/agglayer/provers/pkgs/container/aggkit-prover
+    "aggkit_image": "aggkit:local",  # https://github.com/agglayer/aggkit/pkgs/container/aggkit
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.0-rc.20",  # https://github.com/agglayer/agglayer/pkgs/container/agglayer
+    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:0.1.0-rc.27",  # https://github.com/agglayer/provers/pkgs/container/aggkit-prover
     "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.19",  # https://hub.docker.com/r/hermeznetwork/cdk-erigon/tags
     "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.5.4-rc1",  # https://github.com/0xpolygon/cdk/pkgs/container/cdk
     "cdk_validium_node_image": "ghcr.io/0xpolygon/cdk-validium-node:0.6.4-cdk.10",  # https://github.com/0xPolygon/cdk-validium-node/pkgs/container/cdk-validium-node/
@@ -308,13 +308,13 @@ DEFAULT_ROLLUP_ARGS = {
     "aggchain_vkey_hash": "",
     # AggchainFEP, PolygonValidiumEtrog, PolygonZkEVMEtrog consensus requires programVKey === bytes32(0).
     # TODO automate this `docker run -it ghcr.io/agglayer/agglayer:0.3.0-rc.7 agglayer vkey`
-    "pp_vkey_hash": "0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7",
+    "pp_vkey_hash": "0x00e60517ac96bf6255d81083269e72c14ad006e5f336f852f7ee3efb91b966be",
     # The 4 bytes selector to add to the pessimistic verification keys (AggLayerGateway)
     # TODO automate this `docker run -it ghcr.io/agglayer/agglayer:0.3.0-rc.7 agglayer vkey-selector`
-    "pp_vkey_selector": "0x00000001",
+    "pp_vkey_selector": "0x00000002",
     # Initial aggchain selector
     # TODO automate taking the first 2 bytes of this `docker run -it ghcr.io/agglayer/aggkit-prover:0.1.0-rc.8 aggkit-prover vkey-selector`
-    "aggchain_vkey_selector": "0x00000001",
+    "aggchain_vkey_selector": "0x00010001",
     # ForkID for the consensus contract. Must be 0 for AggchainFEP consensus.
     "fork_id": 12,
     # This flag will enable a stateless executor to verify the execution of the batches.
@@ -922,8 +922,7 @@ def validate_aggchain_vkey_with_binary(plan, aggchain_vkey, aggkit_prover_image)
     )
     plan.verify(
         description="Verifying aggkit prover vkey",
-        # FIXME: At some point in the future, the aggchain vkey hash will probably come prefixed with 0x and we'll need to fix this.
-        value="{}".format(result.output),
+        value=result.output,
         assertion="==",
         target_value=aggchain_vkey,
     )


### PR DESCRIPTION
## Description
This PR updates the images of agglayer and aggkit prover with corresponding `vkeys` and `selectors` for the `PP` - `FEP` upgrade.

The `vkey` from the prover now comes with prefixed `0x`, so this PR removes the format code in the `vkey` check.
