### PR TITLE
ci: avoid expanding secrets in run blocks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
             exit 0
           fi
 
-          if [[ -z "${{ secrets.GH_TOKEN_READ }}" ]]; then
+          if [[ -z "$GITHUB_TOKEN" ]]; then
             echo "No Github token provided. Skipping this job."
             echo "skip=true" >> $GITHUB_OUTPUT
             echo "::warning title=version-matrix::Version matrix job skipped."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
             exit 0
           fi
 
-          if [[ -z "${{ secrets.GH_TOKEN_READ }}" ]]; then
+          if [[ -z "$GITHUB_TOKEN" ]]; then
             echo "No Github token provided. Skipping this job."
             echo "skip=true" >> $GITHUB_OUTPUT
             echo "::warning title=version-matrix::Version matrix job skipped."


### PR DESCRIPTION
## Description

- Avoid expanding secrets in run blocks (sonarcloud rule) - use an env variable instead
- Log a warning in GH ui when the version matrix job is skipped

## References

https://sonarcloud.io/project/security_hotspots?id=0xPolygon_kurtosis-cdk&branch=main&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true