### PR TITLE
chore: bump op-node to `v1.16.9`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@
 Preferred-Languages: en
 
 ## Security-related job openings at Polygon.
-https://polygon.technology/careers
+https://jobs.ashbyhq.com/polygon-labs/
 
 ## Polygon security contact details.
 security@polygon.technology

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -38,9 +38,9 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | agglayer-contracts | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | ✅ matches stable |
 | op-batcher | [1.16.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.5) | [1.16.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.5) | ✅ matches stable |
 | op-deployer | [0.6.0-rc.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.6.0-rc.3) | [0.6.0-rc.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.6.0-rc.3) | ✅ matches stable |
-| op-node | [1.16.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.8) | [1.16.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.8) | ✅ matches stable |
+| op-node | [1.16.9](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9) | [1.16.9](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9) | ✅ matches stable |
 | op-proposer | [1.16.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.1) | [1.16.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.1) | ✅ matches stable |
-| op-reth | [1.11.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.0) | [1.11.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.0) | ✅ matches stable |
+| op-reth | [1.11.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.3) | [1.11.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.3) | ✅ matches stable |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | ✅ matches stable |
 
 ### cdk-opreth-sovereign-pessimistic
@@ -54,9 +54,9 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | agglayer-contracts | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | ✅ matches stable |
 | op-batcher | [1.16.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.5) | [1.16.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.5) | ✅ matches stable |
 | op-deployer | [0.6.0-rc.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.6.0-rc.3) | [0.6.0-rc.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.6.0-rc.3) | ✅ matches stable |
-| op-node | [1.16.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.8) | [1.16.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.8) | ✅ matches stable |
+| op-node | [1.16.9](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9) | [1.16.9](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9) | ✅ matches stable |
 | op-proposer | [1.16.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.1) | [1.16.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.1) | ✅ matches stable |
-| op-reth | [1.11.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.0) | [1.11.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.0) | ✅ matches stable |
+| op-reth | [1.11.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.3) | [1.11.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.3) | ✅ matches stable |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | ✅ matches stable |
 
 ### cdk-opreth-zkrollup
@@ -71,8 +71,8 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | agglayer-contracts | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | ✅ matches stable |
 | op-batcher | [1.16.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.5) | [1.16.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.5) | ✅ matches stable |
 | op-deployer | [0.6.0-rc.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.6.0-rc.3) | [0.6.0-rc.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.6.0-rc.3) | ✅ matches stable |
-| op-node | [1.16.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.8) | [1.16.8](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.8) | ✅ matches stable |
-| op-reth | [1.11.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.0) | [1.11.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.0) | ✅ matches stable |
+| op-node | [1.16.9](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9) | [1.16.9](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9) | ✅ matches stable |
+| op-reth | [1.11.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.3) | [1.11.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v1.11.3) | ✅ matches stable |
 | op-succinct-proposer | [3.5.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.5.0-agglayer) | [3.5.0-rc.1-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.5.0-rc.1-agglayer) | ⚡️ newer than stable |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | ✅ matches stable |
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -117,7 +117,7 @@ DEFAULT_IMAGES = {
     "mitm_image": "mitmproxy/mitmproxy:11.1.3",
     "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.5",
     "op_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.6.0-rc.3-cdk",
-    "op_reth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v1.11.0",
+    "op_reth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v1.11.3",
     "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.9",
     "op_proposer_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.16.1",
     "op_succinct_proposer_image": "ghcr.io/agglayer/op-succinct/op-succinct-agglayer:v3.5.0-agglayer",

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -118,7 +118,7 @@ DEFAULT_IMAGES = {
     "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.5",
     "op_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.6.0-rc.3-cdk",
     "op_reth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v1.11.0",
-    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.8",
+    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.9",
     "op_proposer_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.16.1",
     "op_succinct_proposer_image": "ghcr.io/agglayer/op-succinct/op-succinct-agglayer:v3.5.0-agglayer",
     "status_checker_image": "ghcr.io/0xpolygon/status-checker:v0.2.8",


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.9