### PR TITLE
fix: Make aggoracle committee `/tmp` persistent key consistent with service naming

### DIFF
--- a/lib/aggkit.star
+++ b/lib/aggkit.star
@@ -206,7 +206,7 @@ def create_aggoracle_service_config(
             "/data": Directory(
                 artifact_names=[],
             ),
-            "/tmp": Directory(persistent_key="aggkit-tmp" + args["deployment_suffix"]),
+            "/tmp": Directory(persistent_key="aggkit-tmp" + args["deployment_suffix"] + "-aggoracle-committee-00" + str(member_index)),
         },
         entrypoint=["/usr/local/bin/aggkit"],
         cmd=service_command,


### PR DESCRIPTION
## Description

Make `/tmp` persistent key for aggoracle committee members to include committee suffix and member index.
Ensures proper storage isolation between committee members and consistent naming convention.


Issue: https://github.com/agglayer/aggkit/issues/1036