### PR TITLE
fix: use sequencer url in stuck batches status checks

### DIFF
--- a/lib/service.star
+++ b/lib/service.star
@@ -84,7 +84,7 @@ def get_sequencer_rpc_url(plan, args):
         constants.CONSENSUS_TYPE.rollup,
         constants.CONSENSUS_TYPE.cdk_validium,
     ]:
-        return
+        return ""
 
     sequencer_service = plan.get_service(
         args["sequencer_name"] + args["deployment_suffix"]

--- a/lib/service.star
+++ b/lib/service.star
@@ -1,4 +1,5 @@
 data_availability_package = import_module("./data_availability.star")
+constants = import_module("../src/package_io/constants.star")
 
 
 def get_contract_setup_addresses(plan, args, deployment_stages):
@@ -75,6 +76,24 @@ def get_l2_rpc_url(plan, args):
         plan.print("No ws rpc port found for service: '{}'".format(service.name))
 
     return struct(http=http_url, ws=ws_url)
+
+
+# Return the HTTP RPC URL of the sequencer or empty if it doesn't exist.
+def get_sequencer_rpc_url(plan, args):
+    if args.get("consensus_contract_type") not in [
+        constants.CONSENSUS_TYPE.rollup,
+        constants.CONSENSUS_TYPE.cdk_validium,
+    ]:
+        return
+
+    sequencer_service = plan.get_service(
+        args["sequencer_name"] + args["deployment_suffix"]
+    )
+    sequencer_rpc_url = "http://{}:{}".format(
+        sequencer_service.ip_address, sequencer_service.ports["rpc"].number
+    )
+
+    return sequencer_rpc_url
 
 
 def get_sovereign_contract_setup_addresses(plan, args):

--- a/src/additional_services/status_checker.star
+++ b/src/additional_services/status_checker.star
@@ -7,6 +7,11 @@ def run(plan, args):
         l2_rpc_service.ip_address, l2_rpc_service.ports["rpc"].number
     )
 
+    sequencer_service = plan.get_service(args["sequencer_name"] + args["deployment_suffix"])
+    sequencer_rpc_url = "http://{}:{}".format(
+        sequencer_service.ip_address, sequencer_service.ports["rpc"].number
+    )
+
     status_checker_config_artifact = plan.render_templates(
         name="status-checker-config",
         config={
@@ -50,6 +55,7 @@ def run(plan, args):
             env_vars={
                 "L1_RPC_URL": args.get("l1_rpc_url"),
                 "L2_RPC_URL": l2_rpc_url,
+                "SEQUENCER_RPC_URL": sequencer_rpc_url,
                 "CONSENSUS_CONTRACT_TYPE": args.get("consensus_contract_type"),
             },
         ),

--- a/src/additional_services/status_checker.star
+++ b/src/additional_services/status_checker.star
@@ -7,7 +7,9 @@ def run(plan, args):
         l2_rpc_service.ip_address, l2_rpc_service.ports["rpc"].number
     )
 
-    sequencer_service = plan.get_service(args["sequencer_name"] + args["deployment_suffix"])
+    sequencer_service = plan.get_service(
+        args["sequencer_name"] + args["deployment_suffix"]
+    )
     sequencer_rpc_url = "http://{}:{}".format(
         sequencer_service.ip_address, sequencer_service.ports["rpc"].number
     )

--- a/src/additional_services/status_checker.star
+++ b/src/additional_services/status_checker.star
@@ -1,18 +1,10 @@
 ports_package = import_module("../package_io/ports.star")
+service_package = import_module("../../lib/service.star")
 
 
 def run(plan, args):
-    l2_rpc_service = plan.get_service(args["l2_rpc_name"] + args["deployment_suffix"])
-    l2_rpc_url = "http://{}:{}".format(
-        l2_rpc_service.ip_address, l2_rpc_service.ports["rpc"].number
-    )
-
-    sequencer_service = plan.get_service(
-        args["sequencer_name"] + args["deployment_suffix"]
-    )
-    sequencer_rpc_url = "http://{}:{}".format(
-        sequencer_service.ip_address, sequencer_service.ports["rpc"].number
-    )
+    l2_rpc_url = service_package.get_l2_rpc_url(plan, args).http
+    sequencer_rpc_url = service_package.get_sequencer_rpc_url(plan, args)
 
     status_checker_config_artifact = plan.render_templates(
         name="status-checker-config",

--- a/static_files/additional_services/status-checker-config/checks/lib.sh
+++ b/static_files/additional_services/status-checker-config/checks/lib.sh
@@ -29,7 +29,7 @@ check_consensus() {
 # check_batch checks if a batch is stuck.
 check_batch() {
   local name="$1"             # e.g. "trusted", "verified", or "virtual"
-  local rpc_method="$2"       # e.g. "zkevm_batchNumber" or "zkevm_verifiedBatchNumber"
+  local rpc_method="$2"       # e.g. "zkevm_batchNumber", "zkevm_verifiedBatchNumber", or "zkevm_virtualBatchNumber"
   local threshold="${3:-12}"  # idle threshold (default: 12)
 
   local state_file="./$name.env"

--- a/static_files/additional_services/status-checker-config/checks/lib.sh
+++ b/static_files/additional_services/status-checker-config/checks/lib.sh
@@ -44,7 +44,8 @@ check_batch() {
   eval "${prev_batch_number}=\${${prev_batch_number}:-0}"
   eval "${prev_idle_counter}=\${${prev_idle_counter}:-0}"
 
-  local batch_number="$(cast to-dec "$(cast rpc --rpc-url "$SEQUENCER_RPC_URL" "$rpc_method" | sed 's/\"//g')")"
+  local batch_number
+  batch_number="$(cast to-dec "$(cast rpc --rpc-url "$SEQUENCER_RPC_URL" "$rpc_method" | sed 's/\"//g')")"
   echo "${name^} Batch Number: $batch_number"
 
   if (( batch_number > ${!prev_batch_number} )); then

--- a/static_files/additional_services/status-checker-config/checks/rpc-sequencer-sync.sh
+++ b/static_files/additional_services/status-checker-config/checks/rpc-sequencer-sync.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# shellcheck source=static_files/additional_services/status-checker-config/checks/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+check_consensus rollup cdk_validium
+
+threshold=5
+methods=("zkevm_batchNumber" "zkevm_verifiedBatchNumber" "zkevm_virtualBatchNumber")
+error=0
+
+for rpc_method in "${methods[@]}"; do
+  seq_bn=$(cast to-dec "$(cast rpc --rpc-url "$SEQUENCER_RPC_URL" "$rpc_method" | sed 's/\"//g')")
+  rpc_bn=$(cast to-dec "$(cast rpc --rpc-url "$L2_RPC_URL" "$rpc_method" | sed 's/\"//g')")
+
+  delta=$(( seq_bn > rpc_bn ? seq_bn - rpc_bn : rpc_bn - seq_bn ))
+  if (( delta > threshold )); then
+    echo "ERROR: $rpc_method is out of sync, sequencer=$seq_bn rpc=$rpc_bn"
+    error=1
+  fi
+done
+
+exit "$error"

--- a/static_files/additional_services/status-checker-config/checks/trusted.sh
+++ b/static_files/additional_services/status-checker-config/checks/trusted.sh
@@ -4,33 +4,4 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 check_consensus rollup cdk_validium
-
-state_file="./trusted.env"
-error=0
-
-# shellcheck source=/dev/null
-[[ -f "$state_file" ]] && source "$state_file"
-
-previous_trusted_bn="${previous_trusted_bn:-0}"
-previous_trusted_bn_idle_counter="${previous_trusted_bn_idle_counter:-0}"
-
-trusted_bn="$(cast to-dec "$(cast rpc --rpc-url "$L2_RPC_URL" zkevm_batchNumber | sed 's/\"//g')")"
-echo "[Trusted] Batch Number: ${trusted_bn}"
-
-if [[ "$trusted_bn" -gt "$previous_trusted_bn" ]]; then
-  previous_trusted_bn="$trusted_bn"
-  previous_trusted_bn_idle_counter=0
-else
-  previous_trusted_bn_idle_counter=$((previous_trusted_bn_idle_counter + 1))
-  if [[ "$previous_trusted_bn_idle_counter" -ge 12 ]]; then
-    echo "ERROR: Trusted batch number is stuck."
-    error=1
-  fi
-fi
-
-cat > "$state_file" <<EOF
-previous_trusted_bn=${previous_trusted_bn}
-previous_trusted_bn_idle_counter=${previous_trusted_bn_idle_counter}
-EOF
-
-exit $error
+check_batch trusted "zkevm_batchNumber"

--- a/static_files/additional_services/status-checker-config/checks/verified.sh
+++ b/static_files/additional_services/status-checker-config/checks/verified.sh
@@ -4,33 +4,4 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 check_consensus rollup cdk_validium
-
-state_file="./verified.env"
-error=0
-
-# shellcheck source=/dev/null
-[[ -f "$state_file" ]] && source "$state_file"
-
-previous_verified_bn="${previous_verified_bn:-0}"
-previous_verified_bn_idle_counter="${previous_verified_bn_idle_counter:-0}"
-
-verified_bn="$(cast to-dec "$(cast rpc --rpc-url "$L2_RPC_URL" zkevm_verifiedBatchNumber | sed 's/\"//g')")"
-echo "[Verified] Batch Number: ${verified_bn}"
-
-if [[ "$verified_bn" -gt "$previous_verified_bn" ]]; then
-  previous_verified_bn="$verified_bn"
-  previous_verified_bn_idle_counter=0
-else
-  previous_verified_bn_idle_counter=$((previous_verified_bn_idle_counter + 1))
-  if [[ "$previous_verified_bn_idle_counter" -ge 12 ]]; then
-    echo "ERROR: Verified batch number is stuck."
-    error=1
-  fi
-fi
-
-cat > "$state_file" <<EOF
-previous_verified_bn=${previous_verified_bn}
-previous_verified_bn_idle_counter=${previous_verified_bn_idle_counter}
-EOF
-
-exit $error
+check_batch verified "zkevm_verifiedBatchNumber"

--- a/static_files/additional_services/status-checker-config/checks/virtual.sh
+++ b/static_files/additional_services/status-checker-config/checks/virtual.sh
@@ -4,33 +4,4 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 check_consensus rollup cdk_validium
-
-state_file="./virtual.env"
-error=0
-
-# shellcheck source=/dev/null
-[[ -f "$state_file" ]] && source "$state_file"
-
-previous_virtual_bn="${previous_virtual_bn:-0}"
-previous_virtual_bn_idle_counter="${previous_virtual_bn_idle_counter:-0}"
-
-virtual_bn="$(cast to-dec "$(cast rpc --rpc-url "$L2_RPC_URL" zkevm_virtualBatchNumber | sed 's/\"//g')")"
-echo "[Virtual] Batch Number: ${virtual_bn}"
-
-if [[ "$virtual_bn" -gt "$previous_virtual_bn" ]]; then
-  previous_virtual_bn="$virtual_bn"
-  previous_virtual_bn_idle_counter=0
-else
-  previous_virtual_bn_idle_counter=$((previous_virtual_bn_idle_counter + 1))
-  if [[ "$previous_virtual_bn_idle_counter" -ge 12 ]]; then
-    echo "ERROR: Virtual batch number is stuck."
-    error=1
-  fi
-fi
-
-cat > "$state_file" <<EOF
-previous_virtual_bn=${previous_virtual_bn}
-previous_virtual_bn_idle_counter=${previous_virtual_bn_idle_counter}
-EOF
-
-exit $error
+check_batch virtual "zkevm_virtualBatchNumber"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->
- Uses the sequencer URL to ensure that batches are still being produced
- Adds an additional check to notify when the sequencer and rpc are out of sync

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
