### PR TITLE
feat: remove bash as entrypoint for aggkit

### DIFF
--- a/lib/aggkit.star
+++ b/lib/aggkit.star
@@ -39,6 +39,7 @@ def create_aggkit_cdk_service_config(
                 artifact_names=[],
             ),
         },
+        entrypoint=["/usr/local/bin/aggkit"],
         cmd=service_command,
     )
 
@@ -77,6 +78,7 @@ def create_aggkit_service_config(
                 artifact_names=[],
             ),
         },
+        entrypoint=["/usr/local/bin/aggkit"],
         cmd=service_command,
     )
 


### PR DESCRIPTION
## Description
Remove bash wrapper for the `aggkit` startup, as we are removing the shell from the `aggkit` docker image.

## References (if applicable)
https://github.com/agglayer/aggkit/pull/675
