### PR TITLE
chore: bump cdk-erigon and op-batcher

### DIFF
--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -25,7 +25,7 @@ This section lists all test environments with their configurations and component
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
-| cdk-erigon | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | latest ✅ |
+| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | latest ✅ |
 | zkevm-bridge-service | [0.6.2-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.2-RC2) | [0.6.1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.1) | experimental 🧪 |
 | zkevm-pool-manager | [0.1.2](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.2) | N/A | N/A |
@@ -37,11 +37,11 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
+| aggkit | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | latest ✅ |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
-| cdk-erigon | [2.63.0-rc4](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.63.0-rc4) | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | experimental 🧪 |
+| cdk-erigon | [2.63.0-rc4](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.63.0-rc4) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | experimental 🧪 |
 | zkevm-bridge-service | [0.6.2-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.2-RC2) | [0.6.1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.1) | experimental 🧪 |
 | zkevm-pool-manager | [0.1.2](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.2) | N/A | N/A |
 
@@ -54,7 +54,7 @@ This section lists all test environments with their configurations and component
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
-| cdk-erigon | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | latest ✅ |
+| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | latest ✅ |
 | zkevm-bridge-service | [0.6.2-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.2-RC2) | [0.6.1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.1) | experimental 🧪 |
 | zkevm-da | [0.0.13](https://github.com/0xPolygon/cdk-data-availability/releases/tag/v0.0.13) | N/A | N/A |
@@ -67,12 +67,12 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
+| aggkit | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | latest ✅ |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
-| op-batcher | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | latest ✅ |
-| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.5) | experimental 🧪 |
+| op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
+| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.6](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.6) | experimental 🧪 |
 | op-geth | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | latest ✅ |
 | op-node | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | N/A | N/A |
@@ -84,12 +84,12 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
+| aggkit | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | latest ✅ |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
-| op-batcher | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | latest ✅ |
-| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.5) | experimental 🧪 |
+| op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
+| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.6](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.6) | experimental 🧪 |
 | op-geth | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | latest ✅ |
 | op-node | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | latest ✅ |
 | op-succinct-proposer | [2.3.3-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v2.3.3-agglayer) | N/A | N/A |
@@ -99,16 +99,16 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.5.0-beta4](https://github.com/agglayer/aggkit/releases/tag/v0.5.0-beta4) | [0.5.0](https://github.com/agglayer/aggkit/releases/tag/v0.5.0) | experimental 🧪 |
+| aggkit | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | [0.5.1](https://github.com/agglayer/aggkit/releases/tag/v0.5.1) | latest ✅ |
 | aggkit-prover | [1.2.0](https://github.com/agglayer/provers/releases/tag/v1.2.0) | [1.1.2](https://github.com/agglayer/provers/releases/tag/v1.1.2) | experimental 🧪 |
 | agglayer | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | latest ✅ |
 | agglayer-contracts | [11.0.0-rc.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.2) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
-| cdk-erigon | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | [2.61.23](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.23) | latest ✅ |
+| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | latest ✅ |
 | geth | [1.16.2](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2) | [1.16.2](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2) | latest ✅ |
 | lighthouse | [7.1.0](https://github.com/sigp/lighthouse/releases/tag/v7.1.0) | [7.1.0](https://github.com/sigp/lighthouse/releases/tag/v7.1.0) | latest ✅ |
-| op-batcher | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | [1.14.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.14.0) | latest ✅ |
-| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.5) | experimental 🧪 |
+| op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
+| op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.2.6](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.2.6) | experimental 🧪 |
 | op-geth | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | [1.101511.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101511.1) | latest ✅ |
 | op-node | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | [1.13.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.5) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | N/A | N/A |

--- a/input_parser.star
+++ b/input_parser.star
@@ -41,7 +41,7 @@ DEFAULT_DEPLOYMENT_STAGES = {
 }
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.5.0-beta4",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.5.1",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.2.0",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",

--- a/input_parser.star
+++ b/input_parser.star
@@ -41,7 +41,7 @@ DEFAULT_DEPLOYMENT_STAGES = {
 }
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.5.1",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.5.0-beta4",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.2.0",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",

--- a/input_parser.star
+++ b/input_parser.star
@@ -54,7 +54,7 @@ DEFAULT_IMAGES = {
     "geth_image": "ethereum/client-go:v1.16.2",
     "lighthouse_image": "sigp/lighthouse:v7.1.0",
     "mitm_image": "mitmproxy/mitmproxy:11.1.3",
-    "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.14.0",
+    "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.15.0",
     "op_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.4.0-rc.2",
     "op_geth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101511.1",
     "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5",

--- a/input_parser.star
+++ b/input_parser.star
@@ -46,7 +46,7 @@ DEFAULT_IMAGES = {
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.3.5",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12",
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.0.0",
-    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.23",
+    "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.24",
     "cdk_sovereign_erigon_node_image": "hermeznetwork/cdk-erigon:v2.63.0-rc4",  # Type-1 CDK Erigon Sovereign
     "cdk_node_image": "ghcr.io/0xpolygon/cdk:0.5.4",
     "cdk_validium_node_image": "ghcr.io/0xpolygon/cdk-validium-node:0.6.4-cdk.10",


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

- cdk-erigon: `v2.61.24`
- op-batcher: `v1.15.0`
