### PR TITLE
chore: clean up mount l1 genesis in op-succinct-proposer

### DIFF
--- a/deploy_agglayer_contracts.star
+++ b/deploy_agglayer_contracts.star
@@ -243,12 +243,6 @@ def run(plan, args, deployment_stages, op_stack_args):
             description="Create deploy_op_succinct_contract files artifact",
         )
 
-        # Get L1 genesis artifact for op-succinct
-        l1_genesis_artifact = plan.get_files_artifact(
-            name="l1-genesis-for-op-succinct",
-            description="Get L1 genesis file for op-succinct",
-        )
-
         # Mount op-succinct specific artifacts
         files["/opt/op-succinct/"] = Directory(
             artifact_names=[fetch_rollup_config_artifact]
@@ -256,7 +250,6 @@ def run(plan, args, deployment_stages, op_stack_args):
         files["/opt/scripts/"] = Directory(
             artifact_names=[deploy_op_succinct_contract_artifact]
         )
-        files["/configs/L1"] = Directory(artifact_names=[l1_genesis_artifact])
 
     # Create helper service to deploy contracts
     contracts_service_name = "contracts" + args["deployment_suffix"]

--- a/ethereum.star
+++ b/ethereum.star
@@ -116,59 +116,6 @@ def run(plan, args):
     cl_rpc_url = l1.all_participants[0].cl_context.beacon_http_url
     _wait_for_l1_startup(plan, cl_rpc_url)
 
-    # Store L1 genesis file for op-succinct by querying the L1 RPC
-    # The file will be named {chainId}.json
-    l1_chain_id = str(args.get("l1_chain_id", 271828))
-    plan.print(
-        "Creating L1 genesis file with chain ID: "
-        + l1_chain_id
-        + ", filename: "
-        + l1_chain_id
-        + ".json"
-    )
-
-    # Create genesis template with chain ID
-    genesis_template = """{{
-  "config": {{
-    "chainId": {chain_id},
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
-    "berlinBlock": 0,
-    "londonBlock": 0,
-    "arrowGlacierBlock": 0,
-    "grayGlacierBlock": 0,
-    "mergeNetsplitBlock": 0,
-    "shanghaiTime": 0,
-    "cancunTime": 0,
-    "pragueTime": 0
-  }},
-  "alloc": {{}}
-}}""".format(
-        chain_id=l1_chain_id
-    )
-
-    # Render the genesis file with the chain ID as filename
-    plan.render_templates(
-        name="l1-genesis-for-op-succinct",
-        config={
-            l1_chain_id
-            + ".json": struct(
-                template=genesis_template,
-                data={},
-            ),
-        },
-        description="Creating L1 genesis file at "
-        + l1_chain_id
-        + ".json for op-succinct",
-    )
-
 
 # Generate ethereum package public ports configuration.
 def generate_port_publisher_config(args):

--- a/input_parser.star
+++ b/input_parser.star
@@ -388,7 +388,7 @@ DEFAULT_ARGS = (
         "verbosity": "info",
         # The global log level that all components of the stack should log at.
         # Valid values are "error", "warn", "info", "debug", and "trace".
-        "global_log_level": "debug",
+        "global_log_level": "info",
         "aggkit_prover_log_level": "info",
         # The type of the sequencer to deploy.
         # Options:

--- a/lib/op_succinct.star
+++ b/lib/op_succinct.star
@@ -45,11 +45,9 @@ def create_op_succinct_proposer_service_config(
     }
 
     # Mount L1 genesis file if provided
-    # The op-succinct binary runs from /app working directory (see Dockerfile)
-    # It looks for configs/L1/{chainId}.json relative to working directory
     files = {}
     if l1_genesis_artifact:
-        files["/app/configs/L1"] = Directory(artifact_names=[l1_genesis_artifact])
+        files["/opt/l1"] = Directory(artifact_names=[l1_genesis_artifact])
 
     op_succinct_proposer_service_config = ServiceConfig(
         image=args["op_succinct_proposer_image"],

--- a/main.star
+++ b/main.star
@@ -100,19 +100,6 @@ def run(plan, args={}):
                 # Extract genesis to feed into evm-sketch-genesis
                 op_succinct_package.create_evm_sketch_genesis(plan, args)
 
-                # Verify L1 genesis file is available in contracts service
-                plan.exec(
-                    description="Verifying L1 genesis file in contracts service",
-                    service_name="contracts" + args["deployment_suffix"],
-                    recipe=ExecRecipe(
-                        command=[
-                            "/bin/sh",
-                            "-c",
-                            "echo '=== Checking L1 genesis file ===' && ls -la /configs/L1/ && echo '=== File contents ===' && cat /configs/L1/*.json && echo '=== Verification complete ==='",
-                        ]
-                    ),
-                )
-
                 # Run deploy-op-succinct-contracts.sh script in the contracts-001 service
                 plan.exec(
                     description="Deploying op-succinct contracts",

--- a/templates/op-succinct/deploy-op-succinct-contracts.sh
+++ b/templates/op-succinct/deploy-op-succinct-contracts.sh
@@ -96,15 +96,14 @@ cat .env
 # Save environment variables to .json file for Kurtosis ExecRecipe extract.
 # The extracted environment variables will be passed into the OP-Succinct components' environment variables.
 
-# Copy L1 genesis file from /configs/L1 to /opt/op-succinct/configs/L1
+# Copy L1 genesis file from /opt/l1 to /opt/op-succinct/configs/L1
 # The fetch-l2oo-config tool expects it at configs/L1/{chainId}.json relative to working directory
-mkdir -p /opt/op-succinct/configs/L1
-if [ -d "/configs/L1" ]; then
-    cp -r /configs/L1/* /opt/op-succinct/configs/L1/
-    echo "Copied L1 genesis files from /configs/L1 to /opt/op-succinct/configs/L1"
-    ls -la /opt/op-succinct/configs/L1/
+if [[ -d "/opt/l1" ]]; then
+    mkdir -p /opt/op-succinct/configs/L1
+    cp -r /opt/l1/*.json /opt/op-succinct/configs/L1/
 else
-    echo "Warning: /configs/L1 directory not found"
+    echo "/opt/l1 directory not found"
+    exit 1
 fi
 
 # Run fetch-l2oo-config to get the various configuration values that


### PR DESCRIPTION
- Reuse the L1 genesis file (and rename the file to match the L1 chain id)
- Revert global log level to "info"