### PR TITLE
ci: remove ignore paths

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,10 +2,6 @@ name: docs-build
 
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-      - docs/**
 
 permissions:
   contents: read

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,10 +2,7 @@ name: docs-deploy
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - docs/**
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/kurtosis-deploy.yml
+++ b/.github/workflows/kurtosis-deploy.yml
@@ -2,16 +2,8 @@ name: deploy
 
 on:
   pull_request:
-    paths-ignore:
-      - docs/**
-      - .github/workflows/docs-*.yaml
-
   push:
-    branches:
-      - main
-    paths-ignore:
-      - docs/**
-      - .github/workflows/docs-*.yaml
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/kurtosis-lint.yml
+++ b/.github/workflows/kurtosis-lint.yml
@@ -1,18 +1,9 @@
----
-name: Lint
+name: lint
 
 on:
   pull_request:
-    paths-ignore:
-      - docs/**
-      - .github/workflows/docs-*.yaml
-
   push:
-    branches:
-      - main
-    paths-ignore:
-      - docs/**
-      - .github/workflows/docs-*.yaml
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -1,5 +1,5 @@
----
-name: Security Build
+name: security-build
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Streamline the CI pipeline, particularly the `docs-deploy` workflow, as it seems some jobs are not triggered when pull requests are merged into the main branch. This results in GH uploading the artifact but only rendering the README, causing the documentation website to display differently than intended.