### PR TITLE
fix: spammer scripts should never exit

### DIFF
--- a/static_files/additional_services/bridge-spammer/spam.sh
+++ b/static_files/additional_services/bridge-spammer/spam.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -uxo pipefail
 
 # This script simulates blockchain activity by perfoming L1 to L2 and L2 to L1 bridges.
+
+# Function to handle errors and continue execution.
+handle_error() {
+  echo "An error occurred. Continuing execution..."
+}
+trap handle_error ERR
 
 # Checking environment variables.
 if [[ -z "${PRIVATE_KEY}" ]]; then

--- a/static_files/additional_services/tx-spammer/spam.sh
+++ b/static_files/additional_services/tx-spammer/spam.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -uxo pipefail
 
 # This script simulates blockchain activity by sending transactions and making RPC calls.
+
+# Function to handle errors and continue execution.
+handle_error() {
+  echo "An error occurred. Continuing execution..."
+}
+trap handle_error ERR
 
 # Checking environment variables.
 if [[ -z "${PRIVATE_KEY}" ]]; then


### PR DESCRIPTION
We observed that the transaction and bridge spammer services occasionally exit unexpectedly in the Antithesis environment. These services should always run continuously, so this PR ensures the scripts handle errors gracefully without exiting, allowing them to continue execution seamlessly.

https://github.com/0xPolygon/kurtosis-cdk/issues/654