### PR TITLE
fix: remove trailing slash from aggkit/cdk data path

### DIFF
--- a/input_parser.star
+++ b/input_parser.star
@@ -374,7 +374,7 @@ DEFAULT_ROLLUP_ARGS = {
     "aggkit_pprof_enabled": True,
     # This is a path where the cdk-node will write data
     # https://github.com/0xPolygon/cdk/blob/d0e76a3d1361158aa24135f25d37ecc4af959755/config/default.go#L50
-    "zkevm_path_rw_data": "/tmp/",
+    "zkevm_path_rw_data": "/tmp",
     # OP Stack EL RPC URL. Will be dynamically updated by args_sanity_check() function.
     "op_el_rpc_url": "http://op-el-1-op-geth-op-node-001:8545",
     # OP Stack CL Node URL. Will be dynamically updated by args_sanity_check() function.

--- a/lib/cdk_node.star
+++ b/lib/cdk_node.star
@@ -87,7 +87,7 @@ def get_cdk_node_cmd(args):
             "sleep 20 && cdk-node run "
             + "--cfg=/etc/cdk/cdk-node-config.toml "
             + "--custom-network-file=/etc/cdk/genesis.json "
-            + "--save-config-path=/tmp/ "
+            + "--save-config-path=/tmp "
             + "--components=aggsender"
         ]
 
@@ -95,7 +95,7 @@ def get_cdk_node_cmd(args):
         service_command = [
             "sleep 20 && aggkit run "
             + "--cfg=/etc/cdk/cdk-node-config.toml "
-            + "--save-config-path=/tmp/ "
+            + "--save-config-path=/tmp "
             + "--components=aggsender,bridge"
         ]
 

--- a/templates/aggkit/aggkit-cdk-config.toml
+++ b/templates/aggkit/aggkit-cdk-config.toml
@@ -52,7 +52,7 @@ CertificateSendInterval = "1m"
 CheckSettledInterval = "5s"
 
 [ClaimSponsor]
-DBPath = "{{.zkevm_path_rw_data}}claimsponsor.sqlite"
+DBPath = "{{.zkevm_path_rw_data}}/claimsponsor.sqlite"
 Enabled = "{{.enable_aggkit_claim_sponsor}}"
 SenderAddr = "{{.zkevm_l2_claimsponsor_address}}"
 BridgeAddrL2 = "{{.zkevm_bridge_l2_address}}"

--- a/templates/aggkit/aggkit-config.toml
+++ b/templates/aggkit/aggkit-config.toml
@@ -369,7 +369,7 @@ PrivateKeys = [{Path = "/etc/aggkit/aggoracle.keystore", Password = "{{.zkevm_l2
 # ------------------------------------------------------------------------------
 # StoragePath is the path of the internal storage
 # ------------------------------------------------------------------------------
-# StoragePath = "{{.zkevm_path_rw_data}}ethtxmanager-aggoracle.sqlite"
+# StoragePath = "{{.zkevm_path_rw_data}}/ethtxmanager-aggoracle.sqlite"
 
 # ------------------------------------------------------------------------------
 # ReadPendingL1Txs is a flag to enable the reading of pending L1 txs
@@ -413,7 +413,7 @@ BridgeAddr = "{{.sovereign_bridge_proxy_addr}}"
 # ------------------------------------------------------------------------------
 # DBPath path of the sqlite db
 # ------------------------------------------------------------------------------
-# DBPath = "{{.zkevm_path_rw_data}}bridgel2sync.sqlite"
+# DBPath = "{{.zkevm_path_rw_data}}/bridgel2sync.sqlite"
 
 # ------------------------------------------------------------------------------
 # BlockFinality indicates the status of the blocks that will be queried to sync
@@ -474,7 +474,7 @@ InitialBlock = "{{.zkevm_rollup_manager_block_number}}"
 # ------------------------------------------------------------------------------
 # Path of the DB
 # ------------------------------------------------------------------------------
-DBPath = "{{.zkevm_path_rw_data}}claimsponsor.sqlite"
+DBPath = "{{.zkevm_path_rw_data}}/claimsponsor.sqlite"
 
 # ------------------------------------------------------------------------------
 # Enabled indicates if the sponsor should be run or not
@@ -503,7 +503,7 @@ PrivateKeys = [
 # ------------------------------------------------------------------------------
 # StoragePath is the path of the internal storage
 # ------------------------------------------------------------------------------
-StoragePath = "{{.zkevm_path_rw_data}}ethtxmanager-claimsponsor.sqlite"
+StoragePath = "{{.zkevm_path_rw_data}}/ethtxmanager-claimsponsor.sqlite"
 
 [ClaimSponsor.EthTxManager.Etherman]
 # ------------------------------------------------------------------------------

--- a/templates/trusted-node/cdk-node-config.toml
+++ b/templates/trusted-node/cdk-node-config.toml
@@ -71,7 +71,7 @@ CertificateSendInterval = "1m"
 CheckSettledInterval = "5s"
 
 [ClaimSponsor]
-DBPath = "{{.zkevm_path_rw_data}}claimsponsor.sqlite"
+DBPath = "{{.zkevm_path_rw_data}}/claimsponsor.sqlite"
 Enabled = "{{.enable_aggkit_claim_sponsor}}"
 SenderAddr = "{{.zkevm_l2_claimsponsor_address}}"
 BridgeAddrL2 = "{{.zkevm_bridge_l2_address}}"
@@ -80,7 +80,7 @@ BridgeAddrL2 = "{{.zkevm_bridge_l2_address}}"
 PrivateKeys = [
     {Path = "/etc/cdk/claimsponsor.keystore", Password = "{{.zkevm_l2_keystore_password}}"},
 ]
-StoragePath = "{{.zkevm_path_rw_data}}ethtxmanager-claimsponsor.sqlite"
+StoragePath = "{{.zkevm_path_rw_data}}/ethtxmanager-claimsponsor.sqlite"
 
 [ClaimSponsor.EthTxManager.Etherman]
 URL = "http://{{.l2_rpc_name}}{{.deployment_suffix}}:{{.zkevm_rpc_http_port}}"


### PR DESCRIPTION
## Description
Remove trailing slash from aggkit/cdk data path in order to make it valid, since for the most components in the aggkit and cdk, default is specified this way `PathRWData/<data_storage>.sql`, which results in double slashes (e.g. `tmp//aggsender.sql`)
