### PR TITLE
chore: update aggkit to `0.8.0`

### DIFF
--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -33,7 +33,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.8.0-beta7](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta7) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
+| aggkit | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | ✅ matches stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | ✅ matches stable |
 | op-batcher | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.3) | ✅ matches stable |
@@ -49,7 +49,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | 🚨 behind stable |
+| aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | 🚨 behind stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | ✅ matches stable |
 | op-batcher | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.3) | ✅ matches stable |
@@ -65,7 +65,7 @@ Environments using [op-geth](https://github.com/ethereum-optimism/optimism) as t
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.8.0-beta7](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta7) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
+| aggkit | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | ✅ matches stable |
 | aggkit-prover | [1.9.1](https://github.com/agglayer/provers/releases/tag/v1.9.1) | [1.8.0](https://github.com/agglayer/provers/releases/tag/v1.8.0) | ⚡️ newer than stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | ✅ matches stable |
@@ -86,7 +86,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.8.0-beta7](https://github.com/agglayer/aggkit/releases/tag/v0.8.0-beta7) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | ⚡️ newer than stable |
+| aggkit | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | ✅ matches stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | ✅ matches stable |
 | cdk-erigon | [2.65.0-RC1](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.65.0-RC1) | [2.64.2](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.64.2) | ⚡️ newer than stable |
@@ -99,7 +99,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
-| aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.7.2](https://github.com/agglayer/aggkit/releases/tag/v0.7.2) | 🚨 behind stable |
+| aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.8.0](https://github.com/agglayer/aggkit/releases/tag/v0.8.0) | 🚨 behind stable |
 | agglayer | [0.4.4-remove-agglayer-prover](https://github.com/agglayer/agglayer/tree/38ffe04e71bb6b0eb22a244dbd40d189e1b0d78f) | [0.4.4](https://github.com/agglayer/agglayer/releases/tag/v0.4.4) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | [12.2.2](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.2) | ✅ matches stable |
 | cdk-erigon | [2.65.0-RC1](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.65.0-RC1) | [2.64.2](https://github.com/0xPolygon/cdk-erigon/releases/tag/v2.64.2) | ⚡️ newer than stable |

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -86,7 +86,7 @@ INPUT_DIR = "/opt/input"
 SCRIPTS_DIR = "/opt/scripts"
 
 DEFAULT_IMAGES = {
-    "aggkit_image": "ghcr.io/agglayer/aggkit:0.8.0-beta7",
+    "aggkit_image": "ghcr.io/agglayer/aggkit:0.8.0",
     "aggkit_prover_image": "ghcr.io/agglayer/aggkit-prover:1.9.1",
     "agglayer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer:0.4.4-remove-agglayer-prover",
     "agglayer_contracts_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/agglayer-contracts:v12.2.2",


### PR DESCRIPTION
New release: https://github.com/agglayer/aggkit/releases/tag/v0.8.0