### PR TITLE
feat: delete 0x prefix for sp1_prover_key

### DIFF
--- a/.github/tests/chains/op-succinct-real-prover.yml
+++ b/.github/tests/chains/op-succinct-real-prover.yml
@@ -6,7 +6,8 @@ deployment_stages:
 args:
   # Arbitrary key for the SP1 prover. This will not work if op_succinct_mock is set to false. Replace with a valid SPN key if you want to use the network provers.
   # cast wallet private-key --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
-  sp1_prover_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31" # XXX: Replace with an active key
+  # NOTE: for sp1 early version the network prover key not support '0x' prefix
+  sp1_prover_key: "bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31" # XXX: Replace with an active key
   # Valid values are: "network-prover", "mock-prover"
   agglayer_prover_primary_prover: "network-prover"
   # Valid values are: "network-prover", "mock-prover"

--- a/.github/tests/chains/op2.yml
+++ b/.github/tests/chains/op2.yml
@@ -14,7 +14,8 @@ args:
   op_cl_rpc_url: "http://op-cl-1-op-node-op-geth-002:8547"
   # Arbitrary key for the SP1 prover. Replace with a valid SPN key if you want to use the network provers.
   # cast wallet private-key --mnemonic "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
-  sp1_prover_key: "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
+  # NOTE: for sp1 early version the network prover key not support '0x' prefix
+  sp1_prover_key: "bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
   # Valid values are: "network-prover", "mock-prover"
   agglayer_prover_primary_prover: "mock-prover"
   # Valid values are: "network-prover", "mock-prover"


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

In versions prior to sp1 SDK v5.0.4, the sp1_prover_key could not include a '0x' prefix. This change removes the '0x' prefix from the example to ensure compatibility and successful execution of the full prover mode.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->

https://github.com/succinctlabs/sp1/commit/fdf70a42d56d2da7b37ccb832c742f21b054195c