### PR TITLE
disable aggoracle component for fork12-cdk-erigon-sovereign

### DIFF
--- a/.github/tests/combinations/fork12-cdk-erigon-sovereign.yml
+++ b/.github/tests/combinations/fork12-cdk-erigon-sovereign.yml
@@ -14,5 +14,5 @@ args:
   gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
+  aggkit_components: aggsender,bridge
   sequencer_type: erigon
-  aggkit_components: aggsender

--- a/.github/tests/combinations/fork12-cdk-erigon-sovereign.yml
+++ b/.github/tests/combinations/fork12-cdk-erigon-sovereign.yml
@@ -15,3 +15,4 @@ args:
   zkevm_use_real_verifier: false
   enable_normalcy: true
   sequencer_type: erigon
+  aggkit_components: aggsender

--- a/.github/tests/consensus/sovereign.yml
+++ b/.github/tests/consensus/sovereign.yml
@@ -9,3 +9,4 @@ args:
   gas_token_enabled: false
   zkevm_use_real_verifier: false
   enable_normalcy: true
+  aggkit_components: aggsender,bridge

--- a/aggkit.star
+++ b/aggkit.star
@@ -144,7 +144,6 @@ def run(
     aggkit_configs = aggkit_package.create_aggkit_service_config(
         plan,
         args,
-        deployment_stages,
         aggkit_config_artifact,
         sovereign_genesis_artifact,
         keystore_artifacts,

--- a/lib/aggkit.star
+++ b/lib/aggkit.star
@@ -49,7 +49,6 @@ def create_aggkit_cdk_service_config(
 def create_aggkit_service_config(
     plan,
     args,
-    deployment_stages,
     config_artifact,
     genesis_artifact,
     keystore_artifact,
@@ -59,7 +58,7 @@ def create_aggkit_service_config(
 
     aggkit_name = "aggkit" + args["deployment_suffix"]
     (ports, public_ports) = get_aggkit_ports(args)
-    service_command = get_aggkit_cmd(args, deployment_stages)
+    service_command = get_aggkit_cmd(args)
     cdk_aggoracle_service_config = ServiceConfig(
         image=args["aggkit_image"],
         ports=ports,
@@ -111,23 +110,11 @@ def get_aggkit_ports(args):
     return (ports, public_ports)
 
 
-def get_aggkit_cmd(args, deployment_stages):
-    # If running CDK-Erigon-PP, do not run the aggoracle component.
-    if (
-        not deployment_stages.get("deploy_optimism_rollup", False)
-        and args["consensus_contract_type"] == constants.CONSENSUS_TYPE.pessimistic
-    ):
-        service_command = [
-            "cat /etc/aggkit/config.toml && sleep 20 && aggkit run "
-            + "--cfg=/etc/aggkit/config.toml "
-            + "--components="
-            + args.get("aggkit_components")
-        ]
-    else:
-        service_command = [
-            "cat /etc/aggkit/config.toml && sleep 20 && aggkit run "
-            + "--cfg=/etc/aggkit/config.toml "
-            + "--components="
-            + args.get("aggkit_components")
-        ]
+def get_aggkit_cmd(args):
+    service_command = [
+        "cat /etc/aggkit/config.toml && sleep 20 && aggkit run "
+        + "--cfg=/etc/aggkit/config.toml "
+        + "--components="
+        + args.get("aggkit_components")
+    ]
     return service_command

--- a/templates/aggkit/aggkit-config.toml
+++ b/templates/aggkit/aggkit-config.toml
@@ -9,28 +9,27 @@
 # setup. The values here should work, but are necessarily meant for
 # production environments. DYOR
 # The below configs are the default mandatory parameters to be used.
+# ==============================================================================
 
 PathRWData = "{{.zkevm_path_rw_data}}"
-L1URL="{{.l1_rpc_url}}"
+L1URL = "{{.l1_rpc_url}}"
 {{- if .deploy_optimism_rollup }}
-L2URL="{{.op_el_rpc_url}}"
+L2URL = "{{.op_el_rpc_url}}"
 {{- else }}
-L2URL="{{.l2_rpc_url}}"
+L2URL = "{{.l2_rpc_url}}"
 {{- end }}
 
 # Check if agglayer grpc or readrpc should be used for AggLayerURL
 {{- if eq .agglayer_endpoint "grpc" }}
-AggLayerURL="{{.agglayer_grpc_url}}"
+AggLayerURL = "{{.agglayer_grpc_url}}"
 {{- else }}
-AggLayerURL="{{.agglayer_readrpc_url}}"
+AggLayerURL = "{{.agglayer_readrpc_url}}"
 {{- end }}
 
-AggchainProofURL="{{.aggkit_prover_grpc_url_prefix}}{{.deployment_suffix}}:{{.aggkit_prover_grpc_port}}"
+AggchainProofURL= "{{.aggkit_prover_grpc_url_prefix}}{{.deployment_suffix}}:{{.aggkit_prover_grpc_port}}"
 
 NetworkID = {{.zkevm_rollup_id}}
 
-# This is the admin account for now
-L2Coinbase =  "{{.zkevm_l2_sequencer_address}}"
 {{- if or .deploy_optimism_rollup (eq .consensus_contract_type "pessimistic") }}
 SequencerPrivateKeyPath = "/etc/aggkit/sequencer.keystore"
 SequencerPrivateKeyPassword  = "{{.zkevm_l2_keystore_password}}"
@@ -195,9 +194,9 @@ Port = "{{.aggkit_node_rest_api_port}}"
 AggSenderPrivateKey = {Path = "/etc/aggkit/sequencer.keystore", Password = "{{.zkevm_l2_keystore_password}}"}
 
 {{- if eq .consensus_contract_type "pessimistic"}}
-Mode="PessimisticProof"
+Mode = "PessimisticProof"
 {{- else}}
-Mode="AggchainProof"
+Mode = "AggchainProof"
 {{- end}}
 CheckStatusCertificateInterval = "1s"
 
@@ -604,7 +603,7 @@ StoragePath = "{{.zkevm_path_rw_data}}/ethtxmanager-claimsponsor.sqlite"
 {{- if .deploy_optimism_rollup }}
 URL = "{{.op_el_rpc_url}}"
 {{- else }}
-URL="{{.l2_rpc_url}}"
+URL= "{{.l2_rpc_url}}"
 {{- end }}
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
- Disable `aggoracle` component for `pessimistic` consensus type
- format aggkit config and remove `L2Coinbase` parameter as it is unused
- cleanup `get_aggkit_cmd` in `aggkit.star`, as the branching was not necessary
