### PR TITLE
chore: bump lighthouse and align nightly Slack summary with kurtosis-pos

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true  # prevent this job from failing the workflow
+    outputs:
+      # `continue-on-error` reports the job as successful, so the drift verdict
+      # has to travel to the summary as an output rather than a job result.
+      # Empty when the job was skipped (fork / no token) or an earlier step
+      # failed before the comparison ran — the summary treats that as "unknown"
+      # rather than as "up to date".
+      outdated: ${{ steps.version-check.outputs.outdated }}
     steps:
       - uses: actions/checkout@v4
 
@@ -87,33 +94,7 @@ jobs:
           fi
           echo "HAS_DIFF=${has_diff}" >> $GITHUB_ENV
           echo "HAS_DIFF=${has_diff}"
-
-      - uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        if: ${{ steps.check-run.outputs.skip == 'false' }}
-        with:
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          method: chat.postMessage
-          payload: |
-            {
-              "channel": ${{ env.DEVTOOLS_SLACK_ALERTS_CHANNEL_ID }},
-              "text": "Kurtosis CDK Nightly - Version matrix check",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Kurtosis CDK Nightly>: version matrix is ${{ env.HAS_DIFF == 'true' && 'outdated ❌' || 'up to date ✅' }}"
-                  }
-                }${{ env.HAS_DIFF == 'true' && ',
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Check the documentation at `scripts/version-matrix` to update it"
-                  }
-                }' || '' }}
-              ]
-            }
+          echo "outdated=${has_diff}" >> $GITHUB_OUTPUT
 
       - name: Display check result
         if: ${{ steps.check-run.outputs.skip == 'false' }}
@@ -811,6 +792,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && github.event_name == 'schedule' }}
     needs:
+      - check-version-matrix
       - run-without-args
       - run-with-args
       - run-with-op-succinct
@@ -832,7 +814,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Kurtosis CDK Nightly>: ${{ contains(needs.*.result, 'failure') && 'some tests failed ❌' || (contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) && 'some tests were skipped ⚠️' || 'all tests passed ✅' }}",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Kurtosis CDK Nightly>: ${{ contains(needs.*.result, 'failure') && 'some tests failed ❌' || (contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')) && 'some tests were skipped ⚠️' || 'all tests passed ✅' }} | version matrix is ${{ needs.check-version-matrix.outputs.outdated == 'true' && 'outdated ❌, check the documentation at `scripts/version-matrix` to update it' || needs.check-version-matrix.outputs.outdated == 'false' && 'up to date ✅' || 'unknown ⚠️, the check failed before it could compare the matrix' }}"
                   }
                 }
               ]

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -79,7 +79,7 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | op-deployer | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | ✅ matches stable |
 | op-node | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | ✅ matches stable |
 | op-reth | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | ✅ matches stable |
-| op-succinct-proposer | [3.10.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.10.0-agglayer) | [3.11.2-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.11.2-agglayer) | 📌 pinned — Only supports op-succinct 3.10.x so far. |
+| op-succinct-proposer | [3.10.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.10.0-agglayer) | [3.12.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.12.0-agglayer) | 📌 pinned — Only supports op-succinct 3.10.x so far. |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.3](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3) | ⚡️ newer than stable |
 
 ## CDK Erigon
@@ -146,7 +146,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 | Component | Version Deployed in Kurtosis	 | Latest Stable Version | Status |
 |-----------|-------------------------------|-----------------------|--------|
 | geth | [1.17.5](https://github.com/ethereum/go-ethereum/releases/tag/v1.17.5) | [1.17.5](https://github.com/ethereum/go-ethereum/releases/tag/v1.17.5) | ✅ matches stable |
-| lighthouse | [8.2.1](https://github.com/sigp/lighthouse/releases/tag/v8.2.1) | [8.2.1](https://github.com/sigp/lighthouse/releases/tag/v8.2.1) | ✅ matches stable |
+| lighthouse | [8.2.2](https://github.com/sigp/lighthouse/releases/tag/v8.2.2) | [8.2.2](https://github.com/sigp/lighthouse/releases/tag/v8.2.2) | ✅ matches stable |
 | reth | [2.5.0](https://github.com/paradigmxyz/reth/releases/tag/v2.5.0) | [2.5.0](https://github.com/paradigmxyz/reth/releases/tag/v2.5.0) | ✅ matches stable |
 | status-checker | [0.2.9](https://github.com/0xPolygon/status-checker/releases/tag/v0.2.9) | [0.2.9](https://github.com/0xPolygon/status-checker/releases/tag/v0.2.9) | ✅ matches stable |
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -114,7 +114,7 @@ DEFAULT_IMAGES = {
     "mongodb_image": "mongo:7.0.29",
     "geth_image": "ethereum/client-go:v1.17.5",
     "reth_image": "ghcr.io/paradigmxyz/reth:v2.5.0",
-    "lighthouse_image": "sigp/lighthouse:v8.2.1",
+    "lighthouse_image": "sigp/lighthouse:v8.2.2",
     "mitm_image": "mitmproxy/mitmproxy:11.1.3",
     "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.12",
     "op_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.7.1-cdk",


### PR DESCRIPTION
## Description

- Bump lighthouse to `v8.2.2` and regenerate the version matrix with `scripts/version-matrix` (this also refreshes the op-succinct "latest stable" column to `v3.12.0-agglayer`, still pinned to `v3.10.0-agglayer`), fixing the nightly "version matrix is outdated" alert.
- Align the nightly Slack reporting with kurtosis-pos: the `check-version-matrix` job no longer posts its own message; it exposes the drift verdict as a job output, and the test summary reports everything on a single line:
  - `Kurtosis CDK Nightly: all tests passed ✅ | version matrix is up to date ✅`
  - `Kurtosis CDK Nightly: all tests passed ✅ | version matrix is outdated ❌, check the documentation at scripts/version-matrix to update it`
  - `... | version matrix is unknown ⚠️, the check failed before it could compare the matrix` (job skipped on forks / missing token, or failed before comparing)

Matching PR on the kurtosis-pos side (same branch name): https://github.com/0xPolygon/kurtosis-pos/pull/696

🤖 Generated with [Claude Code](https://claude.com/claude-code)