### PR TITLE
fix: handle empty events string in status checks

### DIFF
--- a/static_files/additional_services/status-checker-config/checks/l1-info-tree/main.sh
+++ b/static_files/additional_services/status-checker-config/checks/l1-info-tree/main.sh
@@ -19,6 +19,10 @@ events=$(
     --json | jq -r '.[] | .topics[1]' | tail -n "$last_n_events"
 )
 
+if [[ -z "$events" ]]; then
+  exit 0
+fi
+
 # Iterate over the sequence batches events because sometimes the batch number is
 # greater than the virtual batch.
 while IFS= read -r hex; do

--- a/static_files/additional_services/status-checker-config/checks/l2-coinbase.sh
+++ b/static_files/additional_services/status-checker-config/checks/l2-coinbase.sh
@@ -17,6 +17,10 @@ events=$(
     --json | jq -r '.[] | .topics[1]' | tail -n "$last_n_events"
 )
 
+if [[ -z "$events" ]]; then
+  exit 0
+fi
+
 miner=$(cast block --rpc-url "$L2_RPC_URL" --json | jq -r '.miner')
 
 # Iterate over the sequence batches events because sometimes the batch number is

--- a/static_files/additional_services/status-checker-config/checks/sequence-timestamp.sh
+++ b/static_files/additional_services/status-checker-config/checks/sequence-timestamp.sh
@@ -17,6 +17,10 @@ events=$(
     --json | jq -r '.[] | .topics[1]' | tail -n "$last_n_events"
 )
 
+if [[ -z "$events" ]]; then
+  exit 0
+fi
+
 # Iterate over the sequence batches events because sometimes the batch number is
 # greater than the virtual batch.
 while IFS= read -r hex; do

--- a/static_files/additional_services/status-checker-config/config.yml
+++ b/static_files/additional_services/status-checker-config/config.yml
@@ -4,7 +4,7 @@
 enabled_by_default: true
 interval: 10s
 logs:
-  level: trace
+  level: warn
 checks_dir: /opt/status-checker/checks
 modify_permissions: true
 antithesis: true


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- Having no events in a status check causes it to error because it tries to request a batch from an empty string.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
