### PR TITLE
fix(ci): pin agglayer to 0.6.0-rc.5 in remaining cdk-node fixtures

### DIFF
--- a/.github/tests/nightly/gas-token/pre-deployed.yml
+++ b/.github/tests/nightly/gas-token/pre-deployed.yml
@@ -10,3 +10,9 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   consensus_contract_type: cdk-validium
   sequencer_type: cdk-erigon
+  # Pinned: this setup settles proofs through cdk-node, whose only settlement path is
+  # `interop_sendTx` (SettlementBackend = "agglayer"). agglayer v0.6.0-rc.6 disabled that
+  # method (returns -10009), so the aggregator can no longer settle and no batch ever gets
+  # verified. Unpin once cdk-node supports the certificate-based settlement flow.
+  # See https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.6
+  agglayer_image: ghcr.io/agglayer/agglayer:0.6.0-rc.5

--- a/.github/tests/other/anvil/anvil-rollup.yml
+++ b/.github/tests/other/anvil/anvil-rollup.yml
@@ -1,3 +1,9 @@
 args:
   l1_engine: anvil
   consensus_contract_type: rollup
+  # Pinned: this setup settles proofs through cdk-node, whose only settlement path is
+  # `interop_sendTx` (SettlementBackend = "agglayer"). agglayer v0.6.0-rc.6 disabled that
+  # method (returns -10009), so the aggregator can no longer settle and no batch ever gets
+  # verified. Unpin once cdk-node supports the certificate-based settlement flow.
+  # See https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.6
+  agglayer_image: ghcr.io/agglayer/agglayer:0.6.0-rc.5

--- a/.github/tests/other/gas-token/auto.yml
+++ b/.github/tests/other/gas-token/auto.yml
@@ -6,3 +6,9 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   consensus_contract_type: cdk-validium
   sequencer_type: cdk-erigon
+  # Pinned: this setup settles proofs through cdk-node, whose only settlement path is
+  # `interop_sendTx` (SettlementBackend = "agglayer"). agglayer v0.6.0-rc.6 disabled that
+  # method (returns -10009), so the aggregator can no longer settle and no batch ever gets
+  # verified. Unpin once cdk-node supports the certificate-based settlement flow.
+  # See https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.6
+  agglayer_image: ghcr.io/agglayer/agglayer:0.6.0-rc.5

--- a/.github/tests/other/gas-token/pre-deployed.yml
+++ b/.github/tests/other/gas-token/pre-deployed.yml
@@ -10,3 +10,9 @@ args:
   zkevm_prover_image: hermeznetwork/zkevm-prover:v8.0.0-RC16-fork.12
   consensus_contract_type: cdk-validium
   sequencer_type: cdk-erigon
+  # Pinned: this setup settles proofs through cdk-node, whose only settlement path is
+  # `interop_sendTx` (SettlementBackend = "agglayer"). agglayer v0.6.0-rc.6 disabled that
+  # method (returns -10009), so the aggregator can no longer settle and no batch ever gets
+  # verified. Unpin once cdk-node supports the certificate-based settlement flow.
+  # See https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.6
+  agglayer_image: ghcr.io/agglayer/agglayer:0.6.0-rc.5


### PR DESCRIPTION
## Description

The nightly `run-with-pre-deployed-gas-token` job fails to verify batches since #930 bumped the default agglayer image to `0.6.0-rc.8`.

**Root cause:** agglayer `0.6.0-rc.6+` removed `interop_sendTx` ([agglayer#1637](https://github.com/agglayer/agglayer/pull/1637), returns `-10009`), which is cdk-node's Aggregator's only settlement path. Any fixture with `consensus_contract_type: rollup`/`cdk-validium` therefore never settles, and `monitor.sh` times out waiting for verified batches.

#930 already pinned `.github/tests/cdk-erigon/rollup.yml` and `validium.yml` to `0.6.0-rc.5`; this PR extends the same pin (with the same evidence comment) to the fixtures that were missed:

- `.github/tests/nightly/gas-token/pre-deployed.yml` (the failing nightly env)
- `.github/tests/other/gas-token/pre-deployed.yml`
- `.github/tests/other/gas-token/auto.yml`
- `.github/tests/other/anvil/anvil-rollup.yml`

Sovereign fixtures (`pessimistic`, `ecdsa-multisig`) and the `constants.star` default stay on `rc.8` — the certificate-based settlement flow is unaffected. The pins can be removed once cdk-node supports certificate-based settlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)