### PR TITLE
chore: remove `AggOracle.BlockFinality` field

### DIFF
--- a/templates/aggkit/aggkit-config.toml
+++ b/templates/aggkit/aggkit-config.toml
@@ -300,13 +300,6 @@ SaveCertificatesToFilesPath = "/tmp"
 # URLRPCL1 = "{{.l1_rpc_url}}"
 
 # ------------------------------------------------------------------------------
-# BlockFinality indicates which finality follows AggLayer accepted values are:
-# LatestBlock, SafeBlock, PendingBlock, FinalizedBlock, EarliestBlock
-# Default value is "FinalizedBlock"
-# ------------------------------------------------------------------------------
-BlockFinality = "FinalizedBlock"
-
-# ------------------------------------------------------------------------------
 # Duration expressed in units: [ns, us, ms, s, m, h, d]"
 # ------------------------------------------------------------------------------
 WaitPeriodNextGER = "10s"


### PR DESCRIPTION
## Description
Remove  `AggOracle.BlockFinality` field from the configuration, as it is deprecated.

## References (if applicable)
Related PR https://github.com/agglayer/aggkit/pull/720
