### PR TITLE
chore: bump aggkit to `0.8.0-beta6`

### DIFF
--- a/docs/docs/_legacy_docs/data-availability-modes.md
+++ b/docs/docs/_legacy_docs/data-availability-modes.md
@@ -12,4 +12,4 @@ The two options are:
 
 > In this mode, the components will run CDK in `validium` mode, the consensus contract will be `PolygonValidiumEtrog` and the CDK DAC will be deployed and configured.
 
-For more detailed information and technical specifications, refer to the [Polygon Knowledge Layer](https://docs.polygon.technology/cdk/spec/validium-vs-rollup/).
+For more detailed information and technical specifications, refer to the [Polygon Docs](https://docs.polygon.technology/).

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -33,7 +33,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.8.0-beta5](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta5) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
+| aggkit | [0.8.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta6) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | ✅ matches stable |
 | op-batcher | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.3) | ✅ matches stable |
@@ -65,7 +65,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.8.0-beta5](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta5) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
+| aggkit | [0.8.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta6) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
 | aggkit-prover | [1.9.1](https://github.com/agglayer/provers/releases/tag/v1.9.1) | [1.8.0](https://github.com/agglayer/provers/releases/tag/v1.8.0) | ⚡️ newer than stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | ✅ matches stable |
@@ -86,10 +86,10 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.8.0-beta5](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta5) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
+| aggkit | [0.8.0-beta6](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta6) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | ✅ matches stable |
-| cdk-erigon | [2.65.0-RC1](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.65.0-RC1) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | ⚡️ newer than stable |
+| cdk-erigon | [2.65.0-RC1](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.65.0-RC1) | [2.64.0](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.64.0) | ⚡️ newer than stable |
 | zkevm-bridge-service | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | ✅ matches stable |
 | zkevm-pool-manager | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | ✅ matches stable |
 
@@ -102,7 +102,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 | aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | 🚨 behind stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | ✅ matches stable |
-| cdk-erigon | [2.65.0-RC1](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.65.0-RC1) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | ⚡️ newer than stable |
+| cdk-erigon | [2.65.0-RC1](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.65.0-RC1) | [2.64.0](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.64.0) | ⚡️ newer than stable |
 | zkevm-bridge-service | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | ✅ matches stable |
 | zkevm-pool-manager | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | ✅ matches stable |
 
@@ -115,7 +115,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | ✅ matches stable |
 | cdk-data-availability | [0.0.13](https://github.com/0xPolygon/cdk-data-availability/releases/tag/v0.0.13) | [0.0.13](https://github.com/0xPolygon/cdk-data-availability/releases/tag/v0.0.13) | ✅ matches stable |
-| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | ✅ matches stable |
+| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.64.0](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.64.0) | 🚨 behind stable |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | ✅ matches stable |
 | zkevm-bridge-service | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | ✅ matches stable |
 | zkevm-pool-manager | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | ✅ matches stable |
@@ -129,7 +129,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 |-----------|-------------------------------|-----------------------|--------|
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | [12.2.1](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.1) | ✅ matches stable |
-| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | ✅ matches stable |
+| cdk-erigon | [2.61.24](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.61.24) | [2.64.0](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.64.0) | 🚨 behind stable |
 | cdk-node | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | [0.5.4](https://github.com/0xPolygon/cdk/releases/tag/v0.5.4) | ✅ matches stable |
 | zkevm-bridge-service | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | [0.6.4-RC1](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC1) | ✅ matches stable |
 | zkevm-pool-manager | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | [0.1.3](https://github.com/0xPolygon/zkevm-pool-manager/releases/tag/v0.1.3) | ✅ matches stable |

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -85,7 +85,7 @@ INPUT_DIR = "/opt/input"
 SCRIPTS_DIR = "/opt/scripts"
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.8.0-beta5",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.8.0-beta6",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.9.1",
     "agglayer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer:0.4.4-remove-agglayer-prover",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.2.1",


### PR DESCRIPTION
New release: https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta6
