### PR TITLE
tests: handle missing github token from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,15 +110,33 @@ jobs:
       - name: Install dependencies
         run: pip install -r scripts/version-matrix/requirements.txt
 
+      - name: Detect fork and set token
+        id: detect-fork
+        run: |
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]] || [[ -z "${{ secrets.GH_TOKEN_READ }}" ]]; then
+            echo "use_token=false" >> $GITHUB_OUTPUT
+            echo "Running from fork or token unavailable - skipping GitHub API calls"
+          else
+            echo "use_token=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Generate version matrix
-        run: python scripts/version-matrix/extract-versions.py
+        run: |
+          if [[ "${{ steps.detect-fork.outputs.use_token }}" == "true" ]]; then
+            echo "Generating version matrix with GitHub API..."
+            python scripts/version-matrix/extract-versions.py
+          else
+            echo "Skipping version matrix generation due to missing GitHub token (fork or missing secret)"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_READ }}
 
       - name: Generate markdown documentation
+        if: ${{ steps.detect-fork.outputs.use_token == 'true' }}
         run: python scripts/version-matrix/generate-markdown.py
 
       - name: Check if there are changes
+        if: ${{ steps.detect-fork.outputs.use_token == 'true' }}
         run: |
           if [[ -n $(git status --porcelain) ]]; then
             echo "❌ Error: Version matrix is not up to date. Check the documentation at scripts/version-matrix to update it."

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -72,7 +72,7 @@ This section lists all test environments with their configurations and component
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | op-batcher | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | latest ✅ |
-| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.2) | deprecated ⚠️ |
+| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.5) | experimental 🧪 |
 | op-geth | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | latest ✅ |
 | op-node | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | N/A | N/A |
@@ -89,7 +89,7 @@ This section lists all test environments with their configurations and component
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | op-batcher | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | latest ✅ |
-| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.2) | deprecated ⚠️ |
+| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.5) | experimental 🧪 |
 | op-geth | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | latest ✅ |
 | op-node | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | latest ✅ |
 | op-succinct-proposer | [2.3.3-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v2.3.3-agglayer) | N/A | N/A |
@@ -108,7 +108,7 @@ This section lists all test environments with their configurations and component
 | geth | [1.16.2](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2) | [1.16.2](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2) | latest ✅ |
 | lighthouse | [7.1.0](https://github.com/sigp/lighthouse/releases/tag/v7.1.0) | [7.1.0](https://github.com/sigp/lighthouse/releases/tag/v7.1.0) | latest ✅ |
 | op-batcher | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | latest ✅ |
-| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.2) | deprecated ⚠️ |
+| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.5) | experimental 🧪 |
 | op-geth | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | latest ✅ |
 | op-node | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | N/A | N/A |


### PR DESCRIPTION
## Description

- When a PR is raised from a fork, the `Generate version matrix` step will fail because the fork will not have access to the `GITHUB_TOKEN` env variable which is required to run this step:

```
"Error: GITHUB_TOKEN environment variable is not set.
Please set it to access GitHub API for version information."
```

- This PR adds a check to see if the PR was raised from a fork, and if true, skip this check.
    - The downside of this approach is that it will require more strict reviews from the maintainers, especially to check if there is a change in the version matrix when a PR is coming from a fork. 