### PR TITLE
fix: `aggsender validator` keystore dir

### DIFF
--- a/aggkit.star
+++ b/aggkit.star
@@ -394,7 +394,7 @@ def get_keystores_artifacts(plan, args):
             aggsender_validator_keystore = plan.store_service_files(
                 name="aggsendervalidator-{}-keystore".format(member_index),
                 service_name="contracts" + args["deployment_suffix"],
-                src=constants.OUTPUT_DIR
+                src=constants.KEYSTORES_DIR
                 + "/aggsendervalidator-{}.keystore".format(member_index),
             )
             aggsender_validator_keystores.append(aggsender_validator_keystore)


### PR DESCRIPTION
## Description
Fix the directory for the aggsender validator keystore, when using multisig committee (committee size=3, signatures quorum=2), which was recently changed through https://github.com/0xPolygon/kurtosis-cdk/pull/791.

### Kurtosis CDK Arguments
```json
{
  "deployment_stages": {
    "deploy_op_succinct": false
  },
  "args": {
    "consensus_contract_type": "ecdsa_multisig",
    "use_agg_sender_validator": true,
    "agg_sender_multisig_threshold": 2,
    "agg_sender_validator_total_number": 3,
    "l1_seconds_per_slot": 2,
    "verbosity": "debug",
    "aggkit_image": "aggkit:local", // this image comes from the CI
    "additional_services": [],
    "binary_name": "aggkit",
    "aggkit_components": "aggsender,aggoracle",
    "zkevm_rollup_chain_id": 20201,
    "zkevm_rollup_id": 1
  },
  "optimism_package": {
    "chains": [
      {
        "participants": [
          {
            "cl_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.13.5"
          }
        ],
        "proposer_params": {
          "enabled": false
        },
        "challenger_params": {
          "enabled": false
        },
        "network_params": {
          "name": "001",
          "network_id": "20201",
          "seconds_per_slot": 1
        }
      }
    ],
    "observability": {
      "enabled": false
    }
  }
}
```

### Log excerpt with error message
The output of the execution can be found [here](https://github.com/agglayer/aggkit/actions/runs/18462651441/job/52597697023)

```bash
There was an error executing Starlark code 
An error occurred executing instruction (number 139) at github.com/0xPolygon/kurtosis-cdk/aggkit.star[394:68]:
  store_service_files(service_name="contracts-001", src="/opt/output/aggsendervalidator-2.keystore", name="aggsendervalidator-2-keystore")
  Caused by: Failed to copy file '/opt/output/aggsendervalidator-2.keystore' from service 'contracts-001
  Caused by: There was an error in copying files over to disk
  Caused by: An error occurred gzip'ing and pushing tar'd file bytes to the pipe
  Caused by: An error occurred copying source '/opt/output/aggsendervalidator-2.keystore' from user service with UUID '4bc33573334044cd948c665b17ef2564' in enclave with UUID '5b96eef881914c98bf1c7bb9e6f0632c'
  Caused by: An error occurred copying files from sourcepath '/opt/output/aggsendervalidator-2.keystore' in user service with UUID '4bc33573334044cd948c665b17ef2564' in enclave with UUID '5b96eef881914c98bf1c7bb9e6f0632c'
  Caused by: An error occurred copying content from sourcepath '/opt/output/aggsendervalidator-2.keystore' in container '/contracts-001--4bc33573334044cd948c665b17ef2564' for user service '4bc33573334044cd948c665b17ef2564' in enclave '5b96eef881914c98bf1c7bb9e6f0632c'
  Caused by: an error occurred while verifying whether the file was a folder
  Caused by: request returned Not Found for API route and version http://%2Fvar%2Frun%2Fdocker.sock/v1.43/containers/301dc390a2dfba9e3400c4a2b54bc284502ea5e16a477d23027d73dcf0907118/archive?path=%2Fopt%2Foutput%2Faggsendervalidator-2.keystore, check if the server supports the requested API version
```