### PR TITLE
feat: disable op-propsoer+op-challenger in op-succinct

### DIFF
--- a/.github/tests/chains/op-succinct.yml
+++ b/.github/tests/chains/op-succinct.yml
@@ -29,5 +29,14 @@ args:
     - bridge_spammer
 
 optimism_package:
+  chains:
+    - proposer_params:
+        enabled: false
+      challenger_params:
+        enabled: false
+      network_params:
+        name: "001"
+        network_id: "2151908"
+        seconds_per_slot: 1
   observability:
     enabled: false


### PR DESCRIPTION
## Description

- This PR disables the native op-proposer and op-challenger components which are not needed when deploying op-succinct.
- Changes were made directly into the `.yml` files because runtime manipulation of these values are not possible 