### PR TITLE
feat: add Aggkit Prover gRPC server URL configuration

### DIFF
--- a/templates/aggkit/aggkit-config.toml
+++ b/templates/aggkit/aggkit-config.toml
@@ -168,7 +168,6 @@ Port = "{{.aggkit_node_rest_api_port}}"
 # AggsenderPrivateKey is the private key which is used to sign certificates
 # ------------------------------------------------------------------------------
 AggsenderPrivateKey = {Path = "/etc/aggkit/sovereignadmin.keystore", Password = "{{.zkevm_l2_keystore_password}}"}
-AggchainProofURL="{{.aggkit_prover_grpc_url_prefix}}{{.deployment_suffix}}:{{.aggkit_prover_grpc_port}}"
 CheckStatusCertificateInterval = "1s"
 
 {{- if eq .consensus_contract_type "pessimistic"}}
@@ -176,6 +175,12 @@ Mode="PessimisticProof"
 {{- else}}
 Mode="AggchainProof"
 {{- end}}
+
+[AggSender.AggkitProverClient]
+# ------------------------------------------------------------------------------
+# URL is the URL of the Aggkit Prover gRPC server
+# ------------------------------------------------------------------------------
+URL="{{.aggkit_prover_grpc_url_prefix}}{{.deployment_suffix}}:{{.aggkit_prover_grpc_port}}"
 
 [AggSender.MaxSubmitCertificateRate]
 NumRequests = 20


### PR DESCRIPTION
## Description
We have introduced retry policies for GRPC calls in the aggkit. It changed the aggkit configuration layout a bit.

The configuration evolved from this:
```toml
AggLayerURL = "{{AggLayerURL}}"
```

to this:
```toml
[AggSender.AgglayerClient]
URL = "{{AggLayerURL}}"
MinConnectTimeout = "5s"
RequestTimeout = "5s"
UseTLS = false
    [AggSender.AgglayerClient.Retry]
    InitialBackoff = "1s"
    MaxBackoff = "10s"
    BackoffMultiplier = 2.0
    MaxAttempts = 8
        [AggSender.AgglayerClient.Retry.Excluded]
            Service = "agglayer.node.v1.ConfigurationService"
            Method = "GetEpochConfiguration"
```

Affected configuration sections:
- `AggSender.AggLayerURL` -> `AggSender.AgglayerClient`
- `AggSender.AggchainProofURL` -> `AggSender.AggkitProverClient`
- `AggchainProofGen.AggchainProofURL` -> `AggchainProofGen.AggkitProverClient`

## References (if applicable)
Related [PR](https://github.com/agglayer/aggkit/pull/524) on the aggkit
