### PR TITLE
fix: e2e ci

### DIFF
--- a/.github/actions/kurtosis-pre-run/action.yml
+++ b/.github/actions/kurtosis-pre-run/action.yml
@@ -69,7 +69,9 @@ runs:
     - name: Add registry prefix to image names
       if: ${{ inputs.pull_images_from_gcr == 'true' }}
       shell: bash
-      run: python3 ${{ github.action_path }}/../../scripts/add-registry-prefix.py --registry-prefix "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/virtual"
+      run: |
+        script_path=$(realpath "${{ github.action_path }}/../../scripts/add-registry-prefix.py")
+        python3 "${script_path}" --registry-prefix "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/virtual"
 
     - uses: google-github-actions/auth@v2.0.0
       if: ${{ inputs.pull_images_from_gcr == 'true' }}


### PR DESCRIPTION
Resolve an issue preventing downstream repositories from locating the `add-registry-prefix.py` script

Example: https://github.com/agglayer/e2e/actions/runs/16782084785/job/47523656186

Related to https://github.com/agglayer/e2e/pull/124