### PR TITLE
chore: bump agglayer to 0.4.2

### DIFF
--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -68,7 +68,7 @@ DEFAULT_IMAGES = {
     "aggkit_image": "ghcr.io/agglayer/aggkit:0.7.0",
     "aggkit_sovereign_image": "ghcr.io/agglayer/aggkit:0.5.4",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.7.0",
-    "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.0-rc.21",
+    "agglayer_image": "ghcr.io/agglayer/agglayer:0.4.2",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.1.5-fork.0",
     "agglogger_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglogger:bf1f8c1",
     "anvil_image": "ghcr.io/foundry-rs/foundry:v1.4.3",


### PR DESCRIPTION
Bump agglayer to the latest release.