### PR TITLE
feat: bump op-node to `1.16.3`

### DIFF
--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -40,7 +40,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 | op-batcher | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | latest ✅ |
 | op-deployer | [0.4.5-cdk](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.5-cdk) | [0.5.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.5.0-rc.2) | deprecated ⚠️ |
 | op-geth | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | latest ✅ |
-| op-node | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | latest ✅ |
+| op-node | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | latest ✅ |
 | zkevm-bridge-service | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | latest ✅ |
 
@@ -57,7 +57,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 | op-batcher | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | latest ✅ |
 | op-deployer | [0.4.5-cdk](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.5-cdk) | [0.5.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.5.0-rc.2) | deprecated ⚠️ |
 | op-geth | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | latest ✅ |
-| op-node | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | latest ✅ |
+| op-node | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | latest ✅ |
 | zkevm-bridge-service | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | latest ✅ |
 
@@ -74,7 +74,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 | op-batcher | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | latest ✅ |
 | op-deployer | [0.4.5-cdk](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.5-cdk) | [0.5.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.5.0-rc.2) | deprecated ⚠️ |
 | op-geth | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | latest ✅ |
-| op-node | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | latest ✅ |
+| op-node | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | latest ✅ |
 | op-succinct-proposer | [3.4.0-rc.1-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.4.0-rc.1-agglayer) | [3.4.0-rc.1](https://github.com/agglayer/op-succinct/releases/tag/v3.4.0-rc.1) | latest ✅ |
 | zkevm-bridge-service | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | latest ✅ |
 
@@ -156,7 +156,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 | op-batcher | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.2) | latest ✅ |
 | op-deployer | [0.4.5-cdk](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.4.5-cdk) | [0.5.0-rc.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.5.0-rc.2) | deprecated ⚠️ |
 | op-geth | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | [1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5) | latest ✅ |
-| op-node | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | [1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2) | latest ✅ |
+| op-node | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3) | latest ✅ |
 | op-proposer | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | [1.10.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.10.0) | latest ✅ |
 | op-succinct-proposer | [3.4.0-rc.1-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.4.0-rc.1-agglayer) | [3.4.0-rc.1](https://github.com/agglayer/op-succinct/releases/tag/v3.4.0-rc.1) | latest ✅ |
 | zkevm-bridge-service | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | [0.6.3-RC7](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3-RC7) | latest ✅ |

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -82,7 +82,7 @@ DEFAULT_IMAGES = {
     "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.2",
     "op_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.4.5-cdk",
     "op_geth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.5",
-    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.2",
+    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.3",
     "op_proposer_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.10.0",
     "op_succinct_proposer_image": "ghcr.io/agglayer/op-succinct/op-succinct-agglayer:v3.4.0-rc.1-agglayer",
     "status_checker_image": "ghcr.io/0xpolygon/status-checker:v0.2.8",


### PR DESCRIPTION
New op-node release: https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.16.3