### PR TITLE
chore: update aggkit-prover

### DIFF
--- a/.github/tests/cdk-erigon/aggchain-ecdsa-multisig.yml
+++ b/.github/tests/cdk-erigon/aggchain-ecdsa-multisig.yml
@@ -17,7 +17,7 @@ args:
   aggkit_image: ghcr.io/agglayer/aggkit:0.7.0-beta8
 
   # Agglayer related params
-  agglayer_contracts_image: jhkimqd/agglayer-contracts:v0.0.0-rc.0.fix.1.create.genesis-fork.12
+  agglayer_contracts_image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.1.0
   agglayer_prover_primary_prover: mock-prover
   zkevm_use_real_verifier: false
   sp1_prover_key: ""

--- a/.github/tests/cdk-erigon/aggchain-ecdsa-multisig.yml
+++ b/.github/tests/cdk-erigon/aggchain-ecdsa-multisig.yml
@@ -14,7 +14,7 @@ args:
   # Aggkit related params
   binary_name: aggkit
   aggkit_components: aggsender
-  aggkit_image: ghcr.io/agglayer/aggkit:0.7.0-beta6
+  aggkit_image: ghcr.io/agglayer/aggkit:0.7.0-beta8
 
   # Agglayer related params
   agglayer_contracts_image: jhkimqd/agglayer-contracts:v0.0.0-rc.0.fix.1.create.genesis-fork.12

--- a/.github/tests/cdk-erigon/aggchain-ecdsa-multisig.yml
+++ b/.github/tests/cdk-erigon/aggchain-ecdsa-multisig.yml
@@ -17,7 +17,7 @@ args:
   aggkit_image: ghcr.io/agglayer/aggkit:0.7.0-beta8
 
   # Agglayer related params
-  agglayer_contracts_image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.1.0
+  agglayer_contracts_image: jhkimqd/agglayer-contracts:v0.0.0-rc.0.fix.1.create.genesis-fork.12
   agglayer_prover_primary_prover: mock-prover
   zkevm_use_real_verifier: false
   sp1_prover_key: ""

--- a/.github/tests/op-geth/aggchain-ecdsa-multisig.yml
+++ b/.github/tests/op-geth/aggchain-ecdsa-multisig.yml
@@ -3,7 +3,7 @@ deployment_stages:
   deploy_op_succinct: false
 
 args:
-  aggkit_image: "ghcr.io/agglayer/aggkit:0.7.0-beta6"  # https://github.com/agglayer/aggkit/tree/v0.7.0-beta6
+  aggkit_image: "ghcr.io/agglayer/aggkit:0.7.0-beta8"  # https://github.com/agglayer/aggkit/tree/v0.7.0-beta6
   
   # Agghcain ecdsa_multisig consensus.
   consensus_contract_type: ecdsa_multisig

--- a/.github/tests/op-succinct/mock-prover.yml
+++ b/.github/tests/op-succinct/mock-prover.yml
@@ -20,7 +20,7 @@ args:
     # Size of the range proof.
     op_succinct_range_proof_interval: "60"
 
-    aggkit_image: "ghcr.io/agglayer/aggkit:0.7.0-beta6"  # https://github.com/agglayer/aggkit/tree/v0.7.0-beta6
+    aggkit_image: "ghcr.io/agglayer/aggkit:0.7.0-beta8"  # https://github.com/agglayer/aggkit/tree/v0.7.0-beta6
     # OP Networks rely on L1 blocks to have finalization on L2. This means if the L1 blocktime is very fast, OP Succinct proof requests will have to bundle many L1 blocks into a single proof.
     # This will significantly increase cycles even if the L2 network is empty. Instead of having 2s, for OP Succinct deployments, we recommend 12s.
     # Note this will noticeably increase the deployment time because of the increased L1 finality.

--- a/.github/tests/op-succinct/real-prover.yml
+++ b/.github/tests/op-succinct/real-prover.yml
@@ -37,7 +37,7 @@ args:
   zkevm_rollup_id: 1
   # Size of the range proof.
   op_succinct_range_proof_interval: "1800"
-  aggkit_image: "ghcr.io/agglayer/aggkit:0.7.0-beta6"  # https://github.com/agglayer/aggkit/tree/v0.7.0-beta6
+  aggkit_image: "ghcr.io/agglayer/aggkit:0.7.0-beta8"  # https://github.com/agglayer/aggkit/tree/v0.7.0-beta6
   # OP Networks rely on L1 blocks to have finalization on L2. This means if the L1 blocktime is very fast, OP Succinct proof requests will have to bundle many L1 blocks into a single proof.
   # This will significantly increase cycles even if the L2 network is empty. Instead of having 2s, for OP Succinct deployments, we recommend 12s.
   # Note this will noticeably increase the deployment time because of the increased L1 finality.

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -87,7 +87,7 @@ This section lists all test environments with their configurations and component
 | aggkit | [0.7.0-beta8](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta8) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
 | aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
-| agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
+| agglayer-contracts | [12.1.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.1.0) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
 | op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.3.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.3.4) | experimental 🧪 |
 | op-geth | [1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3) | [1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3) | latest ✅ |
@@ -102,7 +102,7 @@ This section lists all test environments with their configurations and component
 | aggkit | [0.7.0-beta8](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta8) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
 | aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
-| agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
+| agglayer-contracts | [12.1.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.1.0) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | latest ✅ |
 | geth | [1.16.3](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.3) | [1.16.4](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.4) | deprecated ⚠️ |

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -23,7 +23,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | latest ✅ |
-| aggkit-prover | [1.4.1](https://github.com/agglayer/provers/releases/tag/v1.4.1) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.63.0-rc4](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.63.0-rc4) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | experimental 🧪 |
@@ -36,7 +36,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit-prover | [1.4.1](https://github.com/agglayer/provers/releases/tag/v1.4.1) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
@@ -52,7 +52,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit-prover | [1.4.1](https://github.com/agglayer/provers/releases/tag/v1.4.1) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
@@ -68,7 +68,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | latest ✅ |
-| aggkit-prover | [1.4.1](https://github.com/agglayer/provers/releases/tag/v1.4.1) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
@@ -85,7 +85,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.7.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta6) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
-| aggkit-prover | [1.4.1](https://github.com/agglayer/provers/releases/tag/v1.4.1) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
 | op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
@@ -100,7 +100,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.7.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta6) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
-| aggkit-prover | [1.4.1](https://github.com/agglayer/provers/releases/tag/v1.4.1) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -84,7 +84,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.7.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta6) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
+| aggkit | [0.7.0-beta8](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta8) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
 | aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
@@ -99,7 +99,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit | [0.7.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta6) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
+| aggkit | [0.7.0-beta8](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta8) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
 | aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -87,7 +87,7 @@ This section lists all test environments with their configurations and component
 | aggkit | [0.7.0-beta8](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta8) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
 | aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
-| agglayer-contracts | [12.1.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.1.0) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
+| agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
 | op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
 | op-deployer | [0.4.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.0-rc.2) | [0.3.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.3.4) | experimental 🧪 |
 | op-geth | [1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3) | [1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3) | latest ✅ |
@@ -102,7 +102,7 @@ This section lists all test environments with their configurations and component
 | aggkit | [0.7.0-beta8](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta8) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
 | aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
-| agglayer-contracts | [12.1.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.1.0) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
+| agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | latest ✅ |
 | geth | [1.16.3](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.3) | [1.16.4](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.4) | deprecated ⚠️ |

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -23,7 +23,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | latest ✅ |
-| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.63.0-rc4](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.63.0-rc4) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | experimental 🧪 |
@@ -36,7 +36,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
@@ -52,7 +52,7 @@ This section lists all test environments with their configurations and component
 
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
-| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |
@@ -68,7 +68,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | latest ✅ |
-| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [11.0.0-rc.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v11.0.0-rc.3) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | experimental 🧪 |
 | op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
@@ -85,7 +85,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.7.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta6) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
-| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
 | op-batcher | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | [1.15.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.15.0) | latest ✅ |
@@ -100,7 +100,7 @@ This section lists all test environments with their configurations and component
 | Component | Current Version | Latest Version | Status |
 |-----------|-----------------|----------------|--------|
 | aggkit | [0.7.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.7.0-beta6) | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | experimental 🧪 |
-| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.1.3](https://github.com/agglayer/provers/releases/tag/v1.1.3) | experimental 🧪 |
+| aggkit-prover | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | [1.4.2](https://github.com/agglayer/provers/releases/tag/v1.4.2) | latest ✅ |
 | agglayer | [0.4.0-rc.12](https://github.com/agglayer/agglayer/releases/tag/v0.4.0-rc.12) | [0.3.5](https://github.com/agglayer/agglayer/releases/tag/v0.3.5) | experimental 🧪 |
 | agglayer-contracts | [0.0.0-rc.3.aggchain.multisig](https://github.com/agglayer/agglayer-contracts/releases/tag/v0.0.0-rc.3.aggchain.multisig) | [9.0.0](https://github.com/agglayer/agglayer-contracts/releases/tag/v9.0.0) | deprecated ⚠️ |
 | cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | latest ✅ |

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -53,7 +53,7 @@ L1_ENGINES = ("geth", "anvil")
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0-beta6",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0-beta8",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.4.2",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.12",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v0.0.0-rc.3.aggchain.multisig",  # https://github.com/agglayer/agglayer-contracts/compare/v12.1.0-rc.3...feature/initialize-tool-refactor

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -54,7 +54,7 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 DEFAULT_IMAGES = {
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0-beta6",
-    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.4.1",
+    "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.4.2",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.12",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v0.0.0-rc.3.aggchain.multisig",  # https://github.com/agglayer/agglayer-contracts/compare/v12.1.0-rc.3...feature/initialize-tool-refactor
     "agglogger_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglogger:bf1f8c1",

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -56,7 +56,7 @@ DEFAULT_IMAGES = {
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0-beta8",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.4.2",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.12",
-    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v0.0.0-rc.3.aggchain.multisig",  # https://github.com/agglayer/agglayer-contracts/compare/v12.1.0-rc.3...feature/initialize-tool-refactor
+    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.1.0",  # https://github.com/agglayer/agglayer-contracts/tree/v12.1.0
     "agglogger_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglogger:bf1f8c1",
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.0.0",
     "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.24",

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -56,7 +56,7 @@ DEFAULT_IMAGES = {
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0-beta8",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.4.2",
     "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.12",
-    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.1.0",  # https://github.com/agglayer/agglayer-contracts/tree/v12.1.0
+    "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v0.0.0-rc.3.aggchain.multisig",  # https://github.com/agglayer/agglayer-contracts/compare/v12.1.0-rc.3...feature/initialize-tool-refactor
     "agglogger_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglogger:bf1f8c1",
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.0.0",
     "cdk_erigon_node_image": "hermeznetwork/cdk-erigon:v2.61.24",


### PR DESCRIPTION
## Description
Aggkit prover release [v1.4.2
](https://github.com/agglayer/provers/releases/tag/v1.4.2)
