### PR TITLE
chore: bump deps

### DIFF
--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -42,9 +42,9 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | aggkit | [0.10.0](https://github.com/agglayer/aggkit/releases/tag/v0.10.0) | [0.10.0](https://github.com/agglayer/aggkit/releases/tag/v0.10.0) | ✅ matches stable |
 | agglayer | [0.6.0-rc.9](https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.9) | [0.5.1](https://github.com/agglayer/agglayer/releases/tag/v0.5.1) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | ✅ matches stable |
-| op-batcher | [1.16.12](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.12) | [1.16.12](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.12) | ✅ matches stable |
+| op-batcher | [1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13) | [1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13) | ✅ matches stable |
 | op-deployer | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | ✅ matches stable |
-| op-node | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | ✅ matches stable |
+| op-node | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | ✅ matches stable |
 | op-proposer | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.3) | ✅ matches stable |
 | op-reth | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | ✅ matches stable |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.3](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3) | ⚡️ newer than stable |
@@ -58,9 +58,9 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | aggkit | [0.5.4](https://github.com/agglayer/aggkit/releases/tag/v0.5.4) | [0.10.0](https://github.com/agglayer/aggkit/releases/tag/v0.10.0) | 📌 pinned — Only supports aggkit 0.5.x so far. |
 | agglayer | [0.6.0-rc.9](https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.9) | [0.5.1](https://github.com/agglayer/agglayer/releases/tag/v0.5.1) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | ✅ matches stable |
-| op-batcher | [1.16.12](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.12) | [1.16.12](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.12) | ✅ matches stable |
+| op-batcher | [1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13) | [1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13) | ✅ matches stable |
 | op-deployer | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | ✅ matches stable |
-| op-node | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | ✅ matches stable |
+| op-node | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | ✅ matches stable |
 | op-proposer | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.3) | [1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer/v1.16.3) | ✅ matches stable |
 | op-reth | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | ✅ matches stable |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.3](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3) | ⚡️ newer than stable |
@@ -75,9 +75,9 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | aggkit-prover | [2.1.0](https://github.com/agglayer/provers/releases/tag/v2.1.0) | [2.1.0](https://github.com/agglayer/provers/releases/tag/v2.1.0) | ✅ matches stable |
 | agglayer | [0.6.0-rc.9](https://github.com/agglayer/agglayer/releases/tag/v0.6.0-rc.9) | [0.5.1](https://github.com/agglayer/agglayer/releases/tag/v0.5.1) | ⚡️ newer than stable |
 | agglayer-contracts | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | [12.2.3](https://github.com/agglayer/agglayer-contracts/releases/tag/v12.2.3) | ✅ matches stable |
-| op-batcher | [1.16.12](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.12) | [1.16.12](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.12) | ✅ matches stable |
+| op-batcher | [1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13) | [1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13) | ✅ matches stable |
 | op-deployer | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | ✅ matches stable |
-| op-node | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | [1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4) | ✅ matches stable |
+| op-node | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | ✅ matches stable |
 | op-reth | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | ✅ matches stable |
 | op-succinct-proposer | [3.10.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.10.0-agglayer) | [3.12.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.12.0-agglayer) | 📌 pinned — Only supports op-succinct 3.10.x so far. |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.3](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3) | ⚡️ newer than stable |
@@ -147,7 +147,7 @@ Environments using [cdk-erigon](https://github.com/0xPolygon/cdk-erigon) as the 
 |-----------|-------------------------------|-----------------------|--------|
 | geth | [1.17.5](https://github.com/ethereum/go-ethereum/releases/tag/v1.17.5) | [1.17.5](https://github.com/ethereum/go-ethereum/releases/tag/v1.17.5) | ✅ matches stable |
 | lighthouse | [8.2.2](https://github.com/sigp/lighthouse/releases/tag/v8.2.2) | [8.2.2](https://github.com/sigp/lighthouse/releases/tag/v8.2.2) | ✅ matches stable |
-| reth | [2.5.0](https://github.com/paradigmxyz/reth/releases/tag/v2.5.0) | [2.5.0](https://github.com/paradigmxyz/reth/releases/tag/v2.5.0) | ✅ matches stable |
+| reth | [2.5.1](https://github.com/paradigmxyz/reth/releases/tag/v2.5.1) | [2.5.1](https://github.com/paradigmxyz/reth/releases/tag/v2.5.1) | ✅ matches stable |
 | status-checker | [0.2.9](https://github.com/0xPolygon/status-checker/releases/tag/v0.2.9) | [0.2.9](https://github.com/0xPolygon/status-checker/releases/tag/v0.2.9) | ✅ matches stable |
 
 ## Kurtosis Packages

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -113,13 +113,13 @@ DEFAULT_IMAGES = {
     "db_image": "postgres:17.6",
     "mongodb_image": "mongo:7.0.29",
     "geth_image": "ethereum/client-go:v1.17.5",
-    "reth_image": "ghcr.io/paradigmxyz/reth:v2.5.0",
+    "reth_image": "ghcr.io/paradigmxyz/reth:v2.5.1",
     "lighthouse_image": "sigp/lighthouse:v8.2.2",
     "mitm_image": "mitmproxy/mitmproxy:11.1.3",
-    "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.12",
+    "op_batcher_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.13",
     "op_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.7.1-cdk",
     "op_reth_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v2.4.2",
-    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.19.4",
+    "op_node_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.19.5",
     "op_proposer_image": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.16.3",
     # Pinned to v3.10.0: aggkit-prover 2.1.0 embeds the op-succinct-elfs from this
     # version, and it hard-fails at startup if the aggregation vkey baked into the


### PR DESCRIPTION
Bump images flagged as behind stable by the nightly version check (https://github.com/0xPolygon/kurtosis-cdk/actions/runs/32453158100/job/96685244474):

- op-batcher v1.16.12 → [v1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher/v1.16.13)
- op-node v1.19.4 → [v1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5)
- reth v2.5.0 → [v2.5.1](https://github.com/paradigmxyz/reth/releases/tag/v2.5.1)

Replaces #935, #936 and #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)