### PR TITLE
fix fund failed by `deployment_suffix`

### DIFF
--- a/deploy_sovereign_contracts.star
+++ b/deploy_sovereign_contracts.star
@@ -98,11 +98,12 @@ def fund_addresses(plan, args, contract_addresses, rpc_url):
         "ADDRESSES_TO_FUND": contract_addresses_to_fund,
         "RPC_URL": rpc_url,
         "L2_FUNDING_AMOUNT": args.get("l2_funding_amount", "0.1ether"),
+        "DEPLOYMENT_SUFFIX": args["deployment_suffix"],
     }
 
     # Only set L1_PREALLOCATED_MNEMONIC if provided and not using the default RPC
     if (
-        rpc_url != "http://op-el-1-op-geth-op-node-001:8545"
+        rpc_url != "http://op-el-1-op-geth-op-node" + args["deployment_suffix"] + ":8545"
         and "l1_preallocated_mnemonic" in args
     ):
         env_vars["L1_PREALLOCATED_MNEMONIC"] = args["l1_preallocated_mnemonic"]

--- a/deploy_sovereign_contracts.star
+++ b/deploy_sovereign_contracts.star
@@ -103,7 +103,8 @@ def fund_addresses(plan, args, contract_addresses, rpc_url):
 
     # Only set L1_PREALLOCATED_MNEMONIC if provided and not using the default RPC
     if (
-        rpc_url != "http://op-el-1-op-geth-op-node" + args["deployment_suffix"] + ":8545"
+        rpc_url
+        != "http://op-el-1-op-geth-op-node" + args["deployment_suffix"] + ":8545"
         and "l1_preallocated_mnemonic" in args
     ):
         env_vars["L1_PREALLOCATED_MNEMONIC"] = args["l1_preallocated_mnemonic"]

--- a/templates/contract-deploy/run-deploy-l1-agglayer-core-contracts.sh
+++ b/templates/contract-deploy/run-deploy-l1-agglayer-core-contracts.sh
@@ -146,7 +146,7 @@ fi
 
 # The sequencer needs to pay POL when it sequences batches.
 # This gets refunded when the batches are verified on L1.
-# In order for this to work t,he rollup address must be approved to transfer the sequencers' POL tokens.
+# In order for this to work the rollup address must be approved to transfer the sequencers' POL tokens.
 echo_ts "Minting POL token on L1 for the sequencer"
 cast send \
     --private-key "{{.zkevm_l2_sequencer_private_key}}" \

--- a/templates/sovereign-rollup/fund-addresses.sh
+++ b/templates/sovereign-rollup/fund-addresses.sh
@@ -19,7 +19,7 @@ if [[ -z "$L2_FUNDING_AMOUNT" ]]; then
     exit 1
 fi
 
-# The layer1 url when use local
+# The op l2 's rpc url
 EXPECT_URL="http://op-el-1-op-geth-op-node$DEPLOYMENT_SUFFIX:8545"
 
 # Set private key based on RPC_URL

--- a/templates/sovereign-rollup/fund-addresses.sh
+++ b/templates/sovereign-rollup/fund-addresses.sh
@@ -19,8 +19,11 @@ if [[ -z "$L2_FUNDING_AMOUNT" ]]; then
     exit 1
 fi
 
+# The layer1 url when use local
+EXPECT_URL="http://op-el-1-op-geth-op-node$DEPLOYMENT_SUFFIX:8545"
+
 # Set private key based on RPC_URL
-if [[ "$RPC_URL" == "http://op-el-1-op-geth-op-node-001:8545" ]]; then
+if [[ "$RPC_URL" == "$EXPECT_URL" ]]; then
     # Default optimism-package preallocated mnemonic
     if ! private_key=$(cast wallet private-key --mnemonic "test test test test test test test test test test test junk" 2>/dev/null) || [[ -z "$private_key" ]]; then
         echo "Error: Failed to derive private key from mnemonic."


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

When initializing the fund account, the system typically determines whether to use the test account or the specified mnemonic phrase based on the value of the `rpc_url` parameter:

```bash
# Set private key based on RPC_URL
if [[ "$RPC_URL" == "http://op-el-1-op-geth-op-node-001:8545" ]]; then
```

Note the op 's service will use `deployment_suffix` for it 's service name:

```yaml
            "network_params": {
                # name maps to l2_services_suffix in optimism. The optimism-package appends a suffix with the following format: -<name>
                # the "-" however adds another "-" to the Kurtosis deployment_suffix. So we are doing string manipulation to remove the "-"
                "name": DEFAULT_ARGS.get("deployment_suffix")[1:],
                "network_id": str(DEFAULT_ROLLUP_ARGS.get("zkevm_rollup_chain_id")),
                # The blocktime on the OP network
                "seconds_per_slot": 1,
                # Isthmus fork
                # Defaults to None - not activated - decimal value
                # Offset is in seconds
                "isthmus_time_offset": 0,
            },
``` 

And for all deploy code, the `deployment_suffix` should be eq to the op 's network_params 's `deployment_suffix`, if not eq, it will make a lots of errors.

However, when a custom `deployment_suffix` value is used for op 's network_params, the actual service name during deployment may change, which causes this judgment mechanism to fail. Therefore, we need to consider using the deployment_suffix value as the basis for this decision.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
