### PR TITLE
fix(ci): bump nightly agglayer/e2e pins for cast >= 1.8 compat

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -261,7 +261,7 @@ jobs:
         with:
           repository: agglayer/e2e
           path: agglayer-e2e
-          ref: 3fb8af01358583e8c6df167beac9c1d2b06961c1 # 2026-03-05
+          ref: 3a80868ae618a52cc98d70e5ef6d9484063fa9e5 # 2026-08-28, cast >= 1.8 --json envelope compat (agglayer/e2e#266)
 
       - name: Run bridge tests and op optimistic mode tests
         run: |
@@ -625,9 +625,9 @@ jobs:
         with:
           repository: agglayer/e2e
           path: agglayer-e2e
-          # test/upgrade-agglayer-060 HEAD: the agglayer 0.6.0 multi-chain suite
-          # (tests/aggkit/bridge-e2e-{2,3}-chains.bats + the multi-setup helpers).
-          ref: c63f991dbd77003cd3c28cb7142d15f066f55f18
+          # The agglayer 0.6.0 multi-chain suite (tests/aggkit/bridge-e2e-{2,3}-chains.bats +
+          # the multi-setup helpers), now merged into main.
+          ref: 3a80868ae618a52cc98d70e5ef6d9484063fa9e5 # 2026-08-28, cast >= 1.8 --json envelope compat (agglayer/e2e#266)
 
       # NOTE: no agglayer-registration step here. The l2-to-l2-all-pairs.bats setup intentionally
       # does not call the e2e add_network_to_agglayer helper: the attached rollups are already

--- a/docs/docs/version-matrix.md
+++ b/docs/docs/version-matrix.md
@@ -79,7 +79,7 @@ Environments using [op-reth](https://github.com/ethereum-optimism/optimism/tree/
 | op-deployer | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | [0.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-deployer/v0.7.1) | ✅ matches stable |
 | op-node | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | [1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5) | ✅ matches stable |
 | op-reth | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | [2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2) | ✅ matches stable |
-| op-succinct-proposer | [3.10.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.10.0-agglayer) | [3.12.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.12.0-agglayer) | 📌 pinned — Only supports op-succinct 3.10.x so far. |
+| op-succinct-proposer | [3.10.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.10.0-agglayer) | [3.13.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.13.0-agglayer) | 📌 pinned — Only supports op-succinct 3.10.x so far. |
 | zkevm-bridge-service | [0.6.4-RC2](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.4-RC2) | [0.6.3](https://github.com/0xPolygon/zkevm-bridge-service/releases/tag/v0.6.3) | ⚡️ newer than stable |
 
 ## CDK Erigon


### PR DESCRIPTION
- The nightly has failed 4 nights running: `run-with-op-succinct` and `run-with-multi-l2` are the only jobs that run bats on the runner host, so they picked up the foundry 1.8 bump from #939 while keeping their pre-fix `agglayer/e2e` pins — cast >= 1.8 wraps `--json` output in an envelope, and the old helpers index it positionally (`jq: error: Cannot index object with number`).
- Bump both `nightly.yml` e2e pins to [`3a80868a`](https://github.com/agglayer/e2e/commit/3a80868ae618a52cc98d70e5ef6d9484063fa9e5), matching `test.yml`; all three pins across both workflows now agree.
- Refresh the `op-succinct-proposer` "latest stable" row in `docs/docs/version-matrix.md` (upstream released `v3.13.0-agglayer` on 08-31); our pin stays at 3.10.0 as documented.
- Verified by reading the failing frames in all 4 runs and confirming the new ref rewrites exactly those jq calls; the suites can't run locally, so real confirmation is the next nightly or a manual `workflow_dispatch` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
