### PR TITLE
refactor: fork id parsing

### DIFF
--- a/.github/tests/op-geth/sovereign.yml
+++ b/.github/tests/op-geth/sovereign.yml
@@ -3,7 +3,7 @@ deployment_stages:
 
 args:
   aggkit_image: ghcr.io/agglayer/aggkit:0.5.4
-  agglayer_contracts_image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2-fork.12
+  agglayer_contracts_image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v11.0.0-rc.2
   consensus_contract_type: pessimistic
 
 optimism_package:

--- a/input_parser_test.star
+++ b/input_parser_test.star
@@ -1,0 +1,112 @@
+input_parser = import_module("./input_parser.star")
+
+
+def test_get_fork_id(plan):
+    tests = [
+        # rollup - supported forks
+        ["rollup", "agglayer-contracts:v1.0.0-fork.13", 13, "banana", None],
+        ["rollup", "agglayer-contracts:v1.0.0-fork.12", 12, "banana", None],
+        ["rollup", "agglayer-contracts:v1.0.0-fork.11", 11, "elderberry", None],
+        ["rollup", "agglayer-contracts:v1.0.0-fork.9", 9, "elderberry", None],
+        # rollup - unsupported forks should fail
+        [
+            "rollup",
+            "agglayer-contracts:v1.0.0-fork.8",
+            0,
+            "",
+            "not supported by Kurtosis CDK",
+        ],
+        [
+            "rollup",
+            "agglayer-contracts:v1.0.0-fork.14",
+            0,
+            "",
+            "not supported by Kurtosis CDK",
+        ],
+        # rollup - no fork specified should fail
+        ["rollup", "agglayer-contracts:v1.0.0", 0, "", "does not follow the standard"],
+        # cdk validium - supported forks
+        ["cdk_validium", "agglayer-contracts:v1.0.0-fork.13", 13, "banana", None],
+        ["cdk_validium", "agglayer-contracts:v1.0.0-fork.12", 12, "banana", None],
+        ["cdk_validium", "agglayer-contracts:v1.0.0-fork.11", 11, "elderberry", None],
+        ["cdk_validium", "agglayer-contracts:v1.0.0-fork.9", 9, "elderberry", None],
+        # cdk validium - unsupported forks should fail
+        [
+            "cdk_validium",
+            "agglayer-contracts:v1.0.0-fork.8",
+            0,
+            "",
+            "not supported by Kurtosis CDK",
+        ],
+        [
+            "cdk_validium",
+            "agglayer-contracts:v1.0.0-fork.14",
+            0,
+            "",
+            "not supported by Kurtosis CDK",
+        ],
+        # cdk validium - no fork specified should fail
+        [
+            "cdk_validium",
+            "agglayer-contracts:v1.0.0",
+            0,
+            "",
+            "does not follow the standard",
+        ],
+        # pessimistic - supported forks
+        ["pessimistic", "agglayer-contracts:v1.0.0-fork.13", 13, "banana", None],
+        ["pessimistic", "agglayer-contracts:v1.0.0-fork.12", 12, "banana", None],
+        ["pessimistic", "agglayer-contracts:v1.0.0-fork.11", 11, "elderberry", None],
+        ["pessimistic", "agglayer-contracts:v1.0.0-fork.9", 9, "elderberry", None],
+        # pessimistic - unsupported forks should fail
+        [
+            "pessimistic",
+            "agglayer-contracts:v1.0.0-fork.8",
+            0,
+            "",
+            "not supported by Kurtosis CDK",
+        ],
+        [
+            "pessimistic",
+            "agglayer-contracts:v1.0.0-fork.14",
+            0,
+            "",
+            "not supported by Kurtosis CDK",
+        ],
+        # cdk pessimistic - no fork specified should fail
+        [
+            "pessimistic",
+            "agglayer-contracts:v1.0.0",
+            0,
+            "",
+            "does not follow the standard",
+        ],
+        # ecdsa multisig
+        ["ecdsa_multisig", "agglayer-contracts:v1.0.0-fork.13", 0, "aggchain", None],
+        ["ecdsa_multisig", "agglayer-contracts:v1.0.0-fork.12", 0, "aggchain", None],
+        ["ecdsa_multisig", "agglayer-contracts:v1.0.0-fork.11", 0, "aggchain", None],
+        ["ecdsa_multisig", "agglayer-contracts:v1.0.0", 0, "aggchain", None],
+        # fep
+        ["fep", "agglayer-contracts:v1.0.0-fork.13", 0, "aggchain", None],
+        ["fep", "agglayer-contracts:v1.0.0-fork.12", 0, "aggchain", None],
+        ["fep", "agglayer-contracts:v1.0.0-fork.11", 0, "aggchain", None],
+        ["fep", "agglayer-contracts:v1.0.0", 0, "aggchain", None],
+    ]
+
+    for i, t in enumerate(tests):
+        [contract_type, image, expected_fork_id, expected_fork_name, expected_error] = (
+            t[0],
+            t[1],
+            t[2],
+            t[3],
+            t[4],
+        )
+        if expected_error:
+            expect.fails(
+                lambda: input_parser.get_fork_id(contract_type, image),
+                expected_error,
+            )
+        else:
+            (fork_id, fork_name) = input_parser.get_fork_id(contract_type, image)
+            expect.eq(fork_id, expected_fork_id)
+            expect.eq(fork_name, expected_fork_name)

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -56,7 +56,7 @@ DEFAULT_IMAGES = {
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0-beta6",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.4.1",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.12",
-    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v0.0.0-rc.3.aggchain.multisig-fork.0",  # https://github.com/agglayer/agglayer-contracts/compare/v12.1.0-rc.3...feature/initialize-tool-refactor
+    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v0.0.0-rc.3.aggchain.multisig",  # https://github.com/agglayer/agglayer-contracts/compare/v12.1.0-rc.3...feature/initialize-tool-refactor
     "agglogger_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglogger:bf1f8c1",
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.0.0",
     "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.24",

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -36,6 +36,13 @@ SEQUENCER_TYPE = struct(
     ZKEVM="zkevm",
 )
 
+FORK_ID_TO_NAME = {
+    9: "elderberry",
+    11: "elderberry",
+    12: "banana",
+    13: "banana",
+}
+
 TOOLBOX_IMAGE = (
     "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12"
 )


### PR DESCRIPTION
We no longer need to specify the fork id suffix in the agglayer contracts image tag when using aggchain ecdsa multisig or fep consensus types.