### PR TITLE
docs: fix version matrix

### DIFF
--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -37,7 +37,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.4.0](https://github.com/agglayer/aggkit/releases/tag/v0.4.0) | experimental 🧪 |
+| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
@@ -67,7 +67,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.4.0](https://github.com/agglayer/aggkit/releases/tag/v0.4.0) | experimental 🧪 |
+| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
@@ -84,7 +84,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.4.0](https://github.com/agglayer/aggkit/releases/tag/v0.4.0) | experimental 🧪 |
+| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
@@ -99,7 +99,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.4.0](https://github.com/agglayer/aggkit/releases/tag/v0.4.0) | experimental 🧪 |
+| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |

--- a/scripts/version-matrix/extract-versions.py
+++ b/scripts/version-matrix/extract-versions.py
@@ -277,14 +277,18 @@ class VersionMatrixExtractor:
         # Check if version is greater than latest (e.g., pre-release)
         try:
             version_float = version_to_int(version)
+            version_suffix = version.split('-')[1] if '-' in version else ''
             latest_float = version_to_int(latest_version)
+            latest_suffix = latest_version.split('-')[1] if '-' in latest_version else ''
 
             if version_float > latest_float:
                 return "experimental"
             elif version_float < latest_float:
                 return "deprecated"
             else:
-                return "latest"
+                if version_suffix == latest_suffix:
+                    return "latest"
+                return "experimental"
 
         except Exception as e:
             print(f"Error determining status for version {version}: {e}")


### PR DESCRIPTION
When comparing current and latest versions, we only consider the major, minor, and patch numbers—suffixes like `-beta1` are ignored. This can be misleading, as our version matrix showed we were using the latest version of aggkit (`0.5.0-beta4`), when the actual latest release was `0.5.0`.