### PR TITLE
refactor: fund-addresses.sh script

### DIFF
--- a/lib/service.star
+++ b/lib/service.star
@@ -219,3 +219,33 @@ def get_op_succinct_l2oo_config(plan, args):
         recipe=exec_recipe,
     )
     return get_exec_recipe_result(result)
+
+
+def get_kurtosis_addresses(args):
+    zkevm_l2_sequencer_address = args["zkevm_l2_sequencer_address"]
+    zkevm_l2_aggregator_address = args["zkevm_l2_aggregator_address"]
+    zkevm_l2_claimtxmanager_address = args["zkevm_l2_claimtxmanager_address"]
+    zkevm_l2_timelock_address = args["zkevm_l2_timelock_address"]
+    zkevm_l2_admin_address = args["zkevm_l2_admin_address"]
+    zkevm_l2_loadtest_address = args["zkevm_l2_loadtest_address"]
+    zkevm_l2_agglayer_address = args["zkevm_l2_agglayer_address"]
+    zkevm_l2_dac_address = args["zkevm_l2_dac_address"]
+    zkevm_l2_proofsigner_address = args["zkevm_l2_proofsigner_address"]
+    zkevm_l2_l1testing_address = args["zkevm_l2_l1testing_address"]
+    zkevm_l2_aggoracle_address = args["zkevm_l2_aggoracle_address"]
+    zkevm_l2_sovereignadmin_address = args["zkevm_l2_sovereignadmin_address"]
+
+    return {
+        "zkevm_l2_sequencer_address": zkevm_l2_sequencer_address,
+        "zkevm_l2_aggregator_address": zkevm_l2_aggregator_address,
+        "zkevm_l2_claimtxmanager_address": zkevm_l2_claimtxmanager_address,
+        "zkevm_l2_timelock_address": zkevm_l2_timelock_address,
+        "zkevm_l2_admin_address": zkevm_l2_admin_address,
+        "zkevm_l2_loadtest_address": zkevm_l2_loadtest_address,
+        "zkevm_l2_agglayer_address": zkevm_l2_agglayer_address,
+        "zkevm_l2_dac_address": zkevm_l2_dac_address,
+        "zkevm_l2_proofsigner_address": zkevm_l2_proofsigner_address,
+        "zkevm_l2_l1testing_address": zkevm_l2_l1testing_address,
+        "zkevm_l2_aggoracle_address": zkevm_l2_aggoracle_address,
+        "zkevm_l2_sovereignadmin_address": zkevm_l2_sovereignadmin_address,
+    }

--- a/main.star
+++ b/main.star
@@ -78,12 +78,21 @@ def run(plan, args={}):
             op_deployer_configs_artifact = plan.get_files_artifact(
                 name="op-deployer-configs",
             )
+
+            # Fund OP Addresses on L1
             l1_op_contract_addresses = service_package.get_l1_op_contract_addresses(
                 plan, args, op_deployer_configs_artifact
             )
 
             import_module(deploy_sovereign_contracts_package).fund_addresses(
-                plan, args, l1_op_contract_addresses
+                plan, args, l1_op_contract_addresses, args["l1_rpc_url"]
+            )
+
+            # Fund Kurtosis addresses on OP L2
+            l2_kurtosis_addresses = service_package.get_kurtosis_addresses(args)
+
+            import_module(deploy_sovereign_contracts_package).fund_addresses(
+                plan, args, l2_kurtosis_addresses, args["op_el_rpc_url"]
             )
 
             if deployment_stages.get("deploy_op_succinct", False):

--- a/templates/sovereign-rollup/fund-addresses.sh
+++ b/templates/sovereign-rollup/fund-addresses.sh
@@ -1,14 +1,64 @@
 #!/usr/bin/env bash
 
-# Fund L1 OP addresses.
-IFS=';' read -ra addresses <<<"${L1_OP_ADDRESSES}"
-private_key=$(cast wallet private-key --mnemonic "{{.l1_preallocated_mnemonic}}")
+# Exit on error
+set -e
+
+# Validate required environment variables
+if [[ -z "$RPC_URL" ]]; then
+    echo "Error: RPC_URL environment variable is not set."
+    exit 1
+fi
+
+if [[ -z "$ADDRESSES_TO_FUND" ]]; then
+    echo "Error: ADDRESSES_TO_FUND environment variable is not set."
+    exit 1
+fi
+
+if [[ -z "$L2_FUNDING_AMOUNT" ]]; then
+    echo "Error: L2_FUNDING_AMOUNT environment variable is not set."
+    exit 1
+fi
+
+# Fund addresses
+IFS=';' read -ra addresses <<<"$ADDRESSES_TO_FUND"
+
+# Set private key based on RPC_URL
+if [[ "$RPC_URL" == "http://op-el-1-op-geth-op-node-001:8545" ]]; then
+    # Default optimism-package preallocated mnemonic
+    private_key=$(cast wallet private-key --mnemonic "test test test test test test test test test test test junk" 2>/dev/null)
+    if [[ $? -ne 0 ]] || [[ -z "$private_key" ]]; then
+        echo "Error: Failed to derive private key from mnemonic."
+        exit 1
+    fi
+else
+    if [[ -z "$L1_PREALLOCATED_MNEMONIC" ]]; then
+        echo "Error: L1_PREALLOCATED_MNEMONIC environment variable is not set for non-default RPC."
+        exit 1
+    fi
+    private_key=$(cast wallet private-key --mnemonic "$L1_PREALLOCATED_MNEMONIC" 2>/dev/null)
+    if [[ $? -ne 0 ]] || [[ -z "$private_key" ]]; then
+        echo "Error: Failed to derive private key from mnemonic."
+        exit 1
+    fi
+fi
+
+# Validate addresses and fund them
 for address in "${addresses[@]}"; do
-    echo "Funding ${address}"
+    # Basic address validation (ensure it’s a valid Ethereum address)
+    if ! [[ "$address" =~ ^0x[a-fA-F0-9]{40}$ ]]; then
+        echo "Error: Invalid Ethereum address: $address"
+        continue
+    fi
+
+    echo "Funding $address with $L2_FUNDING_AMOUNT"
     cast send \
         --private-key "$private_key" \
-        --rpc-url "{{.l1_rpc_url}}" \
-        --value "{{.l2_funding_amount}}" \
-        "${address}"
+        --rpc-url "$RPC_URL" \
+        --value "$L2_FUNDING_AMOUNT" \
+        "$address" >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to fund $address"
+    else
+        echo "Successfully funded $address"
+    fi
 done
-


### PR DESCRIPTION
## Description

This PR refactors the `fund-addresses.sh` script:
- Add checks and errors for better debugging in case of errors
- Make the `fund-addresses.sh` script agnostic to addresses and rpc, and instead take these as arguments
- Fund all Kurtosis [default accounts](https://github.com/0xPolygon/kurtosis-cdk/blob/main/input_parser.star#L147-L184) on OP L2